### PR TITLE
Util classname 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.20",
+        "clsx": "^2.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -11417,6 +11418,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.20",
+    "clsx": "^2.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { AccordionItemContext } from '../contexts/AccordionItemContext';
+import { clsx } from 'clsx';
 
 type AccordionContentProps = {
   children: React.ReactNode;
@@ -16,7 +17,7 @@ const AccordionContent: React.FC<AccordionContentProps> = ({ children, index, ac
 
     return (
         <div
-            className={`${rootClass}-content ${className}`}
+            className={clsx(`${rootClass}-content`, className)}
             id={`content-${index}`}
             role="region"
             aria-labelledby={`section-${index}`}

--- a/src/components/ui/Accordion/fragments/AccordionHeader.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { clsx } from 'clsx';
 
 export type AccordionHeaderProps = {
     children: React.ReactNode;
@@ -7,7 +8,7 @@ export type AccordionHeaderProps = {
 
 const AccordionHeader: React.FC<AccordionHeaderProps> = ({ children, className = '' }) => {
     return (
-        <div className={className}>
+        <div className={clsx(className)}>
             {children}
         </div>
     );

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useId, useEffect, useRef } from 'react';
-
+import { clsx } from 'clsx';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { AccordionItemContext } from '../contexts/AccordionItemContext';
 
@@ -61,7 +61,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, classNam
         <AccordionItemContext.Provider value={{ itemValue, setItemValue, handleBlurEvent, handleClickEvent, handleFocusEvent }}>
             <div
                 ref={accordionItemRef}
-                className={`${rootClass}-item ${className}`} {...props}
+                className={clsx(`${rootClass}-item`, className)} {...props}
                 id={`accordion-data-item-${id}`}
                 role="region"
                 aria-labelledby={`accordion-trigger-${id}`}

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { getAllBatchElements, getNextBatchItem, getPrevBatchItem } from '~/core/batches';
@@ -55,7 +55,7 @@ const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
                 accordionRef
 
             }}>
-            <div className={`${rootClass}-root`} ref={accordionRef} >
+            <div className={clsx(${rootClass}-root)} ref={accordionRef} >
                 {children}
             </div>
         </AccordionContext.Provider>

--- a/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { AccordionItemContext } from '../contexts/AccordionItemContext';
+import { clsx } from 'clsx';
 
 type AccordionTriggerProps = {
   children: React.ReactNode;
@@ -31,7 +32,7 @@ const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, index, cl
 
         <button
             type="button"
-            className={`${rootClass}-trigger ${className}`}
+            className={clsx(`${rootClass}-trigger`, className)}
             onBlur={handleBlurEvent}
             onFocus={onFocusHandler}
             onKeyDown={(e) => {

--- a/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
-
+import { clsx } from 'clsx';
 export type AlertDialogContentProps = {
     children: React.ReactNode;
 }
@@ -11,7 +11,7 @@ const AlertDialogContent = ({ children } : AlertDialogContentProps) => {
     return (
         <>
             {isOpen && (
-                <div className={`${rootClass}-content`}>
+                <div className={clsx(`${rootClass}-content`)}>
                     {children}
                 </div>
             )}

--- a/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
 import Floater from '~/core/primitives/Floater';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
-
+import { clsx } from 'clsx';
 const AlertDialogOverlay = () => {
     const { isOpen, rootClass, handleOverlayClick } = useContext(AlertDialogContext);
     return (
         <>
             {isOpen && (
                 <Floater.Overlay
-                    className={`${rootClass}-overlay`} onClick={handleOverlayClick}>
+                    className={clsx(`${rootClass}-overlay`)} onClick={handleOverlayClick}>
 
                 </Floater.Overlay>
             )}

--- a/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { customClassSwitcher } from '~/core';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
-
+import { clsx } from 'clsx';
 import Floater from '~/core/primitives/Floater';
 
 export type AlertDialogRootProps = {
@@ -31,7 +31,7 @@ const AlertDialogRoot = ({ children, customRootClass = '', open, onOpenChange, o
     const props = { isOpen, handleOpenChange, floaterContext, rootClass, handleOverlayClick };
     return (
         <AlertDialogContext.Provider value={props}>
-            <div className={rootClass} >
+            <div className={clsx(rootClass)} >
                 {children}
             </div>
         </AlertDialogContext.Provider>

--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { clsx } from 'clsx';
 import AvatarPrimitive from '~/core/primitives/Avatar';
 
 const COMPONENT_NAME = 'Avatar';
@@ -20,7 +20,7 @@ const Avatar = ({ customRootClass = '', fallback, className, src, alt, ...props 
             <AvatarPrimitive.Image
                 src={src}
                 alt={alt}
-                className={className}
+                className={clsx(className)}
                 {...props}
             />
             <AvatarPrimitive.Fallback>

--- a/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { clsx } from 'clsx';
 import AvatarGroupRoot from './fragments/AvatarGroupRoot';
 import AvatarPrimitiveRoot from '~/core/primitives/Avatar/fragments/AvatarPrimitiveRoot';
 import AvatarPrimitiveFallback from '~/core/primitives/Avatar/fragments/AvatarPrimitiveFallback';
@@ -18,7 +18,7 @@ type AvatarGroupProps = {
 }
 
 const AvatarGroup = ({ avatars = [], size, customRootClass = '', className, ...props }: AvatarGroupProps) => {
-    return <AvatarGroupRoot customRootClass={customRootClass} className={className} {...props} >
+    return <AvatarGroupRoot customRootClass={customRootClass} className={clsx(className)} {...props} >
         {avatars.map((avatar, index) => (
             <AvatarPrimitiveRoot key={index} src={avatar.src}>
                 <AvatarPrimitiveImage src={avatar.src} alt={avatar.alt} />

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core/customClassSwitcher';
 
 type AvatarGroupRootProps = {
@@ -11,7 +11,7 @@ type AvatarGroupRootProps = {
 const AvatarGroupRoot = ({ customRootClass = '', children, className, ...props }: AvatarGroupRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, 'AvatarGroup');
     return (
-        <div className={`${rootClass} ${className}`} {...props}>
+        <div className={clsx(rootClass, className)} {...props}>
             {children}
         </div>
     );

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import BadgeRoot from './fragments/BadgeRoot';
 import BadgeContent from './fragments/BadgeContent';
+import { clsx } from 'clsx';
 export type BadgeProps = {
     children?: React.ReactNode,
     customRootClass?: string,
@@ -11,7 +12,7 @@ export type BadgeProps = {
 }
 
 const Badge = ({ children, customRootClass, className, color, ...props }: BadgeProps) => {
-    return <BadgeRoot customRootClass={customRootClass} className={`${className}`} color={color ?? undefined} {...props}>
+    return <BadgeRoot customRootClass={customRootClass} className={clsx(className)} color={color ?? undefined} {...props}>
 
         <BadgeContent>
             {children}

--- a/src/components/ui/Badge/fragments/BadgeRoot.tsx
+++ b/src/components/ui/Badge/fragments/BadgeRoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Badge';
 
 type BadgeRootProps = {
@@ -15,7 +15,7 @@ const BadgeRoot = ({ children, customRootClass, className, color, ...props }:Bad
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
-        <span className= {`${rootClass} ${className}`} data-accent-color={color ?? undefined} {...props}>
+        <span className={clsx(rootClass, className)} data-accent-color={color ?? undefined} {...props}>
             {children}
         </span>
     );

--- a/src/components/ui/BlockQuote/BlockQuote.tsx
+++ b/src/components/ui/BlockQuote/BlockQuote.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 
 const COMPONENT_NAME = 'BlockQuote';
@@ -14,7 +14,7 @@ export type BlockQuoteProps = {
 const BlockQuote = ({ children, customRootClass, className, ...props }: BlockQuoteProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    return <blockquote className={`${rootClass} ${className}`} {...props}>{children}</blockquote>;
+    return <blockquote className={clsx(rootClass, className)} {...props}>{children}</blockquote>;
 };
 
 BlockQuote.displayName = COMPONENT_NAME;

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { ButtonHTMLAttributes, DetailedHTMLProps, PropsWithChildren } from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 import ButtonPrimitive from '~/core/primitives/Button';
 
 // make the color prop default accent color
@@ -21,7 +21,7 @@ const Button = ({ children, type = 'button', customRootClass = '', className = '
     return (
         <ButtonPrimitive
             type={type}
-            className={`${rootClass} button-${variant} ${className} `} data-accent-color={color ?? undefined} data-size={size}
+            className={clsx(rootClass, 'button-${variant}', className, '')} data-accent-color={color ?? undefined} data-size={size}
             {...props}
         >
             {children}

--- a/src/components/ui/Callout/Callout.tsx
+++ b/src/components/ui/Callout/Callout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { clsx } from 'clsx';
 /**
  * Shards
 */
@@ -15,7 +15,7 @@ export type CalloutProps = {
 
 const COMPONENT_NAME = 'Callout';
 const Callout = ({ children, className = '', color, customRootClass, ...props }: CalloutProps) => {
-    return (<CalloutRoot customRootClass={customRootClass} className={`${className}`} color={color ?? undefined} {...props}>
+    return (<CalloutRoot customRootClass={customRootClass} className={clsx(className)} color={color ?? undefined} {...props}>
         {children}
     </CalloutRoot>);
 };

--- a/src/components/ui/Callout/fragments/CalloutRoot.tsx
+++ b/src/components/ui/Callout/fragments/CalloutRoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Callout';
 
 type CalloutRootProps = {
@@ -13,7 +13,7 @@ type CalloutRootProps = {
 
 const CalloutRoot = ({ children, className, color, customRootClass, ...props }: CalloutRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <div className={`${rootClass} ${className}`} data-accent-color={color ?? undefined} {...props}>
+    return <div className={clsx(rootClass, className)} data-accent-color={color ?? undefined} {...props}>
         {children}
     </div>;
 };

--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import CardRoot from './fragments/CardRoot';
-
+import { clsx } from 'clsx';
 export type CardProps = {
     customRootClass?: string;
     className?: string;
@@ -8,7 +8,7 @@ export type CardProps = {
 } & React.ComponentProps<'div'>;
 
 const Card = ({ children, className = '', customRootClass, ...props }: PropsWithChildren<CardProps>) => (
-    <CardRoot className={className} customRootClass={customRootClass} {...props}>
+    <CardRoot className={clsx(className)} customRootClass={customRootClass} {...props}>
         {children}
     </CardRoot>
 );

--- a/src/components/ui/Card/fragments/CardRoot.tsx
+++ b/src/components/ui/Card/fragments/CardRoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Card';
 export type CardRootProps = {
     children: React.ReactNode;
@@ -13,7 +13,7 @@ const CardRoot = ({ children, customRootClass, className = '', ...props }: CardR
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
-        <div className={`${rootClass} ${className}`} {...props} >
+        <div className={clsx(rootClass, className)} {...props} >
             {children}
         </div>
     );

--- a/src/components/ui/Code/Code.tsx
+++ b/src/components/ui/Code/Code.tsx
@@ -1,12 +1,12 @@
 'use client';
 import React from 'react';
-
+import { clsx } from 'clsx';
 export type CodeProps= {
     children: React.ReactNode;
 }
 
 const Code = ({ children }: CodeProps) => {
-    return <code className='rui-code-root'>
+    return <code className={clsx('rui-code-root')}>
         {children}
     </code>;
 };

--- a/src/components/ui/Collapsible/Collapsible.tsx
+++ b/src/components/ui/Collapsible/Collapsible.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, ReactNode, useState } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
-
+import { clsx } from 'clsx';
 /*
  * CHECKLIST
  *
@@ -14,13 +14,13 @@ import ButtonPrimitive from '~/core/primitives/Button';
 export type CollapsibleProps = { open?: boolean, title?: string, trigger?: ReactNode} & PropsWithChildren;
 
 const ExpandIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={clsx('size-6')}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
     </svg>
 );
 
 const CollapseIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={clsx('size-6')}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5 5.25 5.25" />
     </svg>
 );

--- a/src/components/ui/Dropdown/Dropdown.tsx
+++ b/src/components/ui/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Popper from '~/components/tools/Popper/Popper';
-
+import { clsx } from 'clsx';
 // TODO: fix any
 export type DropdownProps ={
     list: {value: any}[];
@@ -9,13 +9,13 @@ export type DropdownProps ={
 
 const Dropdown = ({ list = [], selected }: DropdownProps) => {
     const PopElem = () => {
-        return <ul className='bg-white px-2 py-2 shadow-lg rounded-md'>
+        return <ul className={clsx('bg-white px-2 py-2 shadow-lg rounded-md')}>
             {list.map((item, index) => {
                 return <li key={index}>{item.value}</li>;
             })}
         </ul>;
     };
-    return <div className='relative'>
+    return <div className={clsx('relative')}>
         <Popper open={false} placement="bottom-start" popperName="dropdown" pop={<PopElem/>}>
             <span>Dropdown</span>
         </Popper>

--- a/src/components/ui/Em/Em.tsx
+++ b/src/components/ui/Em/Em.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Em';
 
 export type EmProps = {
@@ -13,7 +13,7 @@ export type EmProps = {
 
 const Em = ({ children, customRootClass, className, ...props }: EmProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <em className={`${rootClass} ${className}`} {...props}>
+    return <em className={clsx(rootClass, className)} {...props}>
         {children}
     </em>;
 };

--- a/src/components/ui/Heading/Heading.tsx
+++ b/src/components/ui/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 
 const RENDER_AS_ENUMS = [
@@ -35,9 +35,9 @@ const Heading = ({ children, as = undefined, customRootClass = '', className = '
 
     if (as !== undefined && RENDER_AS_ENUMS.find((item) => item.tag === as)) {
         const { tag: Tag } = RENDER_AS_ENUMS.find((item) => item.tag === as);
-        return <Tag className={`${rootClass} ${className}`} {...props}>{children}</Tag>;
+        return <Tag className={clsx(rootClass, className)} {...props}>{children}</Tag>;
     }
-    return <h1 className={`${rootClass} ${className}`} {...props}>{children}</h1>;
+    return <h1 className={clsx(rootClass, className)} {...props}>{children}</h1>;
 };
 Heading.displayName = 'Heading';
 

--- a/src/components/ui/HoverCard/fragments/HoverCardArrow.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardArrow.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
-
+import { clsx } from 'clsx';
 import Floater from '~/core/primitives/Floater';
 import HoverCardContext from '../contexts/HoverCardContext';
 
 const HoverCardArrow = ({ ...props }) => {
     const { floatingContext, arrowRef, rootClass } = useContext(HoverCardContext);
 
-    return <Floater.Arrow className={`${rootClass}-arrow`} {...props} context={floatingContext} ref={arrowRef} />;
+    return <Floater.Arrow className={clsx(`${rootClass}-arrow`)} {...props} context={floatingContext} ref={arrowRef} />;
 };
 
 export default HoverCardArrow;

--- a/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-
+import { clsx } from 'clsx';
 import HoverCardContext from '../contexts/HoverCardContext';
 
 type HoverCardContentProps = {
@@ -32,7 +32,7 @@ const HoverCardContent = ({ children, ...props }: HoverCardContentProps) => {
     return <div
         onPointerEnter={openWithDelay}
         onPointerLeave={closeWithDelay}
-        className={`${rootClass}`} {...props}
+        className={clsx(rootClass)} {...props}
         ref={floatingRefs.setFloating}
         style={floatingStyles}
         {...getFloatingProps()}>{children}</div>;

--- a/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef } from 'react';
 import HoverCardContext from '../contexts/HoverCardContext';
 import Floater from '~/core/primitives/Floater';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'HoverCard';
 
 type HoverCardRootProps = {
@@ -114,7 +114,7 @@ const HoverCardRoot = ({ children, open: controlledOpen = undefined, onOpenChang
     };
 
     return <HoverCardContext.Provider value={sendValues}>
-        <div className={rootClass} {...props}>{children}</div>
+        <div className={clsx(rootClass)} {...props}>{children}</div>
     </HoverCardContext.Provider>;
 };
 

--- a/src/components/ui/HoverCard/fragments/HoverCardTrigger.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardTrigger.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-
+import { clsx } from 'clsx';
 import HoverCardContext from '../contexts/HoverCardContext';
 
 import Primitive from '~/core/primitives/Primitive';
@@ -14,7 +14,7 @@ const HoverCardTrigger = ({ children, className = '', ...props }: HoverCardTrigg
 
     return <>
         <Primitive.span
-            className={`${rootTriggerClass} ${className}`}
+            className={clsx(rootTriggerClass, className)}
             onClick={() => {}}
             onMouseEnter={openWithDelay} onMouseLeave={closeWithDelay}
             ref={floatingRefs.setReference}

--- a/src/components/ui/Kbd/Kbd.tsx
+++ b/src/components/ui/Kbd/Kbd.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Kbd';
 
 export type KbdProps = {
@@ -13,7 +13,7 @@ export type KbdProps = {
 
 const Kbd = ({ children, customRootClass, className, ...props }: KbdProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <kbd className={`${rootClass} ${className}`} {...props}>{children}</kbd>;
+    return <kbd className={clsx(rootClass, className)} {...props}>{children}</kbd>;
 };
 
 export default Kbd;

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 
 const COMPONENT_NAME = 'Link';
@@ -15,11 +15,11 @@ export type LinkProps = {
 }
 
 // TODO: in the previous return value
-// return <a href={href} alt={alt} className={`${rootClass} ${className}`} {...props}>{children}</a>;
+// return <a href={href} alt={alt} className={clsx(rootClass, className)} {...props}>{children}</a>;
 // 'alt' prop does not exist on an anchor element
 const Link = ({ children, href = '#', alt, customRootClass, className, ...props }: LinkProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <a href={href} className={`${rootClass} ${className}`} {...props}>{children}</a>;
+    return <a href={href} className={clsx(rootClass, className)} {...props}>{children}</a>;
 };
 
 Link.displayName = COMPONENT_NAME;

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FloatingOverlay, FloatingPortal, FloatingFocusManager, useFloating } from '@floating-ui/react';
-
+import { clsx } from 'clsx';
 export type ModalProps = {
     open: boolean;
     onClose: () => void;
@@ -15,8 +15,8 @@ export const Modal: React.FC<ModalProps> = ({ open = true, onClose, children }) 
     };
 
     return (
-        <div className="modal">
-            <div className="modal__content">
+        <div className={clsx('modal')}>
+            <div className={clsx('modal__content')}>
                 <div>
                     {children}
                 </div>
@@ -24,10 +24,10 @@ export const Modal: React.FC<ModalProps> = ({ open = true, onClose, children }) 
                     {
                         open &&
                         <FloatingPortal>
-                            <FloatingOverlay className="overlay" lockScroll>
+                            <FloatingOverlay className={clsx('overlay')} lockScroll>
                                 <FloatingFocusManager context={context}>
-                                    <div className='fixed bg-black/80 overflow-auto w-screen h-screen grid place-items-center'>
-                                        <div className='bg-white p-4 inline-block rounded-md shadow-lg'>
+                                    <div className={clsx('fixed bg-black/80 overflow-auto w-screen h-screen grid place-items-center')}>
+                                        <div className={clsx('bg-white p-4 inline-block rounded-md shadow-lg')}>
                                             <button onClick={onCloseHandler}>
                                                 Close
                                             </button>

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { ProgressProps, COMPONENT_NAME } from '../Progress';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 interface IndicatorProps
   extends Pick<
     ProgressProps,
@@ -28,7 +28,7 @@ export default function ProgressIndicator({
     return (
         <div
             role="progressbar"
-            className={`${rootClass}-indicator`}
+            className={clsx(`${rootClass}-indicator`)}
             style={{ transform: `translateX(-${maxValue - value}%)` }}
             aria-valuenow={value}
             aria-valuemax={maxValue}

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 
 import { ProgressProps, COMPONENT_NAME } from '../Progress';
@@ -9,5 +9,5 @@ interface ProgressRootProps extends Partial<ProgressProps> {}
 export default function ProgressRoot({ children, customRootClass }: ProgressRootProps) {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    return (<div className={rootClass}>{children}</div>);
+    return (<div className={clsx(rootClass)}>{children}</div>);
 }

--- a/src/components/ui/Quote/Quote.tsx
+++ b/src/components/ui/Quote/Quote.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { customClassSwitcher } from '~/core';
-
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'Quote';
 
 export type QuoteProps = {
@@ -13,7 +13,7 @@ export type QuoteProps = {
 
 const Quote = ({ children, customRootClass, className, ...props }: QuoteProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <q className={`${rootClass} ${className}`} {...props}>{children}</q>;
+    return <q className={clsx(rootClass, className)} {...props}>{children}</q>;
 };
 
 Quote.displayName = COMPONENT_NAME;


### PR DESCRIPTION
This solves the issue https://github.com/rad-ui/ui/issues/613 by using clsx to handle passing the className. It ensures no blank space or undefined className is passed. The files have been manually checked after the script did the migration. ** The tests would fail because main has some issues **. The tests failing are not related to components changed. Primitives have not been changed