### PR TITLE
Fix #900:Inseterted the API documentation section on Tooltip page

### DIFF
--- a/docs/app/docs/components/tooltip/docs/codeUsage.js
+++ b/docs/app/docs/components/tooltip/docs/codeUsage.js
@@ -13,4 +13,15 @@ const ToolTipExample = () => (
     },
 }
 
+export const TooltipTable = {
+    columns: [
+     {name: 'Prop', id: 'prop'},
+     {name: 'Type', id: 'type'},
+     {name: 'Default', id: 'default'},
+     {name: 'Description', id: 'description'},
+    ],
+    data: [
+     {prop: 'content', type: 'string', default: 'Tooltip content', description: 'content/text on hover', id: 'src'},
+    ]
+ }
 export default code;

--- a/docs/app/docs/components/tooltip/docs/codeUsage.js
+++ b/docs/app/docs/components/tooltip/docs/codeUsage.js
@@ -21,7 +21,7 @@ export const TooltipTable = {
      {name: 'Description', id: 'description'},
     ],
     data: [
-     {prop: 'content', type: 'string', default: 'Tooltip content', description: 'content/text on hover', id: 'src'},
+     {prop: 'content', type: 'string', default: 'null', description: 'content/text on hover', id: 'src'},
     ]
  }
 export default code;

--- a/docs/app/docs/components/tooltip/page.mdx
+++ b/docs/app/docs/components/tooltip/page.mdx
@@ -19,6 +19,6 @@ import codeUsage, { TooltipTable } from "./docs/codeUsage"
     </Documentation.ComponentHero>
 
     <div className="max-w-screen-md">
-                <Documentation.Table columns={TooltipTable.columns} data={TooltipTable.data} />
-            </div>
+            <Documentation.Table columns={TooltipTable.columns} data={TooltipTable.data} />
+    </div>
 </Documentation>

--- a/docs/app/docs/components/tooltip/page.mdx
+++ b/docs/app/docs/components/tooltip/page.mdx
@@ -18,5 +18,7 @@ import codeUsage, { TooltipTable } from "./docs/codeUsage"
                     </Card>
     </Documentation.ComponentHero>
 
-   
+    <div className="max-w-screen-md">
+                <Documentation.Table columns={TooltipTable.columns} data={TooltipTable.data} />
+            </div>
 </Documentation>


### PR DESCRIPTION
### Added API documentation section on Tooltip page 

![Screenshot_2025-02-28_00-18-43](https://github.com/user-attachments/assets/19fd0535-16db-4ca5-b2f5-33583efefa68)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a structured table export to present tooltip property details.

- **Documentation**
	- Enhanced the tooltip documentation by integrating a responsive table layout for a clearer presentation of component information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->