### PR TITLE
Add collapsible navigation menu with toggle icons for the docs

### DIFF
--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -8,7 +8,7 @@ const InfoIcon = () => {
 
 const Layout = ({ children }: any) => {
     return (
-        <div data-accent-color="blue" className="lg:flex space-x-2 w-full h-screen overflow-hidden">
+        <div data-accent-color="blue" className="flex space-x-2 w-full h-screen overflow-hidden">
             <div className='flex-none h-full flex flex-col'>
                 <Navigation />
             </div>

--- a/docs/components/navigation/Navigation.js
+++ b/docs/components/navigation/Navigation.js
@@ -3,6 +3,7 @@
 import path from 'path';
 import NavItem from './NavItem.js'
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 
 const sections = [
     {
@@ -197,24 +198,74 @@ const sections = [
 ]
 
 
+const HamburgerIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} {...props}>
+      <g>
+        <path
+          strokeLinecap="round"
+          d="M13.5 2H.5M13.5 7H.5M13.5 12H.5"
+          style={{
+            stroke: "#ab4aba",
+            strokeWidth: 1,
+            strokeDasharray: "none",
+            strokeLinecap: "round",
+            strokeDashoffset: 0,
+            strokeLinejoin: "round",
+            strokeMiterlimit: 4,
+            fill: "#ab4aba",
+            fillRule: "nonzero",
+            opacity: 1,
+          }}
+          transform="matrix(1.43 0 0 1.43 1.99 1.99)"
+        />
+      </g>
+    </svg>
+  )
+
+  const XIcon = (props) => (
+    <svg
+     className='text-red-200'
+    xmlns="http://www.w3.org/2000/svg"
+    // xmlSpace="preserve"
+    width={18}
+    height={18}
+    
+   fill='#ab4aba'
+   stroke='#ab4aba'
+    viewBox="0 0 460.775 460.775"
+    {...props}
+  >
+    <path d="M285.08 230.397 456.218 59.27c6.076-6.077 6.076-15.911 0-21.986L423.511 4.565a15.55 15.55 0 0 0-21.985 0l-171.138 171.14L59.25 4.565a15.551 15.551 0 0 0-21.985 0L4.558 37.284c-6.077 6.075-6.077 15.909 0 21.986l171.138 171.128L4.575 401.505c-6.074 6.077-6.074 15.911 0 21.986l32.709 32.719a15.555 15.555 0 0 0 21.986 0l171.117-171.12 171.118 171.12a15.551 15.551 0 0 0 21.985 0l32.709-32.719c6.074-6.075 6.074-15.909 0-21.986L285.08 230.397z" />
+  </svg>
+  )
+
 const Navigation = () => {
     // get path from ssr
     const pathname = usePathname();
+    const [isCollapsed, setIsCollapsed] = useState(false);
 
-    return <div className='border-box px-1 overflow-y-auto lg:block flex flex-col pb-[200px]'>
-        <div className='flex-none' style={{ width: "240px" }}>
-            {sections.map((section, i) => {
-                return <div key={i}>
-                    <div className='px-2 py-2 font-bold text-md text-gray-1000'>{section.title}</div>
-                    <ul>
-                        {section.items.map((item, itemKey) => {
-                            return <li key={itemKey}>
-                                <NavItem item={item} path={pathname} />
-                            </li>
-                        })}
-                    </ul>
-                </div>
-            })}
+    const toggleCollapse = () => {
+        setIsCollapsed(!isCollapsed);
+    }
+
+
+    return <div className=' relative border-box px-1 overflow-y-auto lg:block flex flex-col pb-[200px] min-w-[40px] min-h-[40px]'>
+        <div onClick={toggleCollapse} className={`absolute right-2 top-3` }>{isCollapsed? <HamburgerIcon /> : <XIcon />}</div>
+        <div className={`${isCollapsed ? "hidden" : "block"}`}>
+            <div className='flex-none' style={{ width: "240px" }}>
+                {sections.map((section, i) => {
+                    return <div key={i}>
+                        <div className='px-2 py-2 font-bold text-md text-gray-1000'>{section.title}</div>
+                        <ul>
+                            {section.items.map((item, itemKey) => {
+                                return <li key={itemKey}>
+                                    <NavItem item={item} path={pathname} />
+                                </li>
+                            })}
+                        </ul>
+                    </div>
+                })}
+            </div>
         </div>
     </div>
 }


### PR DESCRIPTION
A basic collapsible navbar for the docs

This pr closes the issue #701 

> Before Collapsing
![image](https://github.com/user-attachments/assets/e42a2967-1cb2-4329-975f-716b99c03b01)

> Collapsed navbar
![image](https://github.com/user-attachments/assets/7f3cb436-d8af-432d-b438-7547518478cc)
