### PR TITLE
Primitive space bug fix

### DIFF
--- a/src/core/primitives/Primitive/index.tsx
+++ b/src/core/primitives/Primitive/index.tsx
@@ -14,6 +14,8 @@ interface PrimitiveProps extends React.HTMLAttributes<HTMLElement> {
 const createPrimitiveComponent = (elementType: SupportedElement) => {
     const PrimitiveComponent = React.forwardRef<HTMLElement, PrimitiveProps>((props, ref) => {
         const { asChild = false, children, ...elementProps } = props;
+        
+        if (children?.length) throw new Error("children is only expected to receive a single React element child. Try trimming spaces.")
 
         if (asChild && React.isValidElement(children)) {
             return React.cloneElement(children, {


### PR DESCRIPTION
fixes #667 by throwing error when multiple elements in children