### PR TITLE
Fix #577: [New Feature] Added Multiple direction support for Tooltip …

### DIFF
--- a/src/components/tools/Popper/Popper.tsx
+++ b/src/components/tools/Popper/Popper.tsx
@@ -21,7 +21,19 @@ export type PopperProps = {
     customRootClass?: string;
     activationStrategy?: 'hover';
     className?: string;
-    placement?: 'top' | 'bottom' | 'bottom-start'; // TODO: fix
+    placement?:
+        | 'top'
+        | 'bottom'
+        | 'left'
+        | 'right'
+        | 'top-start'
+        | 'top-end'
+        | 'bottom-start'
+        | 'bottom-end'
+        | 'left-start'
+        | 'left-end'
+        | 'right-start'
+        | 'right-end'; 
     children?: React.ReactNode; // TODO: fix
     open?: boolean;
     hoverDelay?: number;

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import Popper from '~/components/tools/Popper/Popper';
 
 const COMPONENT_NAME = 'Tooltip';
@@ -7,13 +6,35 @@ const COMPONENT_NAME = 'Tooltip';
 type TooltipProps = {
     children: React.ReactNode;
     label: string;
+    placement?: 
+        | 'top' 
+        | 'bottom' 
+        | 'left' 
+        | 'right' 
+        | 'top-start' 
+        | 'top-end' 
+        | 'bottom-start' 
+        | 'bottom-end' 
+        | 'left-start' 
+        | 'left-end' 
+        | 'right-start' 
+        | 'right-end';
     [key: string]: any;
 };
 
-const Tooltip = ({ children, label, ...props }:TooltipProps) => {
-    return <div>
-        <Popper popperName={COMPONENT_NAME} pop={'hello'} {...props}>{children}</Popper>
-    </div>;
+const Tooltip = ({ children, label="hello", placement = 'top', ...props }: TooltipProps) => {
+    return (
+        <div>
+            <Popper
+                popperName={COMPONENT_NAME}
+                pop={label} 
+                placement={placement} 
+                {...props}
+            >
+                {children}
+            </Popper>
+        </div>
+    );
 };
 
 export default Tooltip;

--- a/src/components/ui/Tooltip/stories/Tooltip.stories.js
+++ b/src/components/ui/Tooltip/stories/Tooltip.stories.js
@@ -8,7 +8,7 @@ export default {
     component: Tooltip,
     render: (args) => <SandboxEditor>
         <ScrollPlayground>
-            <Tooltip className="text-gray-1000" label="This is a tooltip">
+            <Tooltip className="text-gray-1000" label="This is a tooltip" placement='left'>
                     Hello, hover me!
             </Tooltip>
         </ScrollPlayground>


### PR DESCRIPTION
This PR adds support for cardinal and compound directions in the Tooltip component by extending the placement prop. The supported directions include:

**Cardinal Directions:**
`top`, `bottom`, `left`, `right` .

**Compound Directions:**
`top-start`, `top-end`,` bottom-start`, `bottom-end`,
`left-start`,` left-end`, `right-start`, `right-end`.

Key Changes:

Updated `Popper` and `Tooltip` components to support these directions using the placement prop.
Integrated Floating UI middleware to handle placements dynamically, ensuring proper positioning based on viewport constraints.
Tested the functionality with various placements and alignment strategies.

