### PR TITLE
Avatar and AvatarGroup with color support for fallback

### DIFF
--- a/docs/app/docs/components/avatar/docs/codeUsage.js
+++ b/docs/app/docs/components/avatar/docs/codeUsage.js
@@ -6,7 +6,7 @@ const AvatarExample = () => (
     <div style={{ display: 'flex', gap: 20 }}>
         <Avatar src="https://i.pravatar.cc/1000" />
         <Avatar fallback="RU" />
-        <Avatar fallback="AA" />
+        <Avatar fallback="AA" color='pink'/>
     </div>
 )`
     },

--- a/docs/app/docs/components/avatar/page.js
+++ b/docs/app/docs/components/avatar/page.js
@@ -1,7 +1,5 @@
 const PAGE_NAME = 'AVATAR_DOCS'
 import Documentation from "@/components/layout/Documentation/Documentation"
-
-
 import Avatar from "@radui/ui/Avatar"
 import SEO from "../../docsIndex"
 export const metadata = SEO.getMetadata(PAGE_NAME)
@@ -20,6 +18,7 @@ const AvatarDocs = () => {
     const data = [
         {prop: 'src', type: 'string', default: 'null', description: 'URL of the image to be displayed as the avatar.', id: 'src'},
         {prop: 'fallback', type: 'string', default: 'null', description: 'Text initials or placeholder displayed when the image fails to load or if no src is provided.', id: 'fallback'},
+        {prop: 'color', type: 'string', default: 'null', description: 'Accent Color of the text initials or placeholder displayed when the image fails to load or if no src is provided.', id: 'color'},
     ];
 
 
@@ -29,7 +28,7 @@ const AvatarDocs = () => {
                 <div style={{display:"flex",gap:20}}>
                     <Avatar src="https://i.pravatar.cc/1000" fallback="GG" />
                     <Avatar fallback="RU" />
-                    <Avatar fallback="AA" />
+                    <Avatar fallback="AA" color='pink'/>
                 </div>
             </Documentation.ComponentHero>
             <Documentation.ComponentFeatures features={[

--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -11,10 +11,11 @@ export type AvatarProps = {
     className?: string,
     src?: string,
     alt?: string,
+    color?:string,
     props?: Record<string, any>[]
 }
 
-const Avatar = ({ customRootClass = '', fallback, className, src, alt, ...props }: AvatarProps) => {
+const Avatar = ({ customRootClass = '', fallback, className, src, alt, color, ...props }: AvatarProps) => {
     return (
         <AvatarPrimitive.Root src={src} customRootClass={customRootClass}>
             <AvatarPrimitive.Image
@@ -23,7 +24,7 @@ const Avatar = ({ customRootClass = '', fallback, className, src, alt, ...props 
                 className={clsx(className)}
                 {...props}
             />
-            <AvatarPrimitive.Fallback>
+            <AvatarPrimitive.Fallback color={color}>
                 {fallback}
             </AvatarPrimitive.Fallback>
         </AvatarPrimitive.Root>

--- a/src/components/ui/Avatar/stories/Avatar.stories.js
+++ b/src/components/ui/Avatar/stories/Avatar.stories.js
@@ -41,3 +41,10 @@ export const withAlt = {
         fallback: 'RU'
     }
 };
+
+export const withColor = {
+    args: {
+        fallback: 'RU',
+        color: 'blue'
+    }
+};

--- a/src/components/ui/Avatar/tests/Avatar.test.tsx
+++ b/src/components/ui/Avatar/tests/Avatar.test.tsx
@@ -20,4 +20,9 @@ describe('Avatar', () => {
         render(<Avatar fallback="RU" />);
         expect(screen.getByText('RU')).toBeInTheDocument();
     });
+
+    test('renders color for fallback when src is not provided', async() => {
+        render(<Avatar fallback="RU" color='blue'/>);
+        expect(screen.getByText('RU')).toHaveAttribute('data-accent-color', 'blue');
+    });
 });

--- a/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -14,15 +14,16 @@ type AvatarGroupProps = {
     size: 'sm' | 'md' | 'lg';
     customRootClass?: string;
     className?: string;
+    color?:string;
     props?: Record<string, any>;
 }
 
-const AvatarGroup = ({ avatars = [], size, customRootClass = '', className, ...props }: AvatarGroupProps) => {
+const AvatarGroup = ({ avatars = [], size, customRootClass = '', className, color, ...props }: AvatarGroupProps) => {
     return <AvatarGroupRoot customRootClass={customRootClass} className={clsx(className)} {...props} >
         {avatars.map((avatar, index) => (
             <AvatarPrimitiveRoot key={index} src={avatar.src}>
                 <AvatarPrimitiveImage src={avatar.src} alt={avatar.alt} />
-                <AvatarPrimitiveFallback>{avatar.fallback}</AvatarPrimitiveFallback>
+                <AvatarPrimitiveFallback color={color}>{avatar.fallback}</AvatarPrimitiveFallback>
             </AvatarPrimitiveRoot>
         ))}
     </AvatarGroupRoot>;

--- a/src/components/ui/AvatarGroup/stories/AvatarGroup.stories.js
+++ b/src/components/ui/AvatarGroup/stories/AvatarGroup.stories.js
@@ -23,3 +23,24 @@ export const Default = {
         ]
     }
 };
+
+export const withFallback = {
+    args: {
+        avatars: [
+            { src: '', fallback: 'RU'},
+            { src: '', fallback: 'PK'},
+            { src: '', fallback: 'RU' }
+        ]
+    }
+};
+
+export const withColor = {
+    args: {
+        avatars: [
+            { src: '', fallback: 'RU'},
+            { src: '', fallback: 'PK'},
+            { src: '', fallback: 'RU' }
+        ],
+        color: 'blue' 
+    }
+}

--- a/src/components/ui/AvatarGroup/tests/AvatarGroup.test.js
+++ b/src/components/ui/AvatarGroup/tests/AvatarGroup.test.js
@@ -68,4 +68,10 @@ describe('AvatarGroup', () => {
             expect(screen.getByText(avatar.fallback)).toBeInTheDocument();
         });
     });
+
+    test('renders color for fallback when src is not provided', async() => {
+        render(<AvatarGroup avatars={avatarsWithFallback} color='blue'/>);
+        expect(screen.getByText('A')).toHaveAttribute('data-accent-color', 'blue');
+        expect(screen.getByText('B')).toHaveAttribute('data-accent-color', 'blue');
+    });
 });

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveFallback.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveFallback.tsx
@@ -6,16 +6,17 @@ import { AvatarPrimitiveContext } from '../contexts/AvatarPrimitiveContext';
 export interface AvatarPrimitiveFallbackProps {
     children: React.ReactNode;
     className?: string | '';
+    color?: string;
 }
 
-const AvatarPrimitiveFallback = ({ children, className = '' }: AvatarPrimitiveFallbackProps) => {
+const AvatarPrimitiveFallback = ({ children, className = '' , color = ''}: AvatarPrimitiveFallbackProps) => {
     const { hasError, fallBackRootClass } = useContext(AvatarPrimitiveContext);
 
     if (!hasError) {
         return null;
     }
 
-    return <span className={clsx(fallBackRootClass, className)}>{children}</span>;
+    return <span className={clsx(fallBackRootClass, className)} data-accent-color={color} >{children}</span>;
 };
 
 export default AvatarPrimitiveFallback;


### PR DESCRIPTION
Added the color prop for fallback with tests and storybook example. Updated the docs too will work once we do a npm release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added optional `color` property to Avatar and AvatarGroup components.
  - Introduced color customization for avatar fallback states.

- **Improvements**
  - Enhanced avatar rendering flexibility with the new color attribute.
  - Updated documentation to reflect the new color property and its usage.

- **Testing**
  - Expanded test coverage for avatar color functionality.
  - Added new Storybook stories demonstrating color variations for both Avatar and AvatarGroup components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->