### PR TITLE
Add 'use client' import statements for Table and Accordion

### DIFF
--- a/src/components/ui/Accordion/Accordion.tsx
+++ b/src/components/ui/Accordion/Accordion.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import AccordionRoot from './fragments/AccordionRoot';
 import AccordionItem from './fragments/AccordionItem';

--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { clsx } from 'clsx';
 import React, { useContext } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';

--- a/src/components/ui/Accordion/fragments/AccordionHeader.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionHeader.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useContext } from 'react';
 import { clsx } from 'clsx';
 import { AccordionContext } from '../contexts/AccordionContext';

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState, useContext, useId, useEffect, useRef } from 'react';
 import { clsx } from 'clsx';
 import { AccordionContext } from '../contexts/AccordionContext';

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState, useRef } from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';

--- a/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { clsx } from 'clsx';
 import React, { useContext, useRef } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import TableRoot from './fragments/TableRoot';

--- a/src/components/ui/Table/fragments/TableBody.tsx
+++ b/src/components/ui/Table/fragments/TableBody.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 

--- a/src/components/ui/Table/fragments/TableCell.tsx
+++ b/src/components/ui/Table/fragments/TableCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 

--- a/src/components/ui/Table/fragments/TableColumnCellHeader.tsx
+++ b/src/components/ui/Table/fragments/TableColumnCellHeader.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 

--- a/src/components/ui/Table/fragments/TableHead.tsx
+++ b/src/components/ui/Table/fragments/TableHead.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 

--- a/src/components/ui/Table/fragments/TableRoot.tsx
+++ b/src/components/ui/Table/fragments/TableRoot.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';

--- a/src/components/ui/Table/fragments/TableRow.tsx
+++ b/src/components/ui/Table/fragments/TableRow.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { clsx } from 'clsx';
 


### PR DESCRIPTION
Some issues with the way rollup is packing the components

```
console.log(Tabs.Root) // works
```

```
console.log(Table.Root) // doesn't work
console.log(Accordion.Root) // doesn't work
```


This PR is to rule out that this isn't a SSR related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated interactive accordion and table components to ensure they run optimally on the client side, enhancing rendering consistency and interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->