### PR TITLE
Fix: Read only warning in showcase music app

### DIFF
--- a/docs/app/showcase/music-app/helpers/sections/PlaylistHero.tsx
+++ b/docs/app/showcase/music-app/helpers/sections/PlaylistHero.tsx
@@ -53,7 +53,7 @@ const PlaylistHero: any = () => {
             <div className="gap-4 space-y-4">
                 <div>
                     <div>
-                        <input value="Search..." className='flex flex-1 items-center px-2 rounded-md border border-gray-400 text-gray-700' />
+                        <input placeholder="Search..." className='flex flex-1 items-center px-2 rounded-md border border-gray-400 text-gray-700' />
                     </div>
 
                 </div>


### PR DESCRIPTION
Update input field to use placeholder instead of value for search.
This pr fixes #772 