### PR TITLE
add variant and size for callout

### DIFF
--- a/docs/app/docs/components/callout/docs/colorCodeUsage.js
+++ b/docs/app/docs/components/callout/docs/colorCodeUsage.js
@@ -1,0 +1,9 @@
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+
+const calloutColorSourceCode = await getSourceCodeFromPath('docs/app/docs/components/callout/examples/CalloutColor.tsx');
+
+export const code = {
+    javascript: {
+        code: calloutColorSourceCode
+    }
+};

--- a/docs/app/docs/components/callout/docs/sizeCodeUsage.js
+++ b/docs/app/docs/components/callout/docs/sizeCodeUsage.js
@@ -1,0 +1,9 @@
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+
+const calloutSizesSourceCode = await getSourceCodeFromPath('docs/app/docs/components/callout/examples/CalloutSizes.tsx');
+
+export const code = {
+    javascript: {
+        code: calloutSizesSourceCode
+    }
+};

--- a/docs/app/docs/components/callout/docs/variantCodeUsage.js
+++ b/docs/app/docs/components/callout/docs/variantCodeUsage.js
@@ -1,0 +1,9 @@
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+
+const calloutVariantsSourceCode = await getSourceCodeFromPath('docs/app/docs/components/callout/examples/CalloutVariants.tsx');
+
+export const code = {
+    javascript: {
+        code: calloutVariantsSourceCode
+    }
+};

--- a/docs/app/docs/components/callout/examples/CalloutColor.tsx
+++ b/docs/app/docs/components/callout/examples/CalloutColor.tsx
@@ -1,0 +1,24 @@
+import Callout from '@radui/ui/Callout';
+import Text from "@radui/ui/Text";
+import { BookmarkIcon } from '../docs/codeUsage';
+
+const CalloutColor = () => {
+    const sizes = ['small', 'medium', 'large', 'x-large'];
+    const variants = ['soft', 'outline'];
+    return <div className='flex flex-col gap-4'>
+        {variants.map((variant, index) => {
+            return <div key={index} className='flex justify-center flex-wrap gap-4'>
+                {sizes.map((size, index) => {
+                    return (
+                     <Callout key={index} size={size} variant={variant} color='pink'>
+                        <BookmarkIcon />
+                        <Text className="font-bold">Error</Text>
+                        <Text>Something went wrong. Please try again later.</Text>
+                     </Callout>)
+                })}
+            </div>
+        })}
+    </div>
+}
+
+export default CalloutColor;

--- a/docs/app/docs/components/callout/examples/CalloutSizes.tsx
+++ b/docs/app/docs/components/callout/examples/CalloutSizes.tsx
@@ -1,0 +1,24 @@
+import Callout from '@radui/ui/Callout';
+import Text from "@radui/ui/Text";
+import { BookmarkIcon } from '../docs/codeUsage';
+
+const CalloutSizes = () => {
+    const sizes = ['small', 'medium', 'large', 'x-large'];
+    const variants = ['soft', 'outline'];
+    return <div className='flex flex-col gap-4'>
+        {variants.map((variant, index) => {
+            return <div key={index} className='flex justify-center flex-wrap gap-4'>
+                {sizes.map((size, index) => {
+                    return (
+                       <Callout key={index} size={size} variant={variant}>
+                         <BookmarkIcon />
+                         <Text className="font-bold">Error</Text>
+                         <Text>Something went wrong. Please try again later.</Text>
+                       </Callout>)
+                })}
+            </div>
+        })}
+    </div>
+}
+
+export default CalloutSizes;

--- a/docs/app/docs/components/callout/examples/CalloutVariants.tsx
+++ b/docs/app/docs/components/callout/examples/CalloutVariants.tsx
@@ -1,0 +1,37 @@
+import Callout from '@radui/ui/Callout';
+import Text from "@radui/ui/Text";
+import Separator from '@radui/ui/Separator';
+import Tooltip from '@radui/ui/Tooltip';
+import { BookmarkIcon } from '../docs/codeUsage';
+
+const CalloutVariants = () => {
+  const calloutVariants = ['soft', 'outline'];
+  const calloutStyleDescription = {
+    soft: 'Soft callout have a soft background color and a border.',
+    outline: 'Outline callout have a border and a background color.',
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-4">
+        {calloutVariants.map((variant) => (
+          <span key={variant}>
+            <Callout variant={variant} className="space-x-2">
+                <BookmarkIcon />
+                <Text className="font-bold">Error</Text>
+                <Text>Something went wrong. Please try again later.</Text>
+            </Callout>
+            <Separator orientation="horizontal" style={{ marginTop: 20 }} />
+            <Tooltip label={calloutStyleDescription[variant]} placement="bottom">
+              <Text className="text-gray-800 font-light inline-block cursor-help">
+                {variant}
+              </Text>
+            </Tooltip>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CalloutVariants;

--- a/docs/app/docs/components/callout/page.mdx
+++ b/docs/app/docs/components/callout/page.mdx
@@ -2,6 +2,12 @@ import Documentation from '@/components/layout/Documentation/Documentation';
 import Callout from '@radui/ui/Callout';
 import Text from '@radui/ui/Text';
 import codeUsage, { BookmarkIcon,calloutTable } from './docs/codeUsage';
+import { code as variantCodeUsage } from './docs/variantCodeUsage';
+import { code as sizeCodeUsage } from './docs/sizeCodeUsage';
+import { code as colorCodeUsage } from './docs/colorCodeUsage';
+import CalloutVariants from './examples/CalloutVariants';
+import CalloutSizes from './examples/CalloutSizes';
+import CalloutColor from './examples/CalloutColor';
 
 <Documentation title={`Callout`} description={`
             Callout is a component that can be used to display a message or a notification to the user.
@@ -19,6 +25,19 @@ import codeUsage, { BookmarkIcon,calloutTable } from './docs/codeUsage';
                 </Callout>
             </Documentation.ComponentHero>
 
+               <Documentation.ComponentHero title='Variants' codeUsage={variantCodeUsage}>
+                <CalloutVariants />
+            </Documentation.ComponentHero>
+  
+
+            <Documentation.ComponentHero title='Sizes' codeUsage={sizeCodeUsage}>
+                <CalloutSizes />
+            </Documentation.ComponentHero>
+
+            <Documentation.ComponentHero title='Color' codeUsage={colorCodeUsage}>
+                <CalloutColor />
+            </Documentation.ComponentHero>
+            
             <div className="max-w-screen-md">
                 <Documentation.Table columns={calloutTable.columns} data={calloutTable.data} />
             </div>

--- a/src/components/ui/Callout/Callout.tsx
+++ b/src/components/ui/Callout/Callout.tsx
@@ -9,13 +9,16 @@ export type CalloutProps = {
     children?: React.ReactNode;
     className?: string ;
     color?: string;
+    variant?: string;
+    size?: string;
     customRootClass?: string;
     props?: object[]
 }
 
 const COMPONENT_NAME = 'Callout';
-const Callout = ({ children, className = '', color, customRootClass, ...props }: CalloutProps) => {
-    return (<CalloutRoot customRootClass={customRootClass} className={clsx(className)} color={color ?? undefined} {...props}>
+const Callout = ({ children, className = '', color, variant='', size='', customRootClass, ...props }: CalloutProps) => {
+    return (
+    <CalloutRoot customRootClass={customRootClass} className={clsx(className)} color={color ?? undefined} variant={variant} size={size} {...props}>
         {children}
     </CalloutRoot>);
 };

--- a/src/components/ui/Callout/fragments/CalloutRoot.tsx
+++ b/src/components/ui/Callout/fragments/CalloutRoot.tsx
@@ -7,13 +7,29 @@ type CalloutRootProps = {
     children?: React.ReactNode;
     className?: string | '' ;
     color?: string;
+    variant?: string;
+    size?: string;
     customRootClass?: string;
     props?: Record<any, any>[]
 }
 
-const CalloutRoot = ({ children, className, color, customRootClass, ...props }: CalloutRootProps) => {
+const CalloutRoot = ({ children, className, color, variant='', size='', customRootClass, ...props }: CalloutRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <div className={clsx(rootClass, className)} data-accent-color={color ?? undefined} {...props}>
+    const data_attributes: Record<string, string> = {};
+
+    if (variant) {
+        data_attributes['data-callout-variant'] = variant;
+    }
+
+    if (size) {
+        data_attributes['data-callout-size'] = size;
+    }
+
+    if (color) {
+        data_attributes['data-accent-color'] = color;
+    }
+
+    return <div className={clsx(rootClass, className)} data-accent-color={color ?? undefined} {...data_attributes} {...props}>
         {children}
     </div>;
 };

--- a/src/components/ui/Callout/stories/Callout.stories.tsx
+++ b/src/components/ui/Callout/stories/Callout.stories.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 const InfoIcon = () => {
     return (<svg width="18" height="18" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.49991 0.876892C3.84222 0.876892 0.877075 3.84204 0.877075 7.49972C0.877075 11.1574 3.84222 14.1226 7.49991 14.1226C11.1576 14.1226 14.1227 11.1574 14.1227 7.49972C14.1227 3.84204 11.1576 0.876892 7.49991 0.876892ZM1.82707 7.49972C1.82707 4.36671 4.36689 1.82689 7.49991 1.82689C10.6329 1.82689 13.1727 4.36671 13.1727 7.49972C13.1727 10.6327 10.6329 13.1726 7.49991 13.1726C4.36689 13.1726 1.82707 10.6327 1.82707 7.49972ZM8.24992 4.49999C8.24992 4.9142 7.91413 5.24999 7.49992 5.24999C7.08571 5.24999 6.74992 4.9142 6.74992 4.49999C6.74992 4.08577 7.08571 3.74999 7.49992 3.74999C7.91413 3.74999 8.24992 4.08577 8.24992 4.49999ZM6.00003 5.99999H6.50003H7.50003C7.77618 5.99999 8.00003 6.22384 8.00003 6.49999V9.99999H8.50003H9.00003V11H8.50003H7.50003H6.50003H6.00003V9.99999H6.50003H7.00003V6.99999H6.50003H6.00003V5.99999Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>);
 };
+const Variants = ['soft', 'outline'];
+const Sizes = ['small', 'medium', 'large', 'x-large'];
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -53,3 +55,43 @@ const RedTextTemplate = (args: any) => {
     </SandboxEditor>;
 };
 export const RedText = RedTextTemplate.bind();
+
+export const Size = () => {
+    return <SandboxEditor>
+        <div className='mt-4 mb-2'>
+            <p className='text-gray-950'>Callout Size</p>
+        </div>
+        <div>
+
+            {Variants.map((variant, index) => (
+                <div key={index} className='mb-10'>
+                    <span key={index} className="inline-flex items-start space-x-2">
+                        {Sizes.map((size, index) => {
+                            return <Callout key={index} size={size} variant={variant} >
+                                 <InfoIcon/> <span>This is a Callout</span>
+                            </Callout>;
+                        })}
+                    </span>
+                </div>
+            ))}
+
+        </div>
+    </SandboxEditor>;
+};
+
+export const Variant = () => {
+    return <SandboxEditor>
+        <div className='mt-4 mb-2'>
+            <p className='text-gray-950'>Callout Variant</p>
+        </div>
+        <div className='flex space-x-2'>
+
+                        {Variants.map((variant, index) => {
+                            return <Callout key={index}  variant={variant} >
+                                 <InfoIcon/> <span>This is a Callout</span>
+                            </Callout>;
+                        })}
+
+        </div>
+    </SandboxEditor>;
+};

--- a/styles/themes/components/callout.scss
+++ b/styles/themes/components/callout.scss
@@ -8,4 +8,51 @@
      font-weight: 300;
      font-size: 14px;
      gap:8px;
- }
+
+     &[data-callout-variant="outline"]{
+        background-color: transparent;
+        color: var(--rad-ui-color-accent-900);
+        border: 1px solid var(--rad-ui-color-accent-900);
+
+       
+    }
+
+    &[data-callout-variant="soft"]{
+        border-top: 1px solid var(--rad-ui-color-accent-600);
+        border-left: 1px solid var(--rad-ui-color-accent-600);
+        border-right: 1px solid var(--rad-ui-color-accent-600);
+        border-bottom: 1px solid var(--rad-ui-color-accent-600);
+        color: var(--rad-ui-color-accent-950);
+        background-color:  var(--rad-ui-color-accent-400);
+
+      
+    }
+
+
+    /** Callout Sizes */
+    &[data-callout-size="small"]{
+        font-size: small;
+        padding: 4px 8px;
+        height: 24px;
+    }
+
+    &[data-callout-size="medium"]{
+        font-size: medium;
+        padding: 4px 12px;
+        height: 32px;
+    }
+
+    &[data-callout-size="large"]{
+        font-size: large;
+        padding: 4px 16px;
+        height: 40px;
+    }
+
+    &[data-callout-size="x-large"]{
+        font-size: x-large;
+        padding: 4px 24px;
+        height: 48px;
+    }
+}
+
+ 


### PR DESCRIPTION
Callout component
![image](https://github.com/user-attachments/assets/2bb23fa7-a4c3-4fb6-8444-95558a7d2e1b)

![image](https://github.com/user-attachments/assets/5369db14-01a1-478d-8b7a-ade090e01083)

Docs Page
![image](https://github.com/user-attachments/assets/e8498998-82bf-442d-b3d6-079264a26e93)

![image](https://github.com/user-attachments/assets/11632062-b448-488a-9b31-b76deee28e25)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced new components for showcasing Callout variations, sizes, and colors.
  - Added optional properties for variant and size to the Callout component, enhancing its flexibility.
  
- **Documentation**
  - Enhanced the documentation with additional sections and code usage examples for the Callout component, including variants, sizes, and color options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->