### PR TITLE
Pull Request for Issue #497: Add Copy-Code Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.20",
+        "@radix-ui/react-icons": "^1.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -4332,6 +4333,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.20",
+    "@radix-ui/react-icons": "^1.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/ui/Code/Code.tsx
+++ b/src/components/ui/Code/Code.tsx
@@ -1,14 +1,44 @@
 'use client';
-import React from 'react';
+import { CheckCircledIcon, ClipboardIcon } from '@radix-ui/react-icons';
+import React, { useState } from 'react';
 
 export type CodeProps= {
     children: React.ReactNode;
 }
 
 const Code = ({ children }: CodeProps) => {
-    return <code className='rui-code-root'>
-        {children}
-    </code>;
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async() => {
+        try {
+            await navigator.clipboard.writeText(children as string);
+            setIsCopied(true);
+
+            setTimeout(() => {
+                setIsCopied(false);
+            }, 2000);
+        } catch (error) {
+            console.error('Failed to copy text: ', error);
+        }
+    };
+
+    return (
+        <div className="rui-code-root">
+            <div className='pt-1'>
+
+                <button onClick={handleCopy} className="copy-button" title="Copy code">
+                    {isCopied
+                        ? (
+                            <CheckCircledIcon width={16} height={16} className='inline-block' />
+                        )
+                        : (
+                            <ClipboardIcon width={16} height={16} />
+                        )}
+                </button>
+            </div>
+            <code>{children}</code>
+        </div>
+    );
 };
 
 export default Code;


### PR DESCRIPTION
This pull request implements the copy-code functionality in the project. Users can now easily copy code snippets by clicking on the copy icon next to the code block. The icon changes to a checkmark once the code is successfully copied, providing clear feedback to the user.

**Changes made:**
- Added a button with a clipboard icon to copy the code inside code blocks.
- Used Radix UI's clipboard SVG for the copy icon.
- Implemented state handling to toggle the icon between a clipboard and checkmark after copying.
- Added appropriate styling to position the copy button and ensure accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a copy-to-clipboard functionality in the Code component, allowing users to easily copy code snippets.
	- Introduced visual feedback with a button that changes icon based on copy status.

- **Chores**
	- Updated package dependencies to include `@radix-ui/react-icons`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->