### PR TITLE
Omit src from avatar.root

### DIFF
--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -24,7 +24,7 @@ const Avatar = ({ customRootClass = '', fallback, className, src, alt, variant =
     const accentAttributes = useCreateDataAttribute('accent', { color });
     const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
     return (
-        <AvatarPrimitive.Root src={src} customRootClass={customRootClass} asChild={asChild} {...composedAttributes()}>
+        <AvatarPrimitive.Root customRootClass={customRootClass} asChild={asChild} {...composedAttributes()}>
             <AvatarPrimitive.Image
                 src={src}
                 alt={alt}

--- a/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -21,7 +21,7 @@ export type AvatarGroupProps = {
 const AvatarGroup = ({ avatars = [], size, customRootClass = '', className, color, ...props }: AvatarGroupProps) => {
     return <AvatarGroupRoot customRootClass={customRootClass} className={clsx(className)} {...props} >
         {avatars.map((avatar, index) => (
-            <AvatarPrimitiveRoot key={index} src={avatar.src}>
+            <AvatarPrimitiveRoot key={index}>
                 <AvatarPrimitiveImage src={avatar.src} alt={avatar.alt} />
                 <AvatarPrimitiveFallback color={color}>{avatar.fallback}</AvatarPrimitiveFallback>
             </AvatarPrimitiveRoot>

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
@@ -22,7 +22,11 @@ const AvatarPrimitiveImage = ({
     if (hasError) {
         return null;
     }
-    useEffect(()=>{if(!src) handleErrorImage()},[])
+    useEffect(() => {
+        if (!src && !hasError) {
+            handleErrorImage();
+        }
+    }, [src, handleErrorImage, hasError]);
 
     return (
         <img

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
@@ -20,6 +20,7 @@ const AvatarPrimitiveImage = ({
 
     // If there's no src or there's an error, render nothing
     if (!src || hasError) {
+        if(!src) handleErrorImage()
         return null;
     }
 

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveImage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { clsx } from 'clsx';
 
 import { AvatarPrimitiveContext } from '../contexts/AvatarPrimitiveContext';
@@ -19,10 +19,10 @@ const AvatarPrimitiveImage = ({
     const { handleErrorImage, handleLoadImage, hasError } = useContext(AvatarPrimitiveContext);
 
     // If there's no src or there's an error, render nothing
-    if (!src || hasError) {
-        if(!src) handleErrorImage()
+    if (hasError) {
         return null;
     }
+    useEffect(()=>{if(!src) handleErrorImage()},[])
 
     return (
         <img

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveRoot.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveRoot.tsx
@@ -17,7 +17,7 @@ const AvatarPrimitiveRoot = ({ children, className = '', customRootClass = '', a
     const rootClass = customClassSwitcher(customRootClass, 'Avatar');
     const fallBackRootClass = customClassSwitcher(customRootClass, 'Fallback');
     const [isImageLoaded, setIsImageLoaded] = useState(false);
-    const [hasError, setHasError] = useState(!src);
+    const [hasError, setHasError] = useState(false);
 
     const handleLoadImage = () => {
         setIsImageLoaded(true);

--- a/src/core/primitives/Avatar/fragments/AvatarPrimitiveRoot.tsx
+++ b/src/core/primitives/Avatar/fragments/AvatarPrimitiveRoot.tsx
@@ -8,12 +8,11 @@ import Primitive from '~/core/primitives/Primitive';
 export interface AvatarPrimitiveRootProps {
     customRootClass?: string | '';
     children: React.ReactNode;
-    src?: string;
     className?: string | '';
     asChild?: boolean;
 }
 
-const AvatarPrimitiveRoot = ({ children, className = '', customRootClass = '', asChild = false, src, ...props }: AvatarPrimitiveRootProps) => {
+const AvatarPrimitiveRoot = ({ children, className = '', customRootClass = '', asChild = false, ...props }: AvatarPrimitiveRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, 'Avatar');
     const fallBackRootClass = customClassSwitcher(customRootClass, 'Fallback');
     const [isImageLoaded, setIsImageLoaded] = useState(false);
@@ -37,7 +36,6 @@ const AvatarPrimitiveRoot = ({ children, className = '', customRootClass = '', a
         setHasError,
         handleLoadImage,
         handleErrorImage,
-        src
     };
 
     return <AvatarPrimitiveContext.Provider value={values} >

--- a/src/core/primitives/Avatar/stories/AvatarPrimitive.stories.tsx
+++ b/src/core/primitives/Avatar/stories/AvatarPrimitive.stories.tsx
@@ -25,7 +25,7 @@ export default {
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const WithSrc = {
     args: {
-        src: 'https://via.placeholder.com/150'
+        src: 'https://i.pravatar.cc/64'
     }
 };
 


### PR DESCRIPTION
Made src prop in Avatar.Root as it's not required - src should only be passed to Avatar.Image.
Also updated the placeholder image link in AvatarPrimitive.stories.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved avatar error handling so that missing images no longer trigger premature error states.
- **Refactor**
	- Adjusted the avatar component configuration by removing the `src` prop for better reliability in image rendering.
	- Updated the demo/default avatar image to a fresh new look.
	- Removed the `src` prop from the `AvatarGroup` component to streamline rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->