### PR TITLE
added information in table for Avatar in docs

### DIFF
--- a/docs/app/docs/components/avatar/page.js
+++ b/docs/app/docs/components/avatar/page.js
@@ -14,11 +14,12 @@ const AvatarDocs = () => {
         {name: 'Prop', key: 'prop'},
         {name: 'Type', key: 'type'},
         {name: 'Default', key: 'default'},
+        {name: 'Description', key: 'description'},
     ];
 
     const data = [
-        {prop: 'src', type: 'string', default: 'null'},
-        {prop: 'fallback', type: 'string', default: 'null'},
+        {prop: 'src', type: 'string', default: 'null', description: 'URL of the image to be displayed as the avatar.'},
+        {prop: 'fallback', type: 'string', default: 'null', description: 'Text initials or placeholder displayed when the image fails to load or if no src is provided.'},
     ];
 
 
@@ -37,9 +38,10 @@ const AvatarDocs = () => {
                 "SSR compatible",
             ]} >
             </Documentation.ComponentFeatures>
-            <Documentation.Table columns={columns} data={data}>
-
-            </Documentation.Table>
+            <div className="max-w-screen-md">
+                <Documentation.Table columns={columns} data={data} >
+                </Documentation.Table>
+            </div>
         </Documentation>
     </div>
 }


### PR DESCRIPTION
#544 Also seems to fixed by reducing the table width rather than changing the table ui component. Added for extra information for the api documentation description. Not the final commit. Open for suggestions to add more into the docs.
![image](https://github.com/user-attachments/assets/7cc8d91f-81a8-42bc-91c5-370d039fb4a9)
