### PR TITLE
RovingFocus with prop support for disabling tab indexes

### DIFF
--- a/docs/app/docs/components/accordion/docs/api/root.tsx
+++ b/docs/app/docs/components/accordion/docs/api/root.tsx
@@ -59,7 +59,7 @@ const data = {
        },
        {
         prop: {
-            name : "rovingFocusDisabled",
+            name : "disableTabIndexing",
             info_tooltips: 'Disables the roving tabindex behavior for keyboard navigation.'
         },
         type: 'boolean',

--- a/docs/app/docs/components/accordion/docs/api/root.tsx
+++ b/docs/app/docs/components/accordion/docs/api/root.tsx
@@ -56,6 +56,14 @@ const data = {
         type: 'enum',
         enum_values : ['horizontal', 'vertical'],
         default: 'horizontal',
+       },
+       {
+        prop: {
+            name : "rovingFocusDisabled",
+            info_tooltips: 'Disables the roving tabindex behavior for keyboard navigation.'
+        },
+        type: 'boolean',
+        default: 'true',
        }
     ]
 }

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -17,10 +17,11 @@ export type AccordionRootProps = {
     orientation?: 'horizontal' | 'vertical';
     asChild?: boolean;
     loop?: boolean;
+    rovingFocusDisabled?: boolean;
     openMultiple?: boolean;
 }
 
-const AccordionRoot = ({ children, orientation = 'vertical', asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
+const AccordionRoot = ({ children, orientation = 'vertical', rovingFocusDisabled=true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
@@ -37,7 +38,7 @@ const AccordionRoot = ({ children, orientation = 'vertical', asChild, transition
                 transitionTimingFunction,
                 openMultiple
             }}>
-            <RovingFocusGroup.Root orientation={orientation} loop={loop}>
+            <RovingFocusGroup.Root orientation={orientation} loop={loop} rovingFocusDisabled={rovingFocusDisabled} >
                 <RovingFocusGroup.Group >
                     <Primitive.div className={clsx(`${rootClass}-root`)} ref={accordionRef} asChild={asChild}>
                         {children}

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -21,7 +21,7 @@ export type AccordionRootProps = {
     openMultiple?: boolean;
 }
 
-const AccordionRoot = ({ children, orientation = 'vertical', rovingFocusDisabled=true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
+const AccordionRoot = ({ children, orientation = 'vertical', rovingFocusDisabled= true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -17,11 +17,11 @@ export type AccordionRootProps = {
     orientation?: 'horizontal' | 'vertical';
     asChild?: boolean;
     loop?: boolean;
-    rovingFocusDisabled?: boolean;
+    disableTabIndexing?: boolean;
     openMultiple?: boolean;
 }
 
-const AccordionRoot = ({ children, orientation = 'vertical', rovingFocusDisabled= true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
+const AccordionRoot = ({ children, orientation = 'vertical', disableTabIndexing = true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false }: AccordionRootProps) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
@@ -38,7 +38,7 @@ const AccordionRoot = ({ children, orientation = 'vertical', rovingFocusDisabled
                 transitionTimingFunction,
                 openMultiple
             }}>
-            <RovingFocusGroup.Root orientation={orientation} loop={loop} rovingFocusDisabled={rovingFocusDisabled} >
+            <RovingFocusGroup.Root orientation={orientation} loop={loop} disableTabIndexing={disableTabIndexing} >
                 <RovingFocusGroup.Group >
                     <Primitive.div className={clsx(`${rootClass}-root`)} ref={accordionRef} asChild={asChild}>
                         {children}

--- a/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
+++ b/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
@@ -8,6 +8,7 @@ import { createContext } from 'react';
 export type RovingFocusRootContextTypes = {
   orientation: 'horizontal' | 'vertical';
   loop: boolean;
+  rovingFocusDisabled:boolean;
 }
 
 /**
@@ -16,5 +17,6 @@ export type RovingFocusRootContextTypes = {
  */
 export const RovingFocusRootContext = createContext<RovingFocusRootContextTypes>({
     orientation: 'horizontal',
-    loop: true
+    loop: true,
+    rovingFocusDisabled:true,
 });

--- a/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
+++ b/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
@@ -18,5 +18,5 @@ export type RovingFocusRootContextTypes = {
 export const RovingFocusRootContext = createContext<RovingFocusRootContextTypes>({
     orientation: 'horizontal',
     loop: true,
-    rovingFocusDisabled:true,
+    rovingFocusDisabled: false,
 });

--- a/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
+++ b/src/core/utils/RovingFocusGroup/context/RovingFocusRootContext.tsx
@@ -8,7 +8,7 @@ import { createContext } from 'react';
 export type RovingFocusRootContextTypes = {
   orientation: 'horizontal' | 'vertical';
   loop: boolean;
-  rovingFocusDisabled:boolean;
+  disableTabIndexing: boolean;
 }
 
 /**
@@ -18,5 +18,5 @@ export type RovingFocusRootContextTypes = {
 export const RovingFocusRootContext = createContext<RovingFocusRootContextTypes>({
     orientation: 'horizontal',
     loop: true,
-    rovingFocusDisabled: false,
+    disableTabIndexing: false,
 });

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusItem.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusItem.tsx
@@ -42,7 +42,7 @@ const RovingFocusItem = forwardRef<HTMLButtonElement, RovingFocusItemProps>(({
 }, ref) => {
     const id = useId();
     const { focusedItemId, setFocusedItemId, addFocusItem, focusItems, groupRef } = useContext(RovingFocusGroupContext);
-    const { orientation, loop } = useContext(RovingFocusRootContext);
+    const { orientation, loop, rovingFocusDisabled } = useContext(RovingFocusRootContext);
 
     // Check if the child element is disabled
     const childrenArray = React.Children.toArray(children);
@@ -238,7 +238,7 @@ const RovingFocusItem = forwardRef<HTMLButtonElement, RovingFocusItemProps>(({
     return <Primitive.button
         asChild
         onFocus={handleFocus}
-        tabIndex={!isDisabled && isSelected ? 0 : -1}
+        tabIndex={rovingFocusDisabled ? 0 : !isDisabled && isSelected ? 0 : -1}
         ref={ref}
         id={id}
         onKeyDown={handleKeyDown}

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusItem.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusItem.tsx
@@ -42,8 +42,7 @@ const RovingFocusItem = forwardRef<HTMLButtonElement, RovingFocusItemProps>(({
 }, ref) => {
     const id = useId();
     const { focusedItemId, setFocusedItemId, addFocusItem, focusItems, groupRef } = useContext(RovingFocusGroupContext);
-    const { orientation, loop, rovingFocusDisabled } = useContext(RovingFocusRootContext);
-
+    const { orientation, loop, disableTabIndexing } = useContext(RovingFocusRootContext);
     // Check if the child element is disabled
     const childrenArray = React.Children.toArray(children);
     const child = childrenArray[0] as React.ReactElement;
@@ -51,6 +50,7 @@ const RovingFocusItem = forwardRef<HTMLButtonElement, RovingFocusItemProps>(({
 
     // Is this item currently selected
     const isSelected = focusedItemId === id;
+    const tabIndex = disableTabIndexing ? 0 : !isDisabled && isSelected ? 0 : -1;
 
     // Register this item with the parent group
     useEffect(() => {
@@ -238,7 +238,7 @@ const RovingFocusItem = forwardRef<HTMLButtonElement, RovingFocusItemProps>(({
     return <Primitive.button
         asChild
         onFocus={handleFocus}
-        tabIndex={rovingFocusDisabled ? 0 : !isDisabled && isSelected ? 0 : -1}
+        tabIndex={tabIndex}
         ref={ref}
         id={id}
         onKeyDown={handleKeyDown}

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
@@ -18,6 +18,7 @@ type RovingFocusRootProps = {
     loop?: boolean;
     'aria-label'?: string;
     'aria-labelledby'?: string;
+    rovingFocusDisabled?:boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 /**
@@ -40,11 +41,13 @@ const RovingFocusRoot = ({
     loop = true,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
+    rovingFocusDisabled = false,
     ...props
 }: RovingFocusRootProps) => {
     const sendValues = {
         orientation,
-        loop
+        loop,
+        rovingFocusDisabled,
     };
 
     return <RovingFocusRootContext.Provider value={sendValues}>

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
@@ -18,7 +18,7 @@ type RovingFocusRootProps = {
     loop?: boolean;
     'aria-label'?: string;
     'aria-labelledby'?: string;
-    rovingFocusDisabled?: boolean;
+    disableTabIndexing?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 /**
@@ -41,13 +41,13 @@ const RovingFocusRoot = ({
     loop = true,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
-    rovingFocusDisabled = false,
+    disableTabIndexing = false,
     ...props
 }: RovingFocusRootProps) => {
     const sendValues = {
         orientation,
         loop,
-        rovingFocusDisabled,
+        disableTabIndexing,
     };
 
     return <RovingFocusRootContext.Provider value={sendValues}>

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusRoot.tsx
@@ -18,7 +18,7 @@ type RovingFocusRootProps = {
     loop?: boolean;
     'aria-label'?: string;
     'aria-labelledby'?: string;
-    rovingFocusDisabled?:boolean;
+    rovingFocusDisabled?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 /**


### PR DESCRIPTION
Resolves #1006


https://github.com/user-attachments/assets/6a1cacf1-398c-4304-ad56-8313085d600c





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new option to the Accordion component to disable roving tabindex behavior, allowing users to customize keyboard navigation.
- **Documentation**
	- Updated Accordion documentation to include details about the new keyboard navigation option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->