### PR TITLE
Duplicate import fix

### DIFF
--- a/src/components/ui/RadioGroup/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,7 @@
 import React, { DetailedHTMLProps, InputHTMLAttributes, PropsWithChildren } from 'react';
 import { customClassSwitcher } from '~/core';
 import RadioPrimitive from '~/core/primitives/Radio';
+import { clsx } from 'clsx';
 const COMPONENT_NAME = 'RadioGroup';
 
 export type RadioGroupProps = {
@@ -14,7 +15,7 @@ const RadioGroup = ({ children, type = 'radio', className = '', customRootClass 
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
-        <div className={`${rootClass} ${className}`} role='radiogroup'>
+        <div className={clsx(rootClass, className)} role='radiogroup'>
             <RadioPrimitive
                 type={type}
                 {...props}>

--- a/src/components/ui/RadioGroup/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup/RadioGroup.tsx
@@ -2,11 +2,6 @@ import React, { DetailedHTMLProps, InputHTMLAttributes, PropsWithChildren } from
 import { customClassSwitcher } from '~/core';
 import RadioPrimitive from '~/core/primitives/Radio';
 const COMPONENT_NAME = 'RadioGroup';
-import React, { DetailedHTMLProps, InputHTMLAttributes, PropsWithChildren } from 'react';
-import { clsx } from 'clsx';
-import { customClassSwitcher } from '~/core';
-import RadioPrimitive from '~/core/primitives/Radio';
-const COMPONENT_NAME = 'RadioGroup';
 
 export type RadioGroupProps = {
 
@@ -19,7 +14,7 @@ const RadioGroup = ({ children, type = 'radio', className = '', customRootClass 
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
-        <div className={clsx(rootClass, className)} role='radiogroup'>
+        <div className={`${rootClass} ${className}`} role='radiogroup'>
             <RadioPrimitive
                 type={type}
                 {...props}>


### PR DESCRIPTION
Fixed the radioGroup file causing breaking of chromatic deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Cleaned up import statements in the RadioGroup component.
	- Simplified class name concatenation using template literals.

- **Bug Fixes**
	- Ensured the overall functionality of the RadioGroup component remains intact after modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->