### PR TITLE
`as` prop for text component

### DIFF
--- a/src/components/ui/Text/Text.tsx
+++ b/src/components/ui/Text/Text.tsx
@@ -7,17 +7,38 @@ import { customClassSwitcher } from '~/core';
 // TODO: Add a core reusable function to check and render an as prop
 
 const COMPONENT_NAME = 'Text';
-
+const componentList = [
+    {
+        label: 'DIV',
+        tag: 'div'
+    },
+    {
+        label: 'SPAN',
+        tag: 'span'
+    },
+    {
+        label: 'P',
+        tag: 'p'
+    },
+    {
+        label: 'LABEL',
+        tag: 'label'
+    },
+]
 export type TextProps = {
     children: React.ReactNode;
     customRootClass?: string;
     className?: string;
+    as?: string;
 } & React.ComponentProps<'p'>;
 
-const Text = ({ children, customRootClass = '', className = '', ...props }: TextProps) => {
+const Text = ({ children, customRootClass = '', className = '', as=undefined, ...props }: TextProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    return <p className={`${rootClass} ${className}`} {...props}>{children}</p>;
+    if (!componentList.find((item) => item.tag === as)) as='p'
+
+    const { tag: Tag } = componentList.find((item) => item.tag === as);
+    return <Tag className={`${rootClass} ${className}`} {...props}>{children}</Tag>;
 };
 
 Text.displayName = COMPONENT_NAME;

--- a/src/components/ui/Text/stories/Text.stories.js
+++ b/src/components/ui/Text/stories/Text.stories.js
@@ -8,15 +8,24 @@ export default {
     component: Text,
     render: (args) => <SandboxEditor>
         <div >
-            <Text className='text-gray-950'>  {`I'm not a monkey
+            <Text {...args}>  {`I'm not a monkey
 I will not dance even if the beat's funky`}  </Text>
         </div>
     </SandboxEditor>
 };
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const All = {
+export const WithoutAs = {
     args: {
-        className: ''
+        className: 'text-gray-950'
     }
 };
+
+export const WithAs = {
+    args: {
+        className: 'text-gray-950',
+        as: "div"
+    }
+}
+
+


### PR DESCRIPTION
Text has now `as` prop which has default p tag and option of div, span, label and p tag. Wrote test for with and without `as` prop.