### PR TITLE
Refactor Badge and BlockQuote components for consistency + Add Tests

### DIFF
--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import BadgeRoot from './fragments/BadgeRoot';
 import BadgeContent from './fragments/BadgeContent';
-import { clsx } from 'clsx';
 export type BadgeProps = {
     children?: React.ReactNode,
     customRootClass?: string,
@@ -11,9 +10,8 @@ export type BadgeProps = {
     props?: object[],
 }
 
-const Badge = ({ children, customRootClass, className, color, ...props }: BadgeProps) => {
-    return <BadgeRoot customRootClass={customRootClass} className={clsx(className)} color={color ?? undefined} {...props}>
-
+const Badge = ({ children, customRootClass = '', className = '', color, ...props }: BadgeProps) => {
+    return <BadgeRoot customRootClass={customRootClass} className={className} color={color ?? undefined} {...props}>
         <BadgeContent>
             {children}
         </BadgeContent>

--- a/src/components/ui/Badge/tests/Badge.test.tsx
+++ b/src/components/ui/Badge/tests/Badge.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Badge from '../Badge';
+
+describe('Badge', () => {
+    test('renders Badge component', () => {
+        render(<Badge>Badge</Badge>);
+        expect(screen.getByText('Badge')).toBeInTheDocument();
+    });
+
+    // customRootClass check
+    test('renders Badge component with customRootClass', () => {
+        render(<Badge customRootClass='acme-corp'>Badge</Badge>);
+        expect(screen.getByText('Badge')).toHaveClass('acme-corp');
+    });
+
+    // className check
+    test('renders Badge component with className', () => {
+        render(<Badge className='mr-2'>Badge</Badge>);
+        expect(screen.getByText('Badge')).toHaveClass('mr-2');
+    });
+
+    // custom data attributes check
+    test('renders Badge component with custom data attributes', () => {
+        render(<Badge data-testid='badge'>Badge</Badge>);
+        expect(screen.getByTestId('badge')).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/BlockQuote/BlockQuote.tsx
+++ b/src/components/ui/BlockQuote/BlockQuote.tsx
@@ -9,9 +9,9 @@ export type BlockQuoteProps = {
     children: React.ReactNode;
     customRootClass?: string;
     className?: string;
-    props: Record<string, any>[]
+    props?: Record<string, any>[]
 }
-const BlockQuote = ({ children, customRootClass, className, ...props }: BlockQuoteProps) => {
+const BlockQuote = ({ children, customRootClass = '', className = '', ...props }: BlockQuoteProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return <blockquote className={clsx(rootClass, className)} {...props}>{children}</blockquote>;

--- a/src/components/ui/BlockQuote/tests/BlockQuote.test.tsx
+++ b/src/components/ui/BlockQuote/tests/BlockQuote.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import BlockQuote from '../BlockQuote';
+
+describe('BlockQuote', () => {
+    test('renders BlockQuote component', () => {
+        render(<BlockQuote>BlockQuote</BlockQuote>);
+        expect(screen.getByText('BlockQuote')).toBeInTheDocument();
+    });
+
+    // customRootClass check
+    test('renders BlockQuote component with customRootClass', () => {
+        render(<BlockQuote customRootClass='acme-corp'>BlockQuote</BlockQuote>);
+        expect(screen.getByText('BlockQuote')).toHaveClass('acme-corp');
+    });
+
+    // className check
+    test('renders BlockQuote component with className', () => {
+        render(<BlockQuote className='mr-2'>BlockQuote</BlockQuote>);
+        expect(screen.getByText('BlockQuote')).toHaveClass('mr-2');
+    });
+
+    // custom data attributes check
+    test('renders BlockQuote component with custom data attributes', () => {
+        render(<BlockQuote data-testid='block-quote'>BlockQuote</BlockQuote>);
+        expect(screen.getByTestId('block-quote')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- No new user-facing features added

- **Bug Fixes**
	- Improved component prop handling for Badge and BlockQuote components
	- Ensured default empty strings for `customRootClass` and `className` props

- **Tests**
	- Added comprehensive test suites for Badge and BlockQuote components
	- Verified component rendering, class application, and data attribute handling

- **Chores**
	- Simplified class name handling by removing `clsx` utility function
	- Made props optional in component type definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->