### PR TITLE
Aspect Ratio docs

### DIFF
--- a/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
+++ b/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
@@ -1,0 +1,20 @@
+const code = {
+    javascript: {
+        code: `import AspectRatio from "@radui/ui/AspectRatio""
+
+const AspectRatioExample = () => (
+    <AspectRatio ratio='16/9'>
+        <img
+        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        className="Image"
+        src="https://images.pexels.com/photos/346529/pexels-photo-346529.jpeg?cs=srgb&dl=pexels-bri-schneiter-28802-346529.jpg&fm=jpg"
+        alt="Landscape photograph"
+            />
+    </AspectRatio>
+)`
+    
+}
+}
+
+
+export default code;

--- a/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
+++ b/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
@@ -1,6 +1,6 @@
 const code = {
     javascript: {
-        code: `import AspectRatio from "@radui/ui/AspectRatio""
+        code: `import AspectRatio from "@radui/ui/AspectRatio"`
 
 const AspectRatioExample = () => (
     <AspectRatio ratio='16/9'>

--- a/docs/app/docs/components/aspect-ratio/page.js
+++ b/docs/app/docs/components/aspect-ratio/page.js
@@ -1,0 +1,47 @@
+const PAGE_NAME = 'ASPECT_RATIO_DOCS'
+import Documentation from "@/components/layout/Documentation/Documentation"
+
+
+import AspectRatio from "@radui/ui/AspectRatio"
+import SEO from "../../docsIndex"
+export const metadata = SEO.getMetadata(PAGE_NAME)
+
+import codeUsage from "./docs/codeUsage"
+
+const AspectRatioDocs = () => {
+    const columns = [
+        {name: 'Prop', key: 'prop'},
+        {name: 'Type', key: 'type'},
+        {name: 'Default', key: 'default'},
+        {name: 'Description', key: 'description'},
+    ];
+
+    const data = [
+        {prop: 'ratio', type: 'string', default: '1', description: 'Used to set desired ratio'},
+        
+    ];
+    return <div>
+        <Documentation currentPage={PAGE_NAME} title='Aspect Ratio' description={`
+                    Aspect Ratio is used to set the desired ratio.
+                `}>
+                    <Documentation.ComponentHero codeUsage={codeUsage}>
+                <div>
+                     <AspectRatio ratio='16/9'>
+                                <img
+                                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                                    className="Image"
+                                    src="https://images.pexels.com/photos/346529/pexels-photo-346529.jpeg?cs=srgb&dl=pexels-bri-schneiter-28802-346529.jpg&fm=jpg"
+                                    alt="Landscape photograph"
+                                />
+                    </AspectRatio>
+                </div>
+            </Documentation.ComponentHero>
+            <div className="max-w-screen-md">
+                            <Documentation.Table columns={columns} data={data} />
+                        </div>
+                </Documentation>
+      
+    </div>
+}
+
+export default AspectRatioDocs;

--- a/docs/components/navigation/Navigation.js
+++ b/docs/components/navigation/Navigation.js
@@ -44,6 +44,10 @@ const sections = [
                 path: "/docs/components/avatar"
             },
             {
+                title: "AspectRatio",
+                path: "/docs/components/aspect-ratio"
+            },
+            {
                 title: "Badge",
                 path: "/docs/components/badge"
             },


### PR DESCRIPTION
#688 Adding aspect ratio to docs in the website with example and api documentation. Need to find place for giving credits to the image used even though its free. link to the image https://www.pexels.com/photo/calm-body-of-lake-between-mountains-346529/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for the AspectRatio component
  - Introduced a new navigation item for AspectRatio in the component documentation

- **Documentation**
  - Created comprehensive documentation page for AspectRatio
  - Added code usage example and property details
  - Implemented SEO metadata for the new documentation page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->