### PR TITLE
Fixing the AlertDialogPortal dark mode

### DIFF
--- a/src/components/ui/AlertDialog/contexts/AlertDialogContext.tsx
+++ b/src/components/ui/AlertDialog/contexts/AlertDialogContext.tsx
@@ -1,5 +1,18 @@
 import { createContext } from 'react';
+import { FloatingContext } from '@floating-ui/react';
 
-export const AlertDialogContext = createContext({
+type AlertDialogContextType = {
+  isOpen: boolean;
+  handleOpenChange: (open: boolean) => void;
+  floaterContext: FloatingContext;
+  rootClass: string;
+  handleOverlayClick: () => void;
+};
 
+export const AlertDialogContext = createContext<AlertDialogContextType>({
+  isOpen: false,
+  handleOpenChange: () => {},
+  floaterContext: {} as FloatingContext,
+  rootClass: '',
+  handleOverlayClick: () => {},
 });

--- a/src/components/ui/AlertDialog/shards/AlertDialogPortal.tsx
+++ b/src/components/ui/AlertDialog/shards/AlertDialogPortal.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Floater from '~/core/primitives/Floater';
+import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 export type AlertDialogPortalProps = {
     children: React.ReactNode;
+
 }
 
 const AlertDialogPortal = ({ children } : AlertDialogPortalProps) => {
+    const {rootClass} = useContext(AlertDialogContext)
+    const rootElement = document.getElementsByClassName(rootClass)[0] as HTMLElement | null;
+
     return (
-        <Floater.Portal>
+        <Floater.Portal root={rootElement || document.body}>
             {children}
         </Floater.Portal>
     );

--- a/src/components/ui/AlertDialog/shards/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/shards/AlertDialogRoot.tsx
@@ -31,7 +31,7 @@ const AlertDialogRoot = ({ children, customRootClass = '', open, onOpenChange, o
     const props = { isOpen, handleOpenChange, floaterContext, rootClass, handleOverlayClick };
     return (
         <AlertDialogContext.Provider value={props}>
-            <div className={rootClass}>
+            <div className={rootClass} >
                 {children}
             </div>
         </AlertDialogContext.Provider>

--- a/styles/themes/components/alert-dialog.scss
+++ b/styles/themes/components/alert-dialog.scss
@@ -1,19 +1,19 @@
-.rad-ui-alert-dialog-overlay {  
-        z-index: 50;
-        background-color: rgba(0, 0, 0, 0.8);
+.rad-ui-alert-dialog-overlay {
+  z-index: 50;
+  background-color: rgba(0, 0, 0, 0.8);
 }
 
 .rad-ui-alert-dialog-content {
-    padding: 16px;
-    border-radius: 8px;
-    background-color: white;
-    color: black;
-   width: 100%;
-   max-width: 800px;
-   margin: 10px auto;
-   position: fixed;
-   left: 50%;
-   top: 50%;
-   transform: translate(-50%, -50%);
-   z-index: 50;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: var(--rad-ui-color-red-1000);
+  color: var(--rad-ui-color-gray-50);
+  width: 100%;
+  max-width: 800px;
+  margin: 10px auto;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 50;
 }


### PR DESCRIPTION
## Issue 
We're using FloatingPortal from floating-ui/react as a way to add the dialog box children to the dom. by default it uses the document.body element and adds the HTML as a child to it so the dark theme classes didn't work on it 

## Solution
we will be using  the rootClass from the `AlertDialogRoot` in AlertDialogPortal and get the element and pass it to the FloatingPortal. 
![Screenshot 2024-10-26 at 4 33 56 PM](https://github.com/user-attachments/assets/f6fe2ccc-c2c7-4d56-895a-a0790c0f449e)
![Screenshot 2024-10-26 at 4 34 08 PM](https://github.com/user-attachments/assets/430a3ea9-b8aa-4489-90d0-c4cfdc8646e6)
