### PR TITLE
Fix VisuallyHidden typo in Docs

### DIFF
--- a/docs/app/docs/components/visually-hidden/docs/codeUsage.js
+++ b/docs/app/docs/components/visually-hidden/docs/codeUsage.js
@@ -2,7 +2,7 @@ const code = {
     javascript: {
         code: `import VisuallyHidden from "@radui/ui/VisuallyHidden""
 
-const VisualltHiddenExample = () => (
+const VisuallyHiddenExample = () => (
     <VisuallyHidden asChild style={{display: "none"}}>
             <span>This is a visually hidden text</span>
     </VisuallyHidden>


### PR DESCRIPTION
This changes fix the typo VisualltHiddenExample to VisuallyHiddenExample 
This is linked to the issue: #1078 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the component name within the code example for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->