### PR TITLE
Storybook missing styles in aspect ratio example

### DIFF
--- a/src/components/ui/AspectRatio/stories/AspectRatio.stories.js
+++ b/src/components/ui/AspectRatio/stories/AspectRatio.stories.js
@@ -8,6 +8,7 @@ export default {
     render: (args) => <SandboxEditor>
         <AspectRatio {...args} >
             <img
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
 				className="Image"
 				src="https://images.pexels.com/photos/346529/pexels-photo-346529.jpeg?cs=srgb&dl=pexels-bri-schneiter-28802-346529.jpg&fm=jpg"
 				alt="Landscape photograph"


### PR DESCRIPTION
The storybook example missed the styling in the main commit. This ensures it works as intended 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved image presentation in the `AspectRatio` component by ensuring images cover their container while maintaining aspect ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->