### PR TITLE
Update layout height for improved responsiveness

### DIFF
--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -8,7 +8,7 @@ const InfoIcon = () => {
 
 const Layout = ({ children }: any) => {
     return (
-        <div data-accent-color="blue" className="flex space-x-2 w-full h-[90vh] overflow-hidden">
+        <div data-accent-color="blue" className="flex space-x-2 w-full h-[94vh] overflow-hidden">
             <div className='flex-none h-full flex flex-col'>
                 <Navigation />
             </div>

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -19,7 +19,7 @@ import TrafficAnalyticsDemo from './landingComponents/TrafficAnalyticsDemo'
 
 export default function Home() {
   return (
-    <div className='h-screen '>
+    <div className='min-h-screen '>
       <LandingBgPattern />
       <div className='lg:p-10 flex flex-col'>
         <HeroSection />


### PR DESCRIPTION
Changed the docs layout height to 94vh back from 90vh to fix the bottom white space issue.

![image](https://github.com/user-attachments/assets/9513c846-4037-4ac5-afe5-3d7bb26a0bb6)

The landing dark mode works well. 

![image](https://github.com/user-attachments/assets/763251ef-fe7b-4270-a5aa-31ed7f11bf7b)

Merging of this PR closes #783 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated layout height in documentation page to improve visual presentation
	- Modified home page component to use minimum screen height for more flexible content rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->