### PR TITLE
Refactor path concatenation to use template literals

### DIFF
--- a/docs/utils/parseSourceCode.tsx
+++ b/docs/utils/parseSourceCode.tsx
@@ -6,7 +6,7 @@ export const getComponentScssSourceCode = (componentName: string) => {
     // This function is only meant to be used for scss files inside the styles/themes/components folder
     try {   
         const component_name = componentName.toLowerCase();
-        const path_to_scss = path.join(process.cwd(), '../styles/themes/components/' + component_name + '.scss');
+        const path_to_scss = path.join(process.cwd(), 'styles/themes/components', `${component_name}.scss`);
         const scss_SourceCode = fs.readFileSync(
         path_to_scss,
         'utf8'
@@ -20,7 +20,7 @@ export const getComponentScssSourceCode = (componentName: string) => {
 
 export const getComponentJsxSourceCode = (componentPath: string) => {
     // This function is only meant to be used for jsx files inside the app/docs/components folder
-    const path_to_jsx = path.join(process.cwd(), '/app/docs/components/' + componentPath);
+    const path_to_jsx = path.join(process.cwd(), 'app/docs/components', componentPath);
     const jsx_SourceCode = fs.readFileSync(
         path_to_jsx,
         'utf8'


### PR DESCRIPTION
Testing if this resolves the path resolution in vercel/server deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated path construction methods to use template literals for improved code readability
	- Simplified file path references in utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->