### PR TITLE
export type fixes and added support for color, size and varint in switch

### DIFF
--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import { clsx } from 'clsx';
-
 import AvatarRoot, { AvatarRootProps } from './fragments/AvatarRoot';
 import AvatarImage, { AvatarImageProps } from './fragments/AvatarImage';
 import AvatarFallback from './fragments/AvatarFallback';

--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
-import AvatarRoot from './fragments/AvatarRoot';
-import AvatarImage from './fragments/AvatarImage';
+import AvatarRoot, { AvatarRootProps } from './fragments/AvatarRoot';
+import AvatarImage, { AvatarImageProps } from './fragments/AvatarImage';
 import AvatarFallback from './fragments/AvatarFallback';
 
 const COMPONENT_NAME = 'Avatar';
@@ -11,6 +11,11 @@ const Avatar = () => {
     console.warn('Direct usage of Avatar is not supported. Please use Avatar.Root, Avatar.Image, Avatar.Fallback instead.');
     return null;
 };
+
+export namespace AvatarProps {
+    export type Root = AvatarRootProps;
+    export type Image = AvatarImageProps;
+}
 
 Avatar.displayName = COMPONENT_NAME;
 Avatar.Root = AvatarRoot;

--- a/src/components/ui/Avatar/fragments/AvatarImage.tsx
+++ b/src/components/ui/Avatar/fragments/AvatarImage.tsx
@@ -5,7 +5,7 @@ import AvatarPrimitiveImage, { AvatarRootImageProps } from '~/core/primitives/Av
 import { AvatarContext } from '../contexts/AvatarContext';
 import { clsx } from 'clsx';
 
-type AvatarImageProps = AvatarRootImageProps & {
+export type AvatarImageProps = AvatarRootImageProps & {
     src?: string;
     alt?: string;
 }

--- a/src/components/ui/Avatar/stories/Avatar.stories.tsx
+++ b/src/components/ui/Avatar/stories/Avatar.stories.tsx
@@ -8,7 +8,7 @@ const avatarImage2 = require('/assets/images/avatar-11.jpg');
 export default {
     title: 'Components/Avatar',
     component: Avatar,
-    render: (args: JSX.IntrinsicAttributes & AvatarProps) => <SandboxEditor>
+    render: (args: JSX.IntrinsicAttributes & AvatarProps.Root & AvatarProps.Image & { fallback: string }) => <SandboxEditor>
         <Avatar.Root color={args.color} size={args.size} variant={args.variant} customRootClass={args.customRootClass}>
             <Avatar.Image src={args.src} alt={args.alt} />
             <Avatar.Fallback>{args.fallback}</Avatar.Fallback>
@@ -79,5 +79,5 @@ const WithoutImgTemplate = () => {
 };
 
 export const withoutImg = {
-    render: (args: JSX.IntrinsicAttributes & AvatarProps) => <WithoutImgTemplate />
+    render: (args: JSX.IntrinsicAttributes & AvatarProps.Root & AvatarProps.Image) => <WithoutImgTemplate />
 };

--- a/src/components/ui/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/ui/AvatarGroup/AvatarGroup.tsx
@@ -1,12 +1,19 @@
-import AvatarGroupRoot from './fragments/AvatarGroupRoot';
-import AvatarGroupItem from './fragments/AvatarGroupItem';
-import AvatarGroupAvatar from './fragments/AvatarGroupAvatar';
-import AvatarGroupFallback from './fragments/AvatarGroupFallback';
+import AvatarGroupRoot, { AvatarGroupRootProps } from './fragments/AvatarGroupRoot';
+import AvatarGroupItem, { AvatarGroupItemProps } from './fragments/AvatarGroupItem';
+import AvatarGroupAvatar, { AvatarGroupAvatarProps } from './fragments/AvatarGroupAvatar';
+import AvatarGroupFallback, { AvatarGroupFallbackProps } from './fragments/AvatarGroupFallback';
 
 const AvatarGroup = () => {
     console.warn('Direct usage of AvatarGroup is not supported. Please use AvatarGroup.Root, AvatarGroup.Item, AvatarGroup.Avatar, AvatarGroup.Fallback instead.');
     return null;
 };
+
+export namespace AvatarGroupProps { 
+    export type Root = AvatarGroupRootProps;
+    export type Item = AvatarGroupItemProps;
+    export type Avatar = AvatarGroupAvatarProps;
+    export type Fallback = AvatarGroupFallbackProps;
+}
 
 AvatarGroup.Root = AvatarGroupRoot;
 AvatarGroup.Item = AvatarGroupItem;

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupAvatar.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupAvatar.tsx
@@ -3,7 +3,12 @@
 import React from 'react';
 import AvatarPrimitiveImage from '~/core/primitives/Avatar/fragments/AvatarPrimitiveImage';
 
-const AvatarGroupAvatar = ({ src, alt }: { src: string, alt: string }) => {
+export type AvatarGroupAvatarProps = {
+    src: string;
+    alt: string;
+}
+
+const AvatarGroupAvatar = ({ src, alt }: AvatarGroupAvatarProps) => {
     return <AvatarPrimitiveImage src={src} alt={alt} />;
 };
 

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupFallback.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupFallback.tsx
@@ -4,7 +4,12 @@ import React, { useContext } from 'react';
 import AvatarPrimitiveFallback from '~/core/primitives/Avatar/fragments/AvatarPrimitiveFallback';
 import { AvatarGroupContext } from '../contexts/AvatarGroupContext';
 
-const AvatarGroupFallback = ({ children }: { fallback?: string, children: React.ReactNode }) => {
+export type AvatarGroupFallbackProps = {
+    children: React.ReactNode
+    fallback?: string
+}
+
+const AvatarGroupFallback = ({ children }: AvatarGroupFallbackProps) => {
     const { rootClass } = useContext(AvatarGroupContext);
     return <AvatarPrimitiveFallback className={`${rootClass}-fallback`}>
         {children}

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupItem.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupItem.tsx
@@ -5,7 +5,12 @@ import AvatarPrimitiveRoot from '~/core/primitives/Avatar/fragments/AvatarPrimit
 import { AvatarGroupContext } from '../contexts/AvatarGroupContext';
 import { useCreateDataAccentColorAttribute, useComposeAttributes } from '~/core/hooks/createDataAttribute';
 
-const AvatarGroupItem = ({ color = '', children }: { color?: string, children: React.ReactNode }) => {
+export type AvatarGroupItemProps = { 
+    color?: string
+    children: React.ReactNode 
+};
+
+const AvatarGroupItem = ({ color = '', children }: AvatarGroupItemProps) => {
     const { rootClass } = useContext(AvatarGroupContext);
 
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core/customClassSwitcher';
 import { AvatarGroupContext } from '../contexts/AvatarGroupContext';
 import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
-type AvatarGroupRootProps = {
+export type AvatarGroupRootProps = {
     customRootClass?: string | '';
     size?: string;
     variant?: string;

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core/customClassSwitcher';
 import { AvatarGroupContext } from '../contexts/AvatarGroupContext';
-import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
+import { useCreateDataAttribute, useComposeAttributes } from '~/core/hooks/createDataAttribute';
 export type AvatarGroupRootProps = {
     customRootClass?: string | '';
     size?: string;

--- a/src/components/ui/AvatarGroup/stories/AvatarGroup.stories.tsx
+++ b/src/components/ui/AvatarGroup/stories/AvatarGroup.stories.tsx
@@ -9,7 +9,7 @@ const avatarImage3 = require('/assets/images/avatar-4.jpg');
 export default {
     title: 'Components/AvatarGroup',
     component: AvatarGroup,
-    render: (args: JSX.IntrinsicAttributes & AvatarGroupProps) => <SandboxEditor>
+    render: (args: JSX.IntrinsicAttributes & AvatarGroupProps.Root & AvatarGroupProps.Item & AvatarGroupProps.Avatar & AvatarGroupProps.Fallback & { avatars: { src: string, fallback: string }[] }) => <SandboxEditor>
         <AvatarGroup.Root size='large' variant='circle' >
             <AvatarGroup.Item color='blue'>
                 <AvatarGroup.Avatar src={args.avatars[0].src} alt={args.avatars[0].fallback} />

--- a/src/components/ui/Switch/Switch.tsx
+++ b/src/components/ui/Switch/Switch.tsx
@@ -1,5 +1,5 @@
 'use client';
-import SwitchRoot from './fragments/SwitchRoot';
+import SwitchRoot, { SwitchRootProps } from './fragments/SwitchRoot';
 import SwitchThumb from './fragments/SwitchThumb';
 
 const Switch = () => {
@@ -24,6 +24,10 @@ const Switch = () => {
     //     </>
     // );
 };
+
+export namespace SwitchProps {
+    export type Root = SwitchRootProps;
+}
 
 Switch.Root = SwitchRoot;
 Switch.Thumb = SwitchThumb;

--- a/src/components/ui/Switch/fragments/SwitchRoot.tsx
+++ b/src/components/ui/Switch/fragments/SwitchRoot.tsx
@@ -4,21 +4,29 @@ import React, { useState } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import { customClassSwitcher } from '~/core';
 import { SwitchContext } from '../context/SwitchContext';
+import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
 
 const COMPONENT_NAME = 'Switch';
 
-type SwitchRootProps = {
+export type SwitchRootProps = {
     children: React.ReactNode;
     customRootClass?: string;
+    color?: string;
+    variant?: string;
+    size?: string;
 };
 
-const SwitchRoot = ({ children, customRootClass }: SwitchRootProps) => {
+const SwitchRoot = ({ children, customRootClass, color='', variant, size }: SwitchRootProps) => {
     const [checked, setChecked] = useState(false);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
+    const dataAttributes = useCreateDataAttribute('switch', { variant, size });
+    const accentAttributes = useCreateDataAccentColorAttribute(color);
+    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+
     return (
         <SwitchContext.Provider value={{ checked, setChecked, rootClass }}>
-            <Primitive.button onClick={() => setChecked(!checked)} className={rootClass} data-state={checked ? 'checked' : 'unchecked'}>{children}</Primitive.button>
+            <Primitive.button onClick={() => setChecked(!checked)} className={rootClass} data-state={checked ? 'checked' : 'unchecked'} {...composedAttributes()}>{children}</Primitive.button>
         </SwitchContext.Provider>
     );
 };

--- a/src/components/ui/Switch/stories/Switch.stories.tsx
+++ b/src/components/ui/Switch/stories/Switch.stories.tsx
@@ -8,10 +8,10 @@ const Sizes = ['small', 'medium', 'large', 'x-large'];
 export default {
     title: 'Components/Switch',
     component: Switch,
-    render: (args: JSX.IntrinsicAttributes & SwitchProps) => <SwitchComponent {...args}/>
+    render: (args: JSX.IntrinsicAttributes & SwitchProps.Root) => <SwitchComponent {...args}/>
 };
 
-const SwitchComponent = (args: SwitchProps) => {
+const SwitchComponent = (args: SwitchProps.Root) => {
     const variants = ['classic', 'surface', 'solid'];
     const [isChecked, setIsChecked] = useState(true);
 


### PR DESCRIPTION
closes #1173 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new props to the Switch component, allowing customization of color, variant, and size.
  * Introduced organized namespaces for Avatar, AvatarGroup, and Switch component prop types, making it easier to reference their subcomponent props.

* **Documentation**
  * Improved and clarified TypeScript type annotations in Storybook stories for Avatar, AvatarGroup, and Switch components, enhancing type safety and code readability.

* **Refactor**
  * Exported and standardized prop types for Avatar, AvatarGroup, and Switch components and their subcomponents for better consistency and external usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->