### PR TITLE
enhancement:updated onChange to onPressedChange in Toggle

### DIFF
--- a/docs/app/docs/components/toggle-group/docs/toggle-group-example-basic.tsx
+++ b/docs/app/docs/components/toggle-group/docs/toggle-group-example-basic.tsx
@@ -35,7 +35,7 @@ const ToggleGroupExampleBasic = () => {
     return <div>
         <ToggleGroup
             defaultPressed={false}
-            onChange={handleChange}
+            onPressedChange={handleChange}
             type="multiple"
             items = {items}
         >

--- a/docs/app/docs/components/toggle/docs/codeUsage.js
+++ b/docs/app/docs/components/toggle/docs/codeUsage.js
@@ -11,7 +11,7 @@ const ToggleExample = () => {
   }
   
   return (
-    <Toggle pressed={pressed} onChange={handleChange}>
+    <Toggle pressed={pressed} onPressedChange={handleChange}>
       <Icon />
     </Toggle>
   )

--- a/docs/app/docs/components/toggle/docs/toggle-example-basic.tsx
+++ b/docs/app/docs/components/toggle/docs/toggle-example-basic.tsx
@@ -14,7 +14,7 @@ const ToggleExampleBasic = () => {
     const handleChange = (newPressed) => {
         setPressed(newPressed);
     };
-    return <Toggle defaultPressed={false} onChange={handleChange} >
+    return <Toggle defaultPressed={false} onPressedChange={handleChange} >
         <Icon/>
     </Toggle>;
 };

--- a/src/components/ui/Toggle/Toggle.tsx
+++ b/src/components/ui/Toggle/Toggle.tsx
@@ -38,11 +38,11 @@ export type ToggleProps = {
  * @example
  * // Controlled mode
  * const [pressed, setPressed] = useState(false);
- * <Toggle pressed={pressed} onChange={setPressed}>Toggle Me</Toggle>
+ * <Toggle pressed={pressed} onPressedChange={setPressed}>Toggle Me</Toggle>
  *
  * @example
  * // Uncontrolled mode
- * <Toggle defaultPressed={false} onChange={(isPressed) => console.log(isPressed)}>Toggle Me</Toggle>
+ * <Toggle defaultPressed={false} onPressedChange={(isPressed) => console.log(isPressed)}>Toggle Me</Toggle>
  *
  * @param {ToggleProps} props - The component props
  * @returns {JSX.Element} The Toggle component

--- a/src/components/ui/Toggle/stories/Toggle.stories.tsx
+++ b/src/components/ui/Toggle/stories/Toggle.stories.tsx
@@ -18,7 +18,7 @@ A Toggle component that can be used in either controlled or uncontrolled mode.
 - **Controlled**: The toggle state is managed by the parent component through the \`pressed\` prop
 - **Uncontrolled**: The toggle manages its own state, with an optional \`defaultPressed\` initial value
 
-Both modes require an \`onChange\` handler to respond to state changes.
+Both modes require an \`onPressedChange\` handler to respond to state changes.
                 `
             }
         }
@@ -82,7 +82,7 @@ export const Uncontrolled = () => {
             <div className="mb-2 text-sm font-medium">Uncontrolled Toggle (internal state)</div>
             <div className="text-xs text-gray-600 mb-4">
                 State is managed internally by the Toggle component.
-                The parent is notified via onChange but doesn't control the state.
+                The parent is notified via onPressedChange but doesn't control the state.
             </div>
             <Toggle
                 defaultPressed={false}

--- a/src/components/ui/Toggle/tests/Toggle.test.js
+++ b/src/components/ui/Toggle/tests/Toggle.test.js
@@ -29,7 +29,7 @@ describe('Toggle component', () => {
         // Click toggle
         fireEvent.click(container.firstChild);
 
-        // onChange should be called with true
+        // onPressedChange should be called with true
         expect(handleChange).toHaveBeenCalledWith(true);
 
         // State should not change until prop changes (still false)
@@ -51,7 +51,7 @@ describe('Toggle component', () => {
         // Click toggle
         fireEvent.click(container.firstChild);
 
-        // onChange should be called with true
+        // onPressedChange should be called with true
         expect(handleChange).toHaveBeenCalledWith(true);
 
         // State should update internally (now true)
@@ -60,7 +60,7 @@ describe('Toggle component', () => {
         // Click again
         fireEvent.click(container.firstChild);
 
-        // onChange should be called with false
+        // onPressedChange should be called with false
         expect(handleChange).toHaveBeenCalledWith(false);
 
         // State should update internally (back to false)
@@ -86,7 +86,7 @@ describe('Toggle component', () => {
 
     test('renders with asChild prop correctly', () => {
         const { container } = render(
-            <Toggle asChild onChange={() => {}}>
+            <Toggle asChild onPressedChange={() => {}}>
                 <div data-testid="custom-element">Custom Element</div>
             </Toggle>
         );
@@ -99,7 +99,7 @@ describe('Toggle component', () => {
 
     test('asChild preserves custom element props', () => {
         const { container } = render(
-            <Toggle asChild onChange={() => {}}>
+            <Toggle asChild onPressedChange={() => {}}>
                 <div data-testid="custom-element" className="custom-class" data-custom="value">
                     Custom Element
                 </div>


### PR DESCRIPTION
Summary
This pr resolves the issue #1295 
Updated the Toggle component documentation and examples to consistently use onPressedChange instead of onChange for better semantic clarity and consistency with Radix UI primitives.
Changes Made
Documentation: Updated all JSDoc examples and comments to use onPressedChange
Examples: Updated code examples in documentation files
Tests: Updated test comments and prop usage to use onPressedChange
Stories: Updated Storybook stories documentation text

Would love a feedback, if any