### PR TITLE
Use clsx for <Popper />

### DIFF
--- a/src/components/tools/Popper/Popper.tsx
+++ b/src/components/tools/Popper/Popper.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { customClassSwitcher } from '~/core';
+import { clsx } from 'clsx';
 
 import { useFloating, useInteractions, useHover, FloatingArrow, arrow, offset, flip, autoPlacement, hide, shift, autoUpdate, useRole, useDismiss } from '@floating-ui/react';
 
@@ -101,7 +102,7 @@ const Popper = ({
 
     return <span>
         <span
-            className={`rad-ui-popper ${rootClass}-reference-element ${className}`} ref={refs.setReference} {...getReferenceProps(
+            className={clsx('rad-ui-popper', `${rootClass}-reference-element`, className)} ref={refs.setReference} {...getReferenceProps(
                 {
                     onClick: () => {
                         console.log('click');
@@ -109,8 +110,8 @@ const Popper = ({
                 }
             )}>{children}</span>
         {
-            isOpen && <div className={`${rootClass}-floating-element`} ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} >
-                {showArrow && <FloatingArrow className={`rad-ui-arrow ${rootClass}-arrow`} ref={arrowRef} context={context} />}
+            isOpen && <div className={clsx(`${rootClass}-floating-element`)} ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} >
+                {showArrow && <FloatingArrow className={clsx(`rad-ui-arrow ${rootClass}-arrow`)} ref={arrowRef} context={context} />}
                 {pop}</div>
         }
     </span>;


### PR DESCRIPTION
Add `clsx` to `<Popper />` as per https://github.com/rad-ui/ui/pull/638#issuecomment-2539796208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved class name management in the `Popper` component for better readability and maintainability.
	- Updated class assignments to use the `clsx` utility for consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->