### PR TITLE
delete variants and fix dark mode

### DIFF
--- a/docs/app/docs/components/blockquote/docs/variantCodeUsage.js
+++ b/docs/app/docs/components/blockquote/docs/variantCodeUsage.js
@@ -1,9 +1,0 @@
-import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
-
-const blockQuoteVariantsSourceCode = await getSourceCodeFromPath('docs/app/docs/components/blockquote/examples/BlockQuoteVariants.tsx');
-
-export const code = {
-    javascript: {
-        code: blockQuoteVariantsSourceCode
-    }
-};

--- a/docs/app/docs/components/blockquote/examples/BlockQuoteColor.tsx
+++ b/docs/app/docs/components/blockquote/examples/BlockQuoteColor.tsx
@@ -6,7 +6,7 @@ const BlockQuoteColor = () => {
     return <div className='flex flex-col gap-4'>
                 {sizes.map((size, index) => {
                     return <BlockQuote key={index} size={size} color='pink'>
-                         "Behind every great man is a woman rolling her eyes." — Jim Carrey
+                        <span className='text-gray-950'>"Behind every great man is a woman rolling her eyes." — Jim Carrey</span> 
                     </BlockQuote>
                 })}
             </div>

--- a/docs/app/docs/components/blockquote/examples/BlockQuoteSizes.tsx
+++ b/docs/app/docs/components/blockquote/examples/BlockQuoteSizes.tsx
@@ -7,7 +7,7 @@ const BlockQuoteSizes = () => {
          
                 {sizes.map((size, index) => {
                     return <BlockQuote key={index} size={size} >
-                        <span>"Behind every great man is a woman rolling her eyes." — Jim Carrey</span>
+                        <span className='text-gray-950'>"Behind every great man is a woman rolling her eyes." — Jim Carrey</span>
                         </BlockQuote>
                 })}
             </div>

--- a/docs/app/docs/components/blockquote/examples/BlockQuoteVariants.tsx
+++ b/docs/app/docs/components/blockquote/examples/BlockQuoteVariants.tsx
@@ -1,9 +1,0 @@
-
-const BlockQuoteVariants = () => {
-     return <div>
-         
-     </div>
-    
-};
-
-export default BlockQuoteVariants;

--- a/docs/app/docs/components/blockquote/page.mdx
+++ b/docs/app/docs/components/blockquote/page.mdx
@@ -1,10 +1,8 @@
 import Documentation from "@/components/layout/Documentation/Documentation"
 import codeUsage, { BlockQuoteTable } from "./docs/codeUsage"
 import BlockQuote from "@radui/ui/BlockQuote"
-import { code as variantCodeUsage } from './docs/variantCodeUsage';
 import { code as sizeCodeUsage } from './docs/sizeCodeUsage';
 import { code as colorCodeUsage } from './docs/colorCodeUsage';
-import BlockQuoteVariants from './examples/BlockQuoteVariants';
 import BlockQuoteSizes from './examples/BlockQuoteSizes';
 import BlockQuoteColor from './examples/BlockQuoteColor';
 
@@ -19,12 +17,6 @@ import BlockQuoteColor from './examples/BlockQuoteColor';
                     
             </Documentation.ComponentHero>
             
-           
-
-            <Documentation.ComponentHero title='Variants' codeUsage={variantCodeUsage}>
-                <BlockQuoteVariants />
-            </Documentation.ComponentHero>
-  
 
             <Documentation.ComponentHero title='Sizes' codeUsage={sizeCodeUsage}>
                 <BlockQuoteSizes />


### PR DESCRIPTION
docs page light mode 
![image](https://github.com/user-attachments/assets/97f83d75-3d6a-45c7-8826-e9d8003546c3)

![image](https://github.com/user-attachments/assets/1f6c0afe-e649-4fc1-b818-53ee8fd48886)

dark mode 
![image](https://github.com/user-attachments/assets/07247027-6af2-4176-8b7c-6d93a897739c)

![image](https://github.com/user-attachments/assets/de311723-7b67-4ae5-81df-33a62c757a23)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed the variant examples section from the blockquote documentation to streamline the content.
- **Style**
	- Enhanced the presentation of blockquote examples by updating the text display for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->