### PR TITLE
Feat: Make use of the newly refactored popper component to make the tooltip. Also, add new story.

### DIFF
--- a/src/components/tools/Popper/Popper.tsx
+++ b/src/components/tools/Popper/Popper.tsx
@@ -35,9 +35,9 @@ const Popper = ({
     ...props
 }: PopperProps) => {
     return (
-        <PopperRoot customRootClass={customRootClass} popperName={popperName} placement={placement} open={open}>
+        <PopperRoot showArrow={showArrow} customRootClass={customRootClass} popperName={popperName} placement={placement} open={open}>
             <PopperTrigger className={className}>{children}</PopperTrigger>
-            <PopperContent showArrow={showArrow}>{pop}</PopperContent>
+            <PopperContent>{pop}</PopperContent>
         </PopperRoot>
     );
 };

--- a/src/components/tools/Popper/Popper.tsx
+++ b/src/components/tools/Popper/Popper.tsx
@@ -32,11 +32,12 @@ const Popper = ({
     open = false,
     showArrow = true,
     pop = <></>,
+    asChild,
     ...props
 }: PopperProps) => {
     return (
         <PopperRoot showArrow={showArrow} customRootClass={customRootClass} popperName={popperName} placement={placement} open={open}>
-            <PopperTrigger className={className}>{children}</PopperTrigger>
+            <PopperTrigger asChild={asChild} className={className}>{children}</PopperTrigger>
             <PopperContent>{pop}</PopperContent>
         </PopperRoot>
     );

--- a/src/components/tools/Popper/context/PopperContext.tsx
+++ b/src/components/tools/Popper/context/PopperContext.tsx
@@ -8,6 +8,7 @@ export type TPopperContext = {
   setIsOpen: (open: boolean) => void;
 
   rootClass: string;
+  showArrow: boolean;
 
   floating: UseFloatingReturn;
   interactions: UseInteractionsReturn;

--- a/src/components/tools/Popper/fragments/PopperContent.tsx
+++ b/src/components/tools/Popper/fragments/PopperContent.tsx
@@ -5,12 +5,11 @@ import { FloatingPortal, FloatingArrow } from '@floating-ui/react';
 import Primitive from '~/core/primitives/Primitive';
 
 export type PopperContentProps = PropsWithChildren<{
-    showArrow?: boolean;
     className?: string;
 }>;
 
-export default function PopperContent({ showArrow = true, className = '', children }: PopperContentProps) {
-    const { isOpen, rootClass, floatingArrowRef: arrowRef, floating, interactions: { getFloatingProps } } = usePopper();
+export default function PopperContent({ className = '', children }: PopperContentProps) {
+    const { isOpen, rootClass, floatingArrowRef: arrowRef, floating, interactions: { getFloatingProps }, showArrow } = usePopper();
 
     const { refs: { setFloating }, floatingStyles, context } = floating;
 

--- a/src/components/tools/Popper/fragments/PopperContent.tsx
+++ b/src/components/tools/Popper/fragments/PopperContent.tsx
@@ -6,9 +6,10 @@ import Primitive from '~/core/primitives/Primitive';
 
 export type PopperContentProps = PropsWithChildren<{
     className?: string;
+    asChild?: boolean;
 }>;
 
-export default function PopperContent({ className = '', children }: PopperContentProps) {
+export default function PopperContent({ asChild, className = '', children }: PopperContentProps) {
     const { isOpen, rootClass, floatingArrowRef: arrowRef, floating, interactions: { getFloatingProps }, showArrow } = usePopper();
 
     const { refs: { setFloating }, floatingStyles, context } = floating;
@@ -17,7 +18,7 @@ export default function PopperContent({ className = '', children }: PopperConten
 
     return (
         <FloatingPortal root={document.body}>
-            <Primitive.div asChild={isValidElement(children)} className={clsx(`${rootClass}-floating-element`, className)} ref={setFloating} style={floatingStyles} {...getFloatingProps()} >
+            <Primitive.div asChild={asChild} className={clsx(`${rootClass}-floating-element`, className)} ref={setFloating} style={floatingStyles} {...getFloatingProps()} >
                 {showArrow && <FloatingArrow className={clsx(`rad-ui-arrow ${rootClass}-arrow`)} ref={arrowRef} context={context} />}
                 {children}
             </Primitive.div>

--- a/src/components/tools/Popper/fragments/PopperRoot.tsx
+++ b/src/components/tools/Popper/fragments/PopperRoot.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef } from 'react';
 import PopperContext from '../context/PopperContext';
 import { customClassSwitcher } from '~/core';
 import { useFloating, useInteractions, useHover, FloatingArrow, arrow, offset, flip, hide, shift, autoUpdate, useRole, useDismiss, Placement } from '@floating-ui/react';
-import Primitive from '~/core/primitives/Primitive';
 
 export type PopperRootProps = {
   children: React.ReactNode;
@@ -11,8 +10,8 @@ export type PopperRootProps = {
   placement?: Placement;
   open?: boolean;
   showArrow?: boolean;
-  asChild?: boolean;
-} & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+};
+// & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
 const ARROW_HEIGHT = 7;
 const GAP = 2;
@@ -24,7 +23,6 @@ export default function PopperRoot({
     placement = 'top',
     open = false,
     showArrow = true,
-    asChild,
     ...props
 }: PopperRootProps) {
     const rootClass = customClassSwitcher(customRootClass, popperName);
@@ -72,9 +70,7 @@ export default function PopperRoot({
     ]);
     return (
         <PopperContext.Provider value={{ floatingArrowRef: arrowRef, dismiss, hover, role, interactions, floating, isOpen, setIsOpen, rootClass, showArrow }}>
-            <Primitive.div asChild={asChild} {...props}>
-                {children}
-            </Primitive.div>
+            {children}
         </PopperContext.Provider>
     );
 }

--- a/src/components/tools/Popper/fragments/PopperRoot.tsx
+++ b/src/components/tools/Popper/fragments/PopperRoot.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import PopperContext from '../context/PopperContext';
 import { customClassSwitcher } from '~/core';
 import { useFloating, useInteractions, useHover, FloatingArrow, arrow, offset, flip, hide, shift, autoUpdate, useRole, useDismiss, Placement } from '@floating-ui/react';
+import Primitive from '~/core/primitives/Primitive';
 
 export type PopperRootProps = {
   children: React.ReactNode;
@@ -10,7 +11,8 @@ export type PopperRootProps = {
   placement?: Placement;
   open?: boolean;
   showArrow?: boolean;
-};
+  asChild?: boolean;
+} & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
 const ARROW_HEIGHT = 7;
 const GAP = 2;
@@ -22,6 +24,7 @@ export default function PopperRoot({
     placement = 'top',
     open = false,
     showArrow = true,
+    asChild,
     ...props
 }: PopperRootProps) {
     const rootClass = customClassSwitcher(customRootClass, popperName);
@@ -69,7 +72,9 @@ export default function PopperRoot({
     ]);
     return (
         <PopperContext.Provider value={{ floatingArrowRef: arrowRef, dismiss, hover, role, interactions, floating, isOpen, setIsOpen, rootClass, showArrow }}>
-            {children}
+            <Primitive.div asChild={asChild} {...props}>
+                {children}
+            </Primitive.div>
         </PopperContext.Provider>
     );
 }

--- a/src/components/tools/Popper/fragments/PopperRoot.tsx
+++ b/src/components/tools/Popper/fragments/PopperRoot.tsx
@@ -9,6 +9,7 @@ export type PopperRootProps = {
   customRootClass?: string;
   placement?: Placement;
   open?: boolean;
+  showArrow?: boolean;
 };
 
 const ARROW_HEIGHT = 7;
@@ -20,6 +21,7 @@ export default function PopperRoot({
     customRootClass = '',
     placement = 'top',
     open = false,
+    showArrow = true,
     ...props
 }: PopperRootProps) {
     const rootClass = customClassSwitcher(customRootClass, popperName);
@@ -66,7 +68,7 @@ export default function PopperRoot({
         dismiss
     ]);
     return (
-        <PopperContext.Provider value={{ floatingArrowRef: arrowRef, dismiss, hover, role, interactions, floating, isOpen, setIsOpen, rootClass }}>
+        <PopperContext.Provider value={{ floatingArrowRef: arrowRef, dismiss, hover, role, interactions, floating, isOpen, setIsOpen, rootClass, showArrow }}>
             {children}
         </PopperContext.Provider>
     );

--- a/src/components/tools/Popper/fragments/PopperTrigger.tsx
+++ b/src/components/tools/Popper/fragments/PopperTrigger.tsx
@@ -5,15 +5,16 @@ import Primitive from '~/core/primitives/Primitive';
 
 export type PopperTriggerProps = PropsWithChildren<{
   className?: string;
+  asChild?: boolean
 }>;
 
-export default function PopperTrigger({ children, className = '', ...props }: PopperTriggerProps) {
+export default function PopperTrigger({ asChild, children, className = '', ...props }: PopperTriggerProps) {
     const { rootClass, floating, interactions } = usePopper();
     const { refs: { setReference } } = floating;
     const { getReferenceProps } = interactions;
 
     return (
-        <Primitive.span asChild={isValidElement(children)} className={clsx('rad-ui-popper', `${rootClass}-reference-element`, className)} ref={setReference} {...getReferenceProps()}>
+        <Primitive.span asChild={asChild} className={clsx('rad-ui-popper', `${rootClass}-reference-element`, className)} ref={setReference} {...getReferenceProps()}>
             {children}
         </Primitive.span>)
     ;

--- a/src/components/tools/Popper/stories/Popper.stories.tsx
+++ b/src/components/tools/Popper/stories/Popper.stories.tsx
@@ -20,12 +20,13 @@ export const Default: Story = {
             <SandboxEditor>
                 <Popper.Root
                     placement={'right'}
+                    showArrow={true}
                 >
                     <Popper.Trigger
                         className="inline-block rounded bg-indigo-600 px-8 py-3 text-sm font-medium text-white transition hover:scale-110 hover:shadow-xl"
                     > See Quote </Popper.Trigger>
 
-                    <Popper.Content showArrow={true} className='bg-indigo-600 rounded max-w-[30ch] p-4'>
+                    <Popper.Content className='bg-indigo-600 rounded max-w-[30ch] p-4'>
                         <blockquote cite="https://www.imdb.com/title/tt0373732/characters/nm0936762/">
                             <p> You can’t change the world, but you gotta at least try to change your part in it. - Robert Freeman, Boondocks </p>
                         </blockquote>

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -7,19 +7,27 @@ type TooltipProps = {
   children: React.ReactNode;
   label?: string;
   placement?: PopperProps['placement'];
-} & JSX.IntrinsicElements['span'];
+  showArrow?: boolean;
+  className?: string;
+}
 
-const Tooltip = ({ children, label = '', placement = 'top', ...props }: TooltipProps) => {
+const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className, ...props }: TooltipProps) => {
     return (
-        <Popper
+        <Popper.Root
             popperName={COMPONENT_NAME}
-            pop={label}
             placement={placement}
             {...props}
         >
-            {children}
-        </Popper>
+            <Popper.Trigger className={className}>
+                {children}
+            </Popper.Trigger>
+            <Popper.Content showArrow={showArrow}>
+                {label}
+            </Popper.Content>
+        </Popper.Root>
     );
 };
 
 export default Tooltip;
+
+export type { TooltipProps };

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -18,15 +18,14 @@ const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', cl
             popperName={COMPONENT_NAME}
             placement={placement}
             showArrow={showArrow}
-            asChild={asChild}
             {...props}
         >
-            <Popper.Trigger asChild={true} className={className}>
+            <Popper.Trigger asChild={asChild} className={className}>
                 {children}
-                <Popper.Content >
-                    {label}
-                </Popper.Content>
             </Popper.Trigger>
+            <Popper.Content >
+                {label}
+            </Popper.Content>
         </Popper.Root>
     );
 };

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ type TooltipProps = {
   className?: string;
 }
 
-const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className, ...props }: TooltipProps) => {
+const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className = '', ...props }: TooltipProps) => {
     return (
         <Popper.Root
             popperName={COMPONENT_NAME}

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -9,9 +9,10 @@ type TooltipProps = {
   placement?: PopperProps['placement'];
   showArrow?: boolean;
   className?: string;
+  asChild?: boolean;
 };
 
-const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className = '', ...props }: TooltipProps) => {
+const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className = '', asChild, ...props }: TooltipProps) => {
     return (
         <Popper.Root
             popperName={COMPONENT_NAME}
@@ -19,7 +20,7 @@ const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', cl
             showArrow={showArrow}
             {...props}
         >
-            <Popper.Trigger className={className}>
+            <Popper.Trigger asChild={asChild} className={className}>
                 {children}
             </Popper.Trigger>
             <Popper.Content >

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -9,19 +9,20 @@ type TooltipProps = {
   placement?: PopperProps['placement'];
   showArrow?: boolean;
   className?: string;
-}
+};
 
 const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', className = '', ...props }: TooltipProps) => {
     return (
         <Popper.Root
             popperName={COMPONENT_NAME}
             placement={placement}
+            showArrow={showArrow}
             {...props}
         >
             <Popper.Trigger className={className}>
                 {children}
             </Popper.Trigger>
-            <Popper.Content showArrow={showArrow}>
+            <Popper.Content >
                 {label}
             </Popper.Content>
         </Popper.Root>

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -18,9 +18,10 @@ const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', cl
             popperName={COMPONENT_NAME}
             placement={placement}
             showArrow={showArrow}
+            asChild={asChild}
             {...props}
         >
-            <Popper.Trigger asChild={asChild} className={className}>
+            <Popper.Trigger asChild={true} className={className}>
                 {children}
             </Popper.Trigger>
             <Popper.Content >

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -23,10 +23,10 @@ const Tooltip = ({ children, label = '', showArrow = true, placement = 'top', cl
         >
             <Popper.Trigger asChild={true} className={className}>
                 {children}
+                <Popper.Content >
+                    {label}
+                </Popper.Content>
             </Popper.Trigger>
-            <Popper.Content >
-                {label}
-            </Popper.Content>
         </Popper.Root>
     );
 };

--- a/src/components/ui/Tooltip/stories/Tooltip.stories.tsx
+++ b/src/components/ui/Tooltip/stories/Tooltip.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Tooltip from '../Tooltip';
 import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
 import { Placement } from '@floating-ui/react';
+import Primitive from '~/core/primitives/Primitive';
 
 const placement = ['top', 'right', 'bottom', 'left', 'top-start', 'top-end', 'right-start', 'right-end', 'bottom-start', 'bottom-end', 'left-start', 'left-end'] satisfies Placement[];
 
@@ -16,13 +17,27 @@ export default meta;
 
 type Story = StoryObj<typeof Tooltip>;
 
-export const Basic: Story = {
+export const WithArrow: Story = {
     render: () => (
         <SandboxEditor>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-3">
                 {placement.map((p) => (
-                    <Tooltip label={p} placement={p} key={p} className='capitalize border border-neutral-600 p-4 rounded-md'>
-                        <span>{p}</span>
+                    <Tooltip label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p}>
+                        <Primitive.button >{p}</Primitive.button>
+                    </Tooltip>
+                ))}
+            </div>
+        </SandboxEditor>
+    )
+};
+
+export const WithoutArrow: Story = {
+    render: () => (
+        <SandboxEditor>
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-3">
+                {placement.map((p) => (
+                    <Tooltip label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p} showArrow={false}>
+                        <Primitive.button>{p}</Primitive.button>
                     </Tooltip>
                 ))}
             </div>

--- a/src/components/ui/Tooltip/stories/Tooltip.stories.tsx
+++ b/src/components/ui/Tooltip/stories/Tooltip.stories.tsx
@@ -22,8 +22,8 @@ export const WithArrow: Story = {
         <SandboxEditor>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-3">
                 {placement.map((p) => (
-                    <Tooltip label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p}>
-                        <Primitive.button >{p}</Primitive.button>
+                    <Tooltip asChild label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p}>
+                        <Primitive.button>{p}</Primitive.button>
                     </Tooltip>
                 ))}
             </div>
@@ -36,7 +36,7 @@ export const WithoutArrow: Story = {
         <SandboxEditor>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-3">
                 {placement.map((p) => (
-                    <Tooltip label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p} showArrow={false}>
+                    <Tooltip asChild label={p} className="rounded border border-neutral-400 capitalize p-2" placement={p} key={p} showArrow={false}>
                         <Primitive.button>{p}</Primitive.button>
                     </Tooltip>
                 ))}


### PR DESCRIPTION
Popper was refactored to be more composable. See https://github.com/rad-ui/ui/pull/800. Tooltip was just wrapping around the popper component before but now it will use popper sub-components like `Popper.Trigger` and `Popper.Content`. 

A new story was also added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Tooltip component with new configuration options, including the ability to show/hide the tooltip arrow and apply custom styles through an optional className.
	- Introduced new variations in Storybook for the Tooltip component, showcasing tooltips with and without arrows.
	- Added new properties to the Popper components for improved arrow visibility control and child rendering behavior.

- **Documentation**
	- Updated Storybook stories to demonstrate new Tooltip variations using button elements for interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->