### PR TITLE
Fix: revert preserve modules

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,7 @@
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.2.0",
         "@radui/fx": "^0.2.0",
-        "@radui/ui": "^0.0.45",
+        "@radui/ui": "^0.0.46",
         "@types/mdx": "^2.0.13",
         "@types/node": "20.5.9",
         "@types/react": "19.0.2",
@@ -954,16 +954,16 @@
       }
     },
     "node_modules/@radui/ui": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@radui/ui/-/ui-0.0.45.tgz",
-      "integrity": "sha512-nk+dhgTBrCILP+vA99TNw6I6IkfYAWlQVLe/7DHtDUJPMULV4yh9blvrXmqoA736FeXu39AOueqgUWI1p6gnhQ==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@radui/ui/-/ui-0.0.46.tgz",
+      "integrity": "sha512-01iPMEAimIf/8OF01QI5mGBCxP4BaqTzX5LrNVETWmqzqChPgJXiZGW9nGOzrLkuSilpj92KHmDrjVQOhmKIlw==",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.27.4",
         "clsx": "^2.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-remove-scroll": "^2.7.0"
+        "react-remove-scroll": "^2.7.1"
       },
       "peerDependencies": {
         "react": "^18.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.2.0",
     "@radui/fx": "^0.2.0",
-    "@radui/ui": "^0.0.45",
+    "@radui/ui": "^0.0.46",
     "@types/mdx": "^2.0.13",
     "@types/node": "20.5.9",
     "@types/react": "19.0.2",

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -50,7 +50,7 @@ components.forEach((component) => {
     componentInputs[component] = `src/components/ui/${component}/${component}.tsx`;
 });
 
-// JS builds with preserveModules for parallel builds
+// JS builds with bundled fragments
 const jsBundles = {
     input: componentInputs,
     onwarn(warning, warn) {
@@ -61,8 +61,7 @@ const jsBundles = {
         dir: 'dist/temp-cleanup',
         format: 'es',
         entryFileNames: '[name].js',
-        preserveModules: true,
-        preserveModulesRoot: 'src/components/ui'
+        preserveModules: false
     },
     external: ['react', 'react-dom', 'react/jsx-runtime'],
     plugins: [


### PR DESCRIPTION
Disabling preserveModules 

This gave good speed, but this wasnt enabling us to ship all the fragments components inside a single js file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "@radui/ui" dependency to a newer version.
  * Modified the build configuration to change how JavaScript bundles are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->