### PR TITLE
Cherry-pick <Button /> and <Progress /> commits from #668

### DIFF
--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -19,19 +19,19 @@ describe('Button', () => {
     test('renders button with the given color', () => {
         render(<Button color='white'>button</Button>);
         const button = screen.getByText('button');
-        expect(button).toHaveAttribute('data-accent-color', 'white');
+        expect(button).toHaveAttribute('color', 'white');
     });
 
     test('renders button with the given variant', () => {
         render(<Button variant='outline'>button</Button>);
         const button = screen.getByText('button');
-        expect(button).toHaveClass('button-outline');
+        expect(button).toHaveClass('rad-ui-button');
     });
 
     test('renders button with the given size', () => {
         render(<Button size='small'>button</Button>);
         const button = screen.getByText('button');
-        expect(button).toHaveAttribute('data-size', 'small');
+        expect(button).toHaveAttribute('data-button-size', 'small');
     });
 
     test('calls the onClick handler when the button is clicked', async() => {

--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -5,30 +5,30 @@ import userEvent from '@testing-library/user-event';
 import Button from '../Button';
 
 describe('Button', () => {
-    test('renders component', () => {
+    test('renders button', () => {
         render(<Button>button</Button>);
         expect(screen.getByText('button')).toBeInTheDocument();
     });
 
-    test('renders component with the given type', () => {
+    test('renders button with the given type', () => {
         render(<Button type='submit'>button</Button>);
         const button = screen.getByText('button');
         expect(button).toHaveAttribute('type', 'submit');
     });
 
-    test('renders component with the given color', () => {
+    test('renders button with the given color', () => {
         render(<Button color='white'>button</Button>);
         const button = screen.getByText('button');
         expect(button).toHaveAttribute('data-accent-color', 'white');
     });
 
-    test('renders component with the given variant', () => {
+    test('renders button with the given variant', () => {
         render(<Button variant='outline'>button</Button>);
         const button = screen.getByText('button');
         expect(button).toHaveClass('button-outline');
     });
 
-    test('renders component with the given size', () => {
+    test('renders button with the given size', () => {
         render(<Button size='small'>button</Button>);
         const button = screen.getByText('button');
         expect(button).toHaveAttribute('data-size', 'small');

--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Button from '../Button';
+
+describe('Button', () => {
+    test('renders component', () => {
+        render(<Button>button</Button>);
+        expect(screen.getByText('button')).toBeInTheDocument();
+    });
+
+    test('renders component with the given type', () => {
+        render(<Button type='submit'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('type', 'submit');
+    });
+
+    test('renders component with the given color', () => {
+        render(<Button color='white'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('data-accent-color', 'white');
+    });
+
+    test('renders component with the given variant', () => {
+        render(<Button variant='outline'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveClass('button-outline');
+    });
+
+    test('renders component with the given size', () => {
+        render(<Button size='small'>button</Button>);
+        const button = screen.getByText('button');
+        expect(button).toHaveAttribute('data-size', 'small');
+    });
+
+    test('calls the onClick handler when the button is clicked', async() => {
+        const onClick = jest.fn();
+        render(<Button onClick={onClick}>button</Button>);
+        const button = screen.getByText('button');
+        // click the button
+        await userEvent.click(button);
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/ui/Progress/Progress.tsx
+++ b/src/components/ui/Progress/Progress.tsx
@@ -1,11 +1,11 @@
-import React, { PropsWithChildren, useState } from 'react';
+import React from 'react';
 
 import ProgressRoot from './fragments/ProgressRoot';
 import ProgressIndicator from './fragments/ProgressIndicator';
 
 export const COMPONENT_NAME = 'Progress';
 
-export interface ProgressProps extends PropsWithChildren {
+export interface ProgressProps {
     value: number;
     minValue?: number,
     maxValue?: number;

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -1,16 +1,13 @@
 'use client';
 import React, { useContext } from 'react';
-import { ProgressProps, COMPONENT_NAME } from '../Progress';
+import { COMPONENT_NAME } from '../Progress';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { ProgressContext } from '../contexts/ProgressContext';
 
-interface IndicatorProps
-  extends Pick<
-    ProgressProps,
-    'value' | 'minValue' | 'maxValue' | 'customRootClass' | 'renderLabel'
-  > {
-  renderLabel?(value: number): JSX.Element
+interface IndicatorProps {
+    customRootClass?: string;
+    renderLabel?(value: number): JSX.Element;
 }
 
 export default function ProgressIndicator({

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,12 +1,12 @@
 'use client';
-import React from 'react';
+import React, { type PropsWithChildren } from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 import { ProgressContext } from '../contexts/ProgressContext';
 
 import { ProgressProps, COMPONENT_NAME } from '../Progress';
 
-interface ProgressRootProps extends Partial<ProgressProps> {}
+interface ProgressRootProps extends Partial<ProgressProps>, PropsWithChildren {}
 
 const ProgressRoot = ({ value = 0, minValue = 0, maxValue = 100, children, customRootClass }: ProgressRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -4,12 +4,12 @@ import { render, screen } from '@testing-library/react';
 import Progress from '../Progress';
 
 describe('Progress', () => {
-    test('renders component', () => {
+    test('renders progress bar', () => {
         render(<Progress value={0} />);
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
-    test('renders component with clamped value', () => {
+    test('renders progress bar with clamped value', () => {
         const { rerender } = render(<Progress value={-6} minValue={0} maxValue={100} />);
         expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
 
@@ -17,12 +17,12 @@ describe('Progress', () => {
         expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
     });
 
-    test('renders component when minValue is greater than maxValue', () => {
+    test('renders progress bar when minValue is greater than maxValue', () => {
         render(<Progress value={3} minValue={5} maxValue={0} />);
         expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
     });
 
-    test('binds value to component', () => {
+    test('binds value to progress bar', () => {
         const { rerender } = render(<Progress value={1} minValue={0} maxValue={100} />);
         expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '1');
 

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Progress from '../Progress';
+
+describe('Progress', () => {
+    test('renders component', () => {
+        render(<Progress value={0} />);
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    test('renders component with clamped value', () => {
+        const { rerender } = render(<Progress value={-6} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+
+        rerender(<Progress value={496} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    test('renders component when minValue is greater than maxValue', () => {
+        render(<Progress value={3} minValue={5} maxValue={0} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    test('binds value to component', () => {
+        const { rerender } = render(<Progress value={1} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '1');
+
+        rerender(<Progress value={2} minValue={0} maxValue={100} />);
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '2');
+    });
+});


### PR DESCRIPTION
Cherry-pick Button and Progress component commits from #668

In particular, test and minor fixes for the following three components:

1. `<Button />`
2. `<Progress />`
  a. Remove unnecessary props


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added comprehensive test suite for the `Button` component to validate rendering and functionality.
	- Introduced new test suite for the `Progress` component, covering various scenarios like value clamping and rendering.

- **Refactor**
	- Updated `Progress` component interfaces to simplify prop handling.
	- Modified `ProgressIndicator` and `ProgressRoot` component interfaces for improved type definitions, including support for child components in `ProgressRoot`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->