### PR TITLE
[Testing]Code block replacement

### DIFF
--- a/docs/app/docs/first-steps/installation/page.js
+++ b/docs/app/docs/first-steps/installation/page.js
@@ -25,11 +25,11 @@ const Introduction = () => {
 
             <Text className="mt-4 mb-1 font-medium">Using Yarn</Text>
             <Code >
-                <Copy>yarn add @radui/ui</Copy>
+                <Copy defClass= {"flex items-center"}>yarn add @radui/ui</Copy>
             </Code>
             <Text className="mt-4 mb-1 font-medium">Using npm</Text>
             <Code>
-                <Copy>npm install @radui/ui --save</Copy>
+                <Copy defClass= {"flex items-center"}>npm install @radui/ui --save</Copy>
             </Code>
         </Documentation.Section>
     </Documentation>

--- a/docs/components/Copy.js
+++ b/docs/components/Copy.js
@@ -2,7 +2,7 @@
 import { useState,useEffect } from "react"
 
 
-function Copy({ children }) {
+function Copy({ children, defClass }) {
     const [isCopied, setIsCopied] = useState(false)
 
     const handleCopy = () => {
@@ -30,7 +30,7 @@ function Copy({ children }) {
     }
 
     return(
-        <span className = "flex items-center">
+        <span className={defClass}>
             {children}
             <button 
                 onClick={handleCopy} 

--- a/docs/components/layout/Documentation/helpers/CodeBlock.js
+++ b/docs/components/layout/Documentation/helpers/CodeBlock.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { refractor } from 'refractor';
 import js from 'refractor/lang/javascript';
 import jsx from 'refractor/lang/jsx';
+import Copy from '@/components/Copy';
+import Code from "@radui/ui/Code"
 
 refractor.register(js);
 refractor.register(jsx);
@@ -51,7 +53,7 @@ const CodeBlock = ({ children, language="jsx" }) => {
     code = code.children.map(renderElement);
   return (
     <pre cl>
-      <code className={`language-${language} whitespace-pre-wrap`} style={{wordBreak:"break-word"}}>{code}</code>
+      <Code className={`language-${language} whitespace-pre-wrap`} style={{wordBreak:"break-word"}}><Copy>{code}</Copy></Code>
     </pre>
   );
 };


### PR DESCRIPTION
Replaced the <code> block in return with <Code> imported from "@radui/ui/Code" to test and integrate one component usage only.
Copy at  "@/components/Copy" now has prop for styling "defClass"