### PR TITLE
Test and minor fixes for Accordion, Button, and Progress components

### DIFF
--- a/src/components/ui/Accordion/Accordion.tsx
+++ b/src/components/ui/Accordion/Accordion.tsx
@@ -6,7 +6,7 @@ import AccordionTrigger from './fragments/AccordionTrigger';
 import AccordionContent from './fragments/AccordionContent';
 
 export type AccordionProps = {
-    items: {content: any}[];
+    items: {title: string, content: React.ReactNode}[];
 }
 
 const Accordion = ({ items } : AccordionProps) => {
@@ -15,7 +15,7 @@ const Accordion = ({ items } : AccordionProps) => {
             {items.map((item, index) => (
                 <AccordionItem value={index} key={index} >
                     <AccordionHeader>
-                        <AccordionTrigger >
+                        <AccordionTrigger>
                             {item.title}
                         </AccordionTrigger>
                     </AccordionHeader>

--- a/src/components/ui/Accordion/Accordion.tsx
+++ b/src/components/ui/Accordion/Accordion.tsx
@@ -4,6 +4,7 @@ import AccordionItem from './fragments/AccordionItem';
 import AccordionHeader from './fragments/AccordionHeader';
 import AccordionTrigger from './fragments/AccordionTrigger';
 import AccordionContent from './fragments/AccordionContent';
+import { isReactNode } from '~/core/types';
 
 export type AccordionProps = {
     items: {title: string, content: React.ReactNode}[];
@@ -16,11 +17,11 @@ const Accordion = ({ items } : AccordionProps) => {
                 <AccordionItem value={index} key={index} >
                     <AccordionHeader>
                         <AccordionTrigger>
-                            {item.title}
+                            {isReactNode(item.title) ? item.title : 'Accordion title must be a valid string'}
                         </AccordionTrigger>
                     </AccordionHeader>
                     <AccordionContent>
-                        {item.content}
+                        {isReactNode(item.content) ? item.content : 'Accordion content must be a valid React element'}
                     </AccordionContent>
                 </AccordionItem>
             ))}

--- a/src/components/ui/Accordion/contexts/AccordionContext.tsx
+++ b/src/components/ui/Accordion/contexts/AccordionContext.tsx
@@ -1,3 +1,21 @@
 import { createContext } from 'react';
 
-export const AccordionContext = createContext({});
+type AccordionContextType = {
+  rootClass: string;
+  activeItem: number | null;
+  setActiveItem: React.Dispatch<React.SetStateAction<number | null>>;
+  focusItem: Element | null;
+  setFocusItem: React.Dispatch<React.SetStateAction<Element | null>>;
+  focusPrevItem: () => void;
+  focusNextItem: () => void;
+};
+
+export const AccordionContext = createContext<AccordionContextType>({
+    rootClass: '',
+    activeItem: null,
+    setActiveItem: () => {},
+    focusItem: null,
+    setFocusItem: () => {},
+    focusPrevItem: () => {},
+    focusNextItem: () => {}
+});

--- a/src/components/ui/Accordion/contexts/AccordionItemContext.tsx
+++ b/src/components/ui/Accordion/contexts/AccordionItemContext.tsx
@@ -1,3 +1,17 @@
-import { createContext } from 'react';
+import { createContext, FocusEvent } from 'react';
 
-export const AccordionItemContext = createContext({});
+type AccordionItemContextType = {
+  itemValue: number | null;
+  setItemValue: React.Dispatch<React.SetStateAction<number | null>>;
+  handleBlurEvent: (e: FocusEvent<HTMLButtonElement>) => void;
+  handleClickEvent: () => void;
+  handleFocusEvent: () => void;
+};
+
+export const AccordionItemContext = createContext<AccordionItemContextType>({
+    itemValue: null,
+    setItemValue: () => {},
+    handleBlurEvent: () => {},
+    handleClickEvent: () => {},
+    handleFocusEvent: () => {}
+});

--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -5,12 +5,10 @@ import { clsx } from 'clsx';
 
 type AccordionContentProps = {
   children: React.ReactNode;
-  index: number,
-  activeIndex: number,
-  className? :string
+  className?: string;
 };
 
-const AccordionContent: React.FC<AccordionContentProps> = ({ children, index, activeIndex, className = '' }: AccordionContentProps) => {
+const AccordionContent: React.FC<AccordionContentProps> = ({ children, className = '' }: AccordionContentProps) => {
     const { activeItem, rootClass } = useContext(AccordionContext);
 
     const { itemValue } = useContext(AccordionItemContext);
@@ -18,9 +16,9 @@ const AccordionContent: React.FC<AccordionContentProps> = ({ children, index, ac
     return (
         <div
             className={clsx(`${rootClass}-content`, className)}
-            id={`content-${index}`}
+            id={`content-${itemValue}`}
             role="region"
-            aria-labelledby={`section-${index}`}
+            aria-labelledby={`section-${itemValue}`}
             hidden={itemValue !== activeItem}>
 
             {children}

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -5,8 +5,8 @@ import { AccordionItemContext } from '../contexts/AccordionItemContext';
 
 export type AccordionItemProps = {
     children: React.ReactNode;
+    value: number;
     className?: string;
-    value?: number;
 }
 
 const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, className = '', ...props }) => {

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -10,8 +10,8 @@ export type AccordionItemProps = {
 }
 
 const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, className = '', ...props }) => {
-    const accordionItemRef = useRef(null);
-    const [itemValue, setItemValue] = useState(value);
+    const accordionItemRef = useRef<HTMLDivElement | null>(null);
+    const [itemValue, setItemValue] = useState<number | null>(value);
     const { rootClass, activeItem, focusItem } = useContext(AccordionContext);
 
     const [isOpen, setIsOpen] = useState(itemValue === activeItem);

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useId, useEffect, useRef } from 'react';
+import React, { FocusEvent, useState, useContext, useId, useEffect, useRef } from 'react';
 import { clsx } from 'clsx';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { AccordionItemContext } from '../contexts/AccordionItemContext';
@@ -39,7 +39,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, classNam
         }
     };
 
-    const handleBlurEvent = (e) => {
+    const handleBlurEvent = (e: FocusEvent<HTMLButtonElement>) => {
         // if clicked outside of the accordion, set activeItem to null
         const elem = accordionItemRef?.current;
 

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -59,7 +59,7 @@ const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
                 focusItem,
                 setFocusItem
             }}>
-            <div className={clsx(`${rootClass}-root`)} ref={accordionRef}>
+            <div className={clsx(`${rootClass}-root`)} ref={accordionRef} data-testid="accordion-root">
                 {children}
             </div>
         </AccordionContext.Provider>

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -15,10 +15,8 @@ const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
     const accordionRef = useRef(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    const [activeItem, setActiveItem] = useState(null); // keeps track of the active item, stores the
-    const [focusItem, setFocusItem] = useState(null); // stores the id of the item that should be focused
-
-    useEffect(() => {}, []);
+    const [activeItem, setActiveItem] = useState<number | null>(null); // keeps track of the active item, stores the
+    const [focusItem, setFocusItem] = useState<Element | null>(null); // stores the item that should be focused
 
     const focusNextItem = () => {
         const batches = getAllBatchElements(accordionRef?.current);
@@ -51,9 +49,7 @@ const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
                 focusNextItem,
                 focusPrevItem,
                 focusItem,
-                setFocusItem,
-                accordionRef
-
+                setFocusItem
             }}>
             <div className={clsx(`${rootClass}-root`)} ref={accordionRef}>
                 {children}

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 import { AccordionContext } from '../contexts/AccordionContext';
@@ -12,13 +12,17 @@ export type AccordionRootProps = {
 }
 
 const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
-    const accordionRef = useRef(null);
+    const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [activeItem, setActiveItem] = useState<number | null>(null); // keeps track of the active item, stores the
     const [focusItem, setFocusItem] = useState<Element | null>(null); // stores the item that should be focused
 
     const focusNextItem = () => {
+        if (accordionRef?.current == null) {
+            return;
+        }
+
         const batches = getAllBatchElements(accordionRef?.current);
         const nextItem = getNextBatchItem(batches);
         setFocusItem(nextItem);
@@ -30,6 +34,10 @@ const AccordionRoot = ({ children, customRootClass }: AccordionRootProps) => {
     };
 
     const focusPrevItem = () => {
+        if (accordionRef?.current == null) {
+            return;
+        }
+
         const batches = getAllBatchElements(accordionRef?.current);
         const prevItem = getPrevBatchItem(batches);
         setFocusItem(prevItem);

--- a/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
@@ -6,12 +6,9 @@ import { clsx } from 'clsx';
 type AccordionTriggerProps = {
   children: React.ReactNode;
   className?: string,
-  index: number,
-  activeIndex: number,
-  handleClick: (index: number) => void
 };
 
-const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, index, className = '' }) => {
+const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, className = '' }) => {
     const { setActiveItem, rootClass, focusNextItem, focusPrevItem, activeItem } = useContext(AccordionContext);
     const { itemValue, handleBlurEvent, handleClickEvent, handleFocusEvent } = useContext(AccordionItemContext);
 
@@ -49,7 +46,7 @@ const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, index, cl
             }}
             onClick={onClickHandler}
             aria-expanded={activeItem === itemValue}
-            aria-controls={`content-${index}`}
+            aria-controls={`content-${itemValue}`}
         >
             {children}
         </button>

--- a/src/components/ui/Accordion/tests/Accordion.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Accordion, { type AccordionProps } from '../Accordion';
+
+const items: AccordionProps['items'] = [
+    { title: 'One', content: <>This</> },
+    { title: 'Two', content: <>is</> },
+    { title: 'Three', content: <>content</> }
+];
+
+describe('Accordion', () => {
+    test('renders component', () => {
+        render(<Accordion items={[]} />);
+        expect(screen.getByTestId('accordion-root')).toBeInTheDocument();
+    });
+
+    test('all content is hidden initially', () => {
+        render(<Accordion items={items} />);
+        expect(screen.getByText('One')).toBeInTheDocument();
+        expect(screen.getByText('Two')).toBeInTheDocument();
+        expect(screen.getByText('Three')).toBeInTheDocument();
+        expect(screen.getByText('This')).toHaveAttribute('hidden');
+        expect(screen.getByText('is')).toHaveAttribute('hidden');
+        expect(screen.getByText('content')).toHaveAttribute('hidden');
+    });
+
+    test('clicking on a header toggles its content', async() => {
+        render(<Accordion items={items} />);
+        const header = screen.getByText('One');
+        // click on the first header
+        await userEvent.click(header);
+        // first header's content is shown
+        expect(screen.getByText('This')).not.toHaveAttribute('hidden');
+        // click on the first header again
+        await userEvent.click(header);
+        // first header's content is hidden
+        expect(screen.getByText('This')).toHaveAttribute('hidden');
+    });
+
+    test('clicking on a header while another is open closes the open header', async() => {
+        render(<Accordion items={items} />);
+        const firstHeader = screen.getByText('One');
+        // click on the first header
+        await userEvent.click(firstHeader);
+        // first header's content is shown
+        expect(screen.getByText('This')).not.toHaveAttribute('hidden');
+        const secondHeader = screen.getByText('Two');
+        // click on the second header
+        await userEvent.click(secondHeader);
+        // first header's content is hidden
+        expect(screen.getByText('This')).toHaveAttribute('hidden');
+        // second header's content is shown
+        expect(screen.getByText('is')).not.toHaveAttribute('hidden');
+    });
+
+    test('renders component when header and content are invalid', () => {
+        // @ts-expect-error: title and content should be a string and ReactNode, respectively
+        const { rerender } = render(<Accordion items={[{ title: 28, content: { key: 'value' } }]} />);
+        expect(screen.getByText(28)).toBeInTheDocument();
+        expect(screen.getByText('Accordion content must be a valid React element')).toBeInTheDocument();
+
+        // @ts-expect-error: title and content should be a string and ReactNode, respectively
+        rerender(<Accordion items={[{ title: { hi: 'bye' }, content: () => {} }]} />);
+        expect(screen.getByText('Accordion title must be a valid string')).toBeInTheDocument();
+        expect(screen.getByText('Accordion content must be a valid React element')).toBeInTheDocument();
+
+        // @ts-expect-error: item should contain title and content keys
+        rerender(<Accordion items={[{ extra: '' }]} />);
+        expect(screen.getByTestId('accordion-root')).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Button from '../Button';
+
+describe('Button', () => {
+    test('renders component', () => {
+        render(<Button>button</Button>);
+        expect(screen.getByText('button')).toBeInTheDocument();
+    });
+
+    test('renders component with the given type', () => {
+        render(<Button type='submit'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('type', 'submit');
+    });
+
+    test('renders component with the given color', () => {
+        render(<Button color='white'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('data-accent-color', 'white');
+    });
+
+    test('renders component with the given variant', () => {
+        render(<Button variant='outline'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveClass('button-outline');
+    });
+
+    test('renders component with the given size', () => {
+        render(<Button size='small'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('data-size', 'small');
+    });
+
+    test('calls the onClick handler when the button is clicked', async() => {
+        const onClick = jest.fn();
+        render(<Button onClick={onClick}>button</Button>);
+        const button = screen.getByText('button');
+        // click the button
+        await userEvent.click(button);
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/ui/Progress/Progress.tsx
+++ b/src/components/ui/Progress/Progress.tsx
@@ -1,11 +1,11 @@
-import React, { PropsWithChildren, useState } from 'react';
+import React from 'react';
 
 import ProgressRoot from './fragments/ProgressRoot';
 import ProgressIndicator from './fragments/ProgressIndicator';
 
 export const COMPONENT_NAME = 'Progress';
 
-export interface ProgressProps extends PropsWithChildren {
+export interface ProgressProps {
     value: number;
     minValue?: number,
     maxValue?: number;

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -1,16 +1,13 @@
 'use client';
 import React, { useContext } from 'react';
-import { ProgressProps, COMPONENT_NAME } from '../Progress';
+import { COMPONENT_NAME } from '../Progress';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { ProgressContext } from '../contexts/ProgressContext';
 
-interface IndicatorProps
-  extends Pick<
-    ProgressProps,
-    'value' | 'minValue' | 'maxValue' | 'customRootClass' | 'renderLabel'
-  > {
-  renderLabel?(value: number): JSX.Element
+interface IndicatorProps {
+    customRootClass?: string;
+    renderLabel?(value: number): JSX.Element;
 }
 
 export default function ProgressIndicator({

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,12 +1,12 @@
 'use client';
-import React from 'react';
+import React, { type PropsWithChildren } from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 import { ProgressContext } from '../contexts/ProgressContext';
 
 import { ProgressProps, COMPONENT_NAME } from '../Progress';
 
-interface ProgressRootProps extends Partial<ProgressProps> {}
+interface ProgressRootProps extends Partial<ProgressProps>, PropsWithChildren {}
 
 const ProgressRoot = ({ value = 0, minValue = 0, maxValue = 100, children, customRootClass }: ProgressRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Progress from '../Progress';
+
+describe('Progress', () => {
+    test('renders component', () => {
+        render(<Progress value={0} />);
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    test('renders component with clamped value', () => {
+        const { rerender } = render(<Progress value={-6} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+
+        rerender(<Progress value={496} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    test('renders component when minValue is greater than maxValue', () => {
+        render(<Progress value={3} minValue={5} maxValue={0} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    test('binds value to component', () => {
+        const { rerender } = render(<Progress value={1} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '1');
+
+        rerender(<Progress value={2} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '2');
+    });
+});

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const isReactNode = (value: any): value is React.ReactNode => {
+    return (
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        value === null ||
+        value === undefined ||
+        React.isValidElement(value) ||
+        (Array.isArray(value) && value.every(isReactNode))
+    );
+};


### PR DESCRIPTION
Test and minor fixes for the following three components:

1. `<Accordion />`
  a. TypeScript fixes
  b. Fix a bug when an item's `title` or `content` is invalid/missing (and add a new function that checks if the given value is a `React.ReactNode`)
2. `<Button />`
3. `<Progress />`
  a. Remove unnecessary props