### PR TITLE
new esbuild and removal of prebuild running twice

### DIFF
--- a/src/core/primitives/Checkbox/context/CheckboxPrimitiveContext.tsx
+++ b/src/core/primitives/Checkbox/context/CheckboxPrimitiveContext.tsx
@@ -2,6 +2,20 @@
 
 import React from 'react';
 
-const CheckboxPrimitiveContext = React.createContext({});
+export interface CheckboxPrimitiveContextProps {
+    isChecked: boolean,
+    setIsChecked: (value:boolean) => void,
+    id?: string,
+    required?: boolean,
+    disabled?: boolean
+}
+
+const CheckboxPrimitiveContext = React.createContext<CheckboxPrimitiveContextProps>({
+    isChecked: false,
+    setIsChecked: () => {},
+    id: '',
+    required: false,
+    disabled: false
+});
 
 export default CheckboxPrimitiveContext;

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 
 const CheckboxPrimitiveIndicator = ({ children }: { children: React.ReactNode }) => {
-    const { checked } = React.useContext(CheckboxPrimitiveContext);
+    const { isChecked } = React.useContext(CheckboxPrimitiveContext);
 
-    if (!checked) return null;
+    if (!isChecked) return null;
 
     return <span>{children}</span>;
 };

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
@@ -3,20 +3,47 @@
 import React from 'react';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 import CheckboxPrimitiveTrigger from './CheckboxPrimitiveTrigger';
+import useControllableState from '~/core/hooks/useControllableState';
 
-const CheckboxPrimitiveRoot = ({ children, className = '' }: { children: React.ReactNode, className?: string }) => {
-    const [checked, setChecked] = React.useState(false);
+export type CheckboxPrimitiveProps = {
+    children: React.ReactNode,
+    className?: string,
+    checked?: boolean,
+    defaultChecked? : boolean,
+    onCheckedChange? : () => void,
+    disabled?: boolean
+    required?: boolean
+    name?: string
+    value?: string
+}& React.InputHTMLAttributes<HTMLInputElement>;
+
+const CheckboxPrimitiveRoot = ({ children, className = '', checked, defaultChecked = false, onCheckedChange, disabled, required, name, value, id, ...props }: CheckboxPrimitiveProps) => {
+    const [isChecked, setIsChecked] = useControllableState(
+        checked,
+        defaultChecked,
+        onCheckedChange
+    );
 
     const contextValues = {
-        checked,
-        setChecked
+        isChecked,
+        setIsChecked,
+        id,
+        required,
+        disabled
     };
 
     return <CheckboxPrimitiveContext.Provider value={contextValues}>
         <CheckboxPrimitiveTrigger className={className}>
             {children}
         </CheckboxPrimitiveTrigger>
-        <input type="checkbox" style={{ display: 'none' }} />
+        <input
+            type="checkbox" style={{
+                position: 'absolute',
+                pointerEvents: 'none',
+                opacity: 0,
+                margin: 0,
+                transform: 'translateX(-100%)'
+            }} name={name} value={value} checked={isChecked} disabled={disabled} required={required} {...props}/>
     </CheckboxPrimitiveContext.Provider>;
 };
 

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 
-const CheckboxPrimitiveTrigger = ({ children, ...props }: { children: React.ReactNode } & Primitive.buttonProps) => {
-    const { checked, setChecked } = React.useContext(CheckboxPrimitiveContext);
-    return <Primitive.button onClick={() => setChecked(!checked)} {...props}>{children}</Primitive.button>;
+const CheckboxPrimitiveTrigger = ({ children, ...props }: { children: React.ReactNode }& HTMLAttributes<HTMLButtonElement>) => {
+    const { isChecked, setIsChecked, id, required, disabled } = React.useContext(CheckboxPrimitiveContext);
+    return <Primitive.button onClick={() => setIsChecked(!isChecked)} role="checkbox" id={id} aria-checked={isChecked} aria-required={required} data-checked={isChecked} disabled={disabled} data-disabled={disabled} {...props} >{children}</Primitive.button>;
 };
 
 export default CheckboxPrimitiveTrigger;

--- a/src/core/primitives/Checkbox/stories/CheckboxPrimitive.stories.tsx
+++ b/src/core/primitives/Checkbox/stories/CheckboxPrimitive.stories.tsx
@@ -25,6 +25,41 @@ export const Basic: Story = {
     )
 };
 
+export const FormWithCheckboxPrimitive: Story = {
+    render: () => {
+        const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            const formData = new FormData(e.currentTarget);
+            const entries: Record<string, FormDataEntryValue> = {};
+            formData.forEach((value, key) => {
+                entries[key] = value;
+            });
+            alert(JSON.stringify(entries, null, 2));
+        };
+        return (
+            <SandboxEditor>
+                <form onSubmit={handleSubmit}>
+                    <div className='flex space-x-2 items-center'>
+                        <CheckboxPrimitive.Root name="acceptTerms" id="acceptTerms" value="yes" required className='bg-gray-200 border border-blue-800 w-6 h-6 rounded-md flex items-center justify-center'>
+                            <CheckboxPrimitive.Indicator>
+                                <span className='text-blue-900'>
+                                    <TickIcon />
+                                </span>
+                            </CheckboxPrimitive.Indicator>
+                        </CheckboxPrimitive.Root>
+                        <label htmlFor="acceptTerms">
+                        Accept Terms
+                        </label>
+                    </div>
+                    <button type="submit" style={{ marginTop: 16 }}>
+                        Submit
+                    </button>
+                </form>
+            </SandboxEditor>
+        );
+    }
+};
+
 const TickIcon = () => {
     return <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"></path></svg>;
 };

--- a/src/core/primitives/Checkbox/tests/CheckboxPrimitive.test.tsx
+++ b/src/core/primitives/Checkbox/tests/CheckboxPrimitive.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CheckboxPrimitive from '../index';
+
+const TickIcon = () => (
+    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd" />
+    </svg>
+);
+
+describe('CheckboxPrimitive', () => {
+    it('renders and toggles (uncontrolled)', () => {
+        const { container, queryByText } = render(
+            <CheckboxPrimitive.Root defaultChecked={false} className="test-class">
+                <CheckboxPrimitive.Indicator>
+                    <span>Checked</span>
+                </CheckboxPrimitive.Indicator>
+            </CheckboxPrimitive.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).toHaveAttribute('aria-checked', 'false');
+        expect(queryByText('Checked')).toBeNull();
+        fireEvent.click(button!);
+        expect(button).toHaveAttribute('aria-checked', 'true');
+        expect(queryByText('Checked')).toBeInTheDocument();
+        fireEvent.click(button!);
+        expect(button).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('supports controlled checked prop', () => {
+        const onCheckedChange = jest.fn();
+        const { container, queryByText, rerender } = render(
+            <CheckboxPrimitive.Root checked={false} onCheckedChange={onCheckedChange}>
+                <CheckboxPrimitive.Indicator>
+                    <span>Checked</span>
+                </CheckboxPrimitive.Indicator>
+            </CheckboxPrimitive.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).toHaveAttribute('aria-checked', 'false');
+        expect(queryByText('Checked')).toBeNull();
+        fireEvent.click(button!);
+        expect(onCheckedChange).toHaveBeenCalled();
+        rerender(
+            <CheckboxPrimitive.Root checked={true} onCheckedChange={onCheckedChange}>
+                <CheckboxPrimitive.Indicator>
+                    <span>Checked</span>
+                </CheckboxPrimitive.Indicator>
+            </CheckboxPrimitive.Root>
+        );
+        expect(button).toHaveAttribute('aria-checked', 'true');
+        expect(queryByText('Checked')).toBeInTheDocument();
+    });
+
+    it('applies disabled and required props', () => {
+        const { container } = render(
+            <CheckboxPrimitive.Root disabled required>
+                <CheckboxPrimitive.Indicator>
+                    <span>Checked</span>
+                </CheckboxPrimitive.Indicator>
+            </CheckboxPrimitive.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('passes name and value to the hidden input for form usage', () => {
+        const { container } = render(
+            <form>
+                <CheckboxPrimitive.Root name="testName" value="testValue" defaultChecked>
+                    <CheckboxPrimitive.Indicator>
+                        <TickIcon />
+                    </CheckboxPrimitive.Indicator>
+                </CheckboxPrimitive.Root>
+            </form>
+        );
+        const input = container.querySelector('input[type="checkbox"]');
+        expect(input).toHaveAttribute('name', 'testName');
+        expect(input).toHaveAttribute('value', 'testValue');
+        expect(input).toBeChecked();
+    });
+
+    it('integrates with forms and submits checked value', () => {
+        let submittedData: Record<string, FormDataEntryValue> | undefined;
+        const handleSubmit = jest.fn((e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            const formData = new FormData(e.currentTarget);
+            submittedData = Object.fromEntries(Array.from((formData as any).entries()));
+        });
+        const { container } = render(
+            <form onSubmit={handleSubmit}>
+                <CheckboxPrimitive.Root name="accept" value="yes" required>
+                    <CheckboxPrimitive.Indicator>
+                        <TickIcon />
+                    </CheckboxPrimitive.Indicator>
+                </CheckboxPrimitive.Root>
+                <button type="submit">Submit</button>
+            </form>
+        );
+        const button = container.querySelector('button');
+        fireEvent.click(button!); // check it
+        const submitButton = container.querySelector('button[type="submit"]');
+        if (submitButton) {
+            fireEvent.click(submitButton);
+        }
+        expect(handleSubmit).toHaveBeenCalled();
+        expect(submittedData).toEqual({ accept: 'yes' });
+    });
+
+    it('applies className to the trigger', () => {
+        const { container } = render(
+            <CheckboxPrimitive.Root className="my-checkbox">
+                <CheckboxPrimitive.Indicator>
+                    <TickIcon />
+                </CheckboxPrimitive.Indicator>
+            </CheckboxPrimitive.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).toHaveClass('my-checkbox');
+    });
+});


### PR DESCRIPTION
 uses tsc --noEmit to point out the issues in prebuild failing it in first place if having types error 

currently the script is adding a 'use client' ---- not sure of how it helps or is it right way (can be removed)

we have faced problems of using rad ui in ssr comps, might be helpful in clearing those issues





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the build process for UI components to use a new automated script, improving bundling and build reliability.
  * Added esbuild as a dependency to streamline component builds.
  * Simplified build commands and improved build orchestration.
* **Style**
  * Minor formatting adjustment in a console warning message within the Accordion component (no functional impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->