### PR TITLE
Change default label in <Tooltip />

### DIFF
--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ const COMPONENT_NAME = 'Tooltip';
 
 type TooltipProps = {
     children: React.ReactNode;
-    label: string;
+    label?: string;
     placement?:
         | 'top'
         | 'bottom'
@@ -22,7 +22,7 @@ type TooltipProps = {
     [key: string]: any;
 };
 
-const Tooltip = ({ children, label, placement = 'top', ...props }: TooltipProps) => {
+const Tooltip = ({ children, label = '', placement = 'top', ...props }: TooltipProps) => {
     return (
         <div>
             <Popper

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -22,7 +22,7 @@ type TooltipProps = {
     [key: string]: any;
 };
 
-const Tooltip = ({ children, label = 'hello', placement = 'top', ...props }: TooltipProps) => {
+const Tooltip = ({ children, label, placement = 'top', ...props }: TooltipProps) => {
     return (
         <div>
             <Popper

--- a/src/components/ui/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.test.tsx
@@ -14,13 +14,13 @@ describe('Tooltip', () => {
         render(<Tooltip label='label'>Hover me</Tooltip>);
         // tooltip is initially hidden
         expect(screen.queryByText('label')).not.toBeInTheDocument();
-        const tooltip = screen.getByText('Hover me');
-        // hover over the tooltip
-        await userEvent.hover(tooltip);
+        const text = screen.getByText('Hover me');
+        // hover over the trigger text
+        await userEvent.hover(text);
         // tooltip is visible now
         expect(screen.getByText('label')).toBeInTheDocument();
-        // unhover from the tooltip
-        await userEvent.unhover(tooltip);
+        // unhover from the trigger text
+        await userEvent.unhover(text);
         // tooltip is hidden again
         expect(screen.queryByText('label')).not.toBeInTheDocument();
     });

--- a/src/components/ui/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Tooltip from '../Tooltip';
+
+describe('Tooltip', () => {
+    test('renders component', () => {
+        render(<Tooltip label='label'>Hover me</Tooltip>);
+        expect(screen.getByText('Hover me')).toBeInTheDocument();
+        expect(screen.queryByText('label')).not.toBeInTheDocument();
+    });
+
+    test('renders tooltip on hover and hides on unhover', async() => {
+        render(<Tooltip label='label'>Hover me</Tooltip>);
+        // tooltip is initially hidden
+        expect(screen.queryByText('label')).not.toBeInTheDocument();
+        const tooltip = screen.getByText('Hover me');
+        // hover over the tooltip
+        await userEvent.hover(tooltip);
+        // tooltip is visible now
+        expect(screen.getByText('label')).toBeInTheDocument();
+        // unhover from the tooltip
+        await userEvent.unhover(tooltip);
+        // tooltip is hidden again
+        expect(screen.queryByText('label')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/ui/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.test.tsx
@@ -43,13 +43,25 @@ describe('Tooltip', () => {
 
         test('renders tooltip when label is of an invalid type', async() => {
             // @ts-expect-error: label should be a string
-            expect(() => render(<Tooltip label={42}>Hover me</Tooltip>)).not.toThrow();
+            const { rerender } = render(<Tooltip label={42}>Hover me</Tooltip>);
+            // hover over the trigger text
+            await userEvent.hover(screen.getByText('Hover me'));
+            // tooltip renders without throwing an error
+            expect(screen.getByText(42)).toBeInTheDocument();
 
             // @ts-expect-error:label should be a string
-            expect(() => render(<Tooltip label={true}>Hover me</Tooltip>)).not.toThrow();
+            rerender(<Tooltip label={true}>Hover me</Tooltip>);
+            // hover over the trigger text
+            await userEvent.hover(screen.getByText('Hover me'));
+            // empty tooltip renders without throwing an error
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
 
             // @ts-expect-error: label should be a string
-            expect(() => render(<Tooltip label={null}>Hover me</Tooltip>)).not.toThrow();
+            rerender(<Tooltip label={null}>Hover me</Tooltip>);
+            // hover over the trigger text
+            await userEvent.hover(screen.getByText('Hover me'));
+            // empty tooltip renders without throwing an error
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
         });
     });
 });

--- a/src/components/ui/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.test.tsx
@@ -10,18 +10,46 @@ describe('Tooltip', () => {
         expect(screen.queryByText('label')).not.toBeInTheDocument();
     });
 
-    test('renders tooltip on hover and hides on unhover', async() => {
-        render(<Tooltip label='label'>Hover me</Tooltip>);
-        // tooltip is initially hidden
-        expect(screen.queryByText('label')).not.toBeInTheDocument();
-        const text = screen.getByText('Hover me');
-        // hover over the trigger text
-        await userEvent.hover(text);
-        // tooltip is visible now
-        expect(screen.getByText('label')).toBeInTheDocument();
-        // unhover from the trigger text
-        await userEvent.unhover(text);
-        // tooltip is hidden again
-        expect(screen.queryByText('label')).not.toBeInTheDocument();
+    describe('Labels', () => {
+        test('renders tooltip on hover and hides on unhover', async() => {
+            render(<Tooltip label='label'>Hover me</Tooltip>);
+            // tooltip is initially hidden
+            expect(screen.queryByText('label')).not.toBeInTheDocument();
+            const text = screen.getByText('Hover me');
+            // hover over the trigger text
+            await userEvent.hover(text);
+            // tooltip is visible now
+            expect(screen.getByText('label')).toBeInTheDocument();
+            // unhover from the trigger text
+            await userEvent.unhover(text);
+            // tooltip is hidden again
+            expect(screen.queryByText('label')).not.toBeInTheDocument();
+        });
+
+        test('renders tooltip when label is not given', async() => {
+            render(<Tooltip>Hover me</Tooltip>);
+            // tooltip is initially hidden
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            const text = screen.getByText('Hover me');
+            // hover over the trigger text
+            await userEvent.hover(text);
+            // tooltip is visible now
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+            // unhover from the trigger text
+            await userEvent.unhover(text);
+            // tooltip is hidden again
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        test('renders tooltip when label is of an invalid type', async() => {
+            // @ts-expect-error: label should be a string
+            expect(() => render(<Tooltip label={42}>Hover me</Tooltip>)).not.toThrow();
+
+            // @ts-expect-error:label should be a string
+            expect(() => render(<Tooltip label={true}>Hover me</Tooltip>)).not.toThrow();
+
+            // @ts-expect-error: label should be a string
+            expect(() => render(<Tooltip label={null}>Hover me</Tooltip>)).not.toThrow();
+        });
     });
 });


### PR DESCRIPTION
### Purpose

Fixes #629 

### This PR

Changes the default `hello` label to an empty string for the tooltip component.

Adds tests for the tooltip component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `label` prop for the `Tooltip` component is now optional, with a default value of an empty string.
- **Bug Fixes**
	- Improved error handling for the `Tooltip` component when no label is provided or when the label is of an invalid type.
- **Tests**
	- Added comprehensive unit tests for the `Tooltip` component to validate rendering and interaction behavior, including hover visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->