### PR TITLE
Update Accordion's direction prop to orientation #1014

### DIFF
--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -13,10 +13,10 @@ export type AccordionRootProps = {
     customRootClass?: string;
     transitionDuration?: number;
     transitionTimingFunction?: string;
-    direction?: 'horizontal' | 'vertical';
+    orientation?: 'horizontal' | 'vertical';
 }
 
-const AccordionRoot = ({ children, direction = 'vertical', transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass }: AccordionRootProps) => {
+const AccordionRoot = ({ children, orientation = 'vertical', transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass }: AccordionRootProps) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
@@ -32,7 +32,7 @@ const AccordionRoot = ({ children, direction = 'vertical', transitionDuration = 
                 transitionDuration,
                 transitionTimingFunction
             }}>
-            <RovingFocusGroup.Root direction={direction}>
+            <RovingFocusGroup.Root direction={orientation}>
                 <RovingFocusGroup.Group className={clsx(`${rootClass}-root`)}>
                     <div ref={accordionRef}>
                         {children}


### PR DESCRIPTION
# PR: Rename "direction" to "orientation" in Accordion Component

## Description
This PR renames the `direction` prop to `orientation` in the `AccordionRoot` component. The term "orientation" is more intuitive for specifying layout (horizontal vs. vertical) and avoids confusion with text direction (LTR vs. RTL).

## Changes Made
- Updated `AccordionRootProps` to replace `direction` with `orientation`.
- Set default value for `orientation` to `vertical`.
- Passed the `orientation` value to the `RovingFocusGroup.Root` component.

## Why This Change?
- **Clarity:** "Orientation" clearly indicates layout direction.
- **Consistency:** Reduces confusion by using terminology that aligns with how layout direction is typically described.
- **Improved Developer Experience:** New consumers of the component will have a better understanding of what the prop controls.

## Testing
- Verified that the accordion functions correctly in both horizontal and vertical orientations.
- Ensured that no visual or functional regressions were introduced.

## Additional Notes
- The internal API for `RovingFocusGroup.Root` remains unchanged; we simply pass the value of our `orientation` prop to its `direction` prop.
