### PR TITLE
Refactor Avatar component to use TypeScript + Rollup script improvements

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -22,32 +22,41 @@ function getComponentDirectories() {
 
 const components = getComponentDirectories();
 
-export default components.map((component) => ({
-    input: `src/components/ui/${component}/${component}.js`,
-    output: [
-        {
-            file: `dist/components/${component}.js`,
-            format: 'es',
-        },
-    ],
-    external: ['react', 'react-dom'],
-    plugins: [
-        alias({
-            entries: [
-                {find: '~/core', replacement: path.resolve(__dirname, 'src/core')},
-            ],
-        }),
-        postcss({
-            plugins: [],
-            minimize: true,
-        }),
-        babel({
-            exclude: 'node_modules/**',
-            presets: ['@babel/preset-react'],
-        }),
-        typescript({tsconfig: './tsconfig.json'}),
-        resolve(),
-        terser(),
-        banner2(() => '\'use client\';'),
-    ],
-}));
+export default components.map((component) => {
+    const jsFilePath = `src/components/ui/${component}/${component}.js`;
+    const tsxFilePath = `src/components/ui/${component}/${component}.tsx`;
+
+    const input = fs.existsSync(tsxFilePath) ? tsxFilePath : jsFilePath;
+
+    return {
+        input: input,
+        output: [
+            {
+                file: `dist/components/${component}.js`,
+                format: 'es',
+            },
+        ],
+        external: ['react', 'react-dom'],
+        plugins: [
+            alias({
+                entries: [
+                    {find: '~/core', replacement: path.resolve(__dirname, 'src/core')},
+                ],
+            }),
+            postcss({
+                plugins: [],
+                minimize: true,
+            }),
+            babel({
+                exclude: 'node_modules/**',
+                presets: ['@babel/preset-react'],
+            }),
+            typescript({tsconfig: './tsconfig.json'}),
+            resolve(),
+            terser(),
+            banner2(() => '\'use client\';'),
+        ],
+    };
+},
+
+);

--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -6,7 +6,20 @@ import AvatarRoot from './shards/AvatarRoot';
 import AvatarImage from './shards/AvatarImage';
 import AvatarFallback from './shards/AvatarFallback';
 
-const Avatar = ({children, customRootClass = '', fallback='', className = '', src='', alt, ...props}) => {
+export interface AvatarProps {
+    children?: React.ReactNode;
+    customRootClass?: string;
+    fallback?: string;
+    className?: string;
+    src?: string;
+    alt?: string;
+    Root?: React.FC<AvatarRootProps>;
+    Image?: React.FC<AvatarImageProps>;
+    Fallback?: React.FC<AvatarFallbackProps>;
+}
+
+
+const Avatar: React.FC<AvatarProps> = ({children, customRootClass = '', fallback='', className = '', src='', alt, ...props}) => {
     return (
         <AvatarRoot customRootClass={customRootClass}>
             <AvatarImage

--- a/src/components/ui/Avatar/shards/AvatarFallback.tsx
+++ b/src/components/ui/Avatar/shards/AvatarFallback.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // @ts-ignore
 import {customClassSwitcher} from '~/core';
 
-type AvatarFallbackProps = {
+export type AvatarFallbackProps = {
     fallback: string,
     customRootClass: string,
 };

--- a/src/components/ui/Avatar/shards/AvatarImage.tsx
+++ b/src/components/ui/Avatar/shards/AvatarImage.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 // @ts-ignore
 import {customClassSwitcher} from '~/core';
 
-type AvatarImageProps = {
+export type AvatarImageProps = {
     src: string;
     alt: string;
     className: string;

--- a/src/components/ui/Avatar/shards/AvatarRoot.tsx
+++ b/src/components/ui/Avatar/shards/AvatarRoot.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // @ts-ignore
 import {customClassSwitcher} from '~/core';
 
-type AvatarRootProps = {
+export type AvatarRootProps = {
   children: React.ReactNode;
   customRootClass:string
 };

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export {default as Quote} from './components/ui/Quote/Quote.js';
 
 export {default as Code} from './components/ui/Code/Code.js';
 
-export {default as Avatar} from './components/ui/Avatar/Avatar.js';
+export {default as Avatar} from './components/ui/Avatar/Avatar.tsx';
 
 export {default as Callout} from './components/ui/Callout/Callout.js';
 


### PR DESCRIPTION
This PR modifies the rollup bundle script to accomodate `.tsx` file extensions which previously had only supported `.js` file extensions - which will allow us to bundle typescript components as well in production