### PR TITLE
refactor(alert-dialog): forward refs for dialog fragments

### DIFF
--- a/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
@@ -1,22 +1,33 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef } from 'react';
+import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
-import DialogPrimitive from '~/core/primitives/Dialog';
+import { DialogPrimitiveContext } from '~/core/primitives/Dialog/context/DialogPrimitiveContext';
+import ButtonPrimitive from '~/core/primitives/Button';
 
-export type AlertDialogActionProps = {
-    children: React.ReactNode;
+export type AlertDialogActionProps = React.ComponentPropsWithoutRef<'button'> & {
     asChild?: boolean;
     className?: string;
-}
-
-const AlertDialogAction = ({ children, asChild, className = '', ...props } : AlertDialogActionProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return (
-        <DialogPrimitive.Action className={`${rootClass}-action ${className}`} {...props}>
-            {children}
-        </DialogPrimitive.Action>
-
-    );
 };
+
+const AlertDialogAction = forwardRef<HTMLButtonElement, AlertDialogActionProps>(({ children, asChild, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
+
+    return (
+        <ButtonPrimitive
+            ref={ref}
+            asChild={asChild}
+            className={clsx(`${rootClass}-action`, className)}
+            onClick={() => handleOpenChange(false)}
+            {...getItemProps()}
+            {...props}
+        >
+            {children}
+        </ButtonPrimitive>
+    );
+});
+
+AlertDialogAction.displayName = 'AlertDialogAction';
 
 export default AlertDialogAction;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
@@ -1,22 +1,33 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef } from 'react';
+import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import { DialogPrimitiveContext } from '~/core/primitives/Dialog/context/DialogPrimitiveContext';
+import ButtonPrimitive from '~/core/primitives/Button';
 
-import DialogPrimitive from '~/core/primitives/Dialog';
-
-export type AlertDialogCancelProps = {
-    children: React.ReactNode;
+export type AlertDialogCancelProps = React.ComponentPropsWithoutRef<'button'> & {
     asChild?: boolean;
     className?: string;
-}
-
-const AlertDialogCancel = ({ children, asChild, className = '', ...props } : AlertDialogCancelProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return (
-        <DialogPrimitive.Cancel className={`${rootClass}-cancel ${className}`} {...props}>
-            {children}
-        </DialogPrimitive.Cancel>
-    );
 };
+
+const AlertDialogCancel = forwardRef<HTMLButtonElement, AlertDialogCancelProps>(({ children, asChild, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
+
+    return (
+        <ButtonPrimitive
+            ref={ref}
+            asChild={asChild}
+            className={clsx(`${rootClass}-cancel`, className)}
+            onClick={() => handleOpenChange(false)}
+            {...getItemProps()}
+            {...props}
+        >
+            {children}
+        </ButtonPrimitive>
+    );
+});
+
+AlertDialogCancel.displayName = 'AlertDialogCancel';
 
 export default AlertDialogCancel;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
@@ -1,23 +1,31 @@
 'use client';
-import React, { useContext } from 'react';
-import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import React, { useContext, forwardRef } from 'react';
 import { clsx } from 'clsx';
-import DialogPrimitive from '~/core/primitives/Dialog';
+import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import { DialogPrimitiveContext } from '~/core/primitives/Dialog/context/DialogPrimitiveContext';
+import Floater from '~/core/primitives/Floater';
+import { useMergeRefs } from '@floating-ui/react';
 
-export type AlertDialogContentProps = {
-    children: React.ReactNode;
+export type AlertDialogContentProps = React.ComponentPropsWithoutRef<'div'> & {
     className?: string;
-}
-
-const AlertDialogContent = ({ children, className = '' } : AlertDialogContentProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return (
-        <>
-            <DialogPrimitive.Content className={clsx(`${rootClass}-content`, className)} >
-                {children}
-            </DialogPrimitive.Content>
-        </>
-    );
 };
+
+const AlertDialogContent = forwardRef<HTMLDivElement, AlertDialogContentProps>(({ children, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    const { isOpen, getFloatingProps, floaterContext, refs } = useContext(DialogPrimitiveContext);
+    const mergedRef = useMergeRefs([refs.setFloating as any, ref]);
+
+    if (!isOpen) return null;
+
+    return (
+        <Floater.FocusManager context={floaterContext} returnFocus={true}>
+            <div ref={mergedRef} className={clsx(`${rootClass}-content`, className)} {...getFloatingProps()} {...props}>
+                {children}
+            </div>
+        </Floater.FocusManager>
+    );
+});
+
+AlertDialogContent.displayName = 'AlertDialogContent';
 
 export default AlertDialogContent;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef } from 'react';
+import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-const AlertDialogDescription = ({ children, className = '' }: { children: React.ReactNode, className?: string }) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.p className={`${rootClass}-description ${className}`}>{children}</Primitive.p>;
+export type AlertDialogDescriptionProps = React.ComponentPropsWithoutRef<'p'> & {
+    className?: string;
 };
+
+const AlertDialogDescription = forwardRef<HTMLParagraphElement, AlertDialogDescriptionProps>(({ children, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    return <Primitive.p ref={ref} className={clsx(`${rootClass}-description`, className)} {...props}>{children}</Primitive.p>;
+});
+
+AlertDialogDescription.displayName = 'AlertDialogDescription';
 
 export default AlertDialogDescription;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
@@ -1,21 +1,33 @@
 'use client';
-import React, { useContext } from 'react';
-import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import React, { useContext, forwardRef } from 'react';
 import { clsx } from 'clsx';
+import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import { DialogPrimitiveContext } from '~/core/primitives/Dialog/context/DialogPrimitiveContext';
+import Floater from '~/core/primitives/Floater';
+import { RemoveScroll } from 'react-remove-scroll';
 
-import DialogPrimitive from '~/core/primitives/Dialog';
-
-type AlertDialogOverlayProps = {
+export type AlertDialogOverlayProps = React.ComponentPropsWithoutRef<'div'> & {
     className?: string;
-}
-
-const AlertDialogOverlay = ({ className = '' }: AlertDialogOverlayProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return (
-        <>
-            <DialogPrimitive.Overlay className={clsx(`${rootClass}-overlay`, className)}></DialogPrimitive.Overlay>
-        </>
-    );
 };
+
+const AlertDialogOverlay = forwardRef<HTMLDivElement, AlertDialogOverlayProps>(({ className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    const { isOpen, handleOverlayClick } = useContext(DialogPrimitiveContext);
+
+    if (!isOpen) return null;
+
+    return (
+        <RemoveScroll>
+            <Floater.Overlay
+                ref={ref}
+                onClick={handleOverlayClick}
+                className={clsx(`${rootClass}-overlay`, className)}
+                {...props}
+            />
+        </RemoveScroll>
+    );
+});
+
+AlertDialogOverlay.displayName = 'AlertDialogOverlay';
 
 export default AlertDialogOverlay;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
@@ -1,17 +1,19 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
 export type AlertDialogPortalProps = {
   children: React.ReactNode;
 };
 
-const AlertDialogPortal = ({ children }: AlertDialogPortalProps) => {
+const AlertDialogPortal = forwardRef<HTMLDivElement, AlertDialogPortalProps>(({ children }, _ref) => {
     return (
         <DialogPrimitive.Portal>
             {children}
         </DialogPrimitive.Portal>
     );
-};
+});
+
+AlertDialogPortal.displayName = 'AlertDialogPortal';
 
 export default AlertDialogPortal;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
@@ -1,34 +1,33 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogRootProps = {
+export type AlertDialogRootProps = React.ComponentPropsWithoutRef<'div'> & {
     open?: boolean;
-    children: React.ReactNode;
     customRootClass?: string;
     className?: string;
-}
+};
 
 const COMPONENT_NAME = 'AlertDialog';
 
-const AlertDialogRoot = ({ children, className = '', customRootClass = '', open = false, ...props } : AlertDialogRootProps) => {
+const AlertDialogRoot = forwardRef<HTMLDivElement, AlertDialogRootProps>(({ children, className = '', customRootClass = '', open = false, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const contextProps = { rootClass };
     return (
-        <DialogPrimitive.Root className={clsx(rootClass, className)} {...props}>
+        <DialogPrimitive.Root open={open} className={clsx(rootClass, className)} {...props}>
             <AlertDialogContext.Provider value={contextProps}>
-                <div className={clsx(rootClass, className)}>
+                <div ref={ref} className={clsx(rootClass, className)}>
                     {children}
                 </div>
             </AlertDialogContext.Provider>
         </DialogPrimitive.Root>
     );
-};
+});
 
 AlertDialogRoot.displayName = COMPONENT_NAME;
 export default AlertDialogRoot;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef } from 'react';
+import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-type AlertDialogTitleProps = {
-    children: React.ReactNode;
+export type AlertDialogTitleProps = React.ComponentPropsWithoutRef<'h2'> & {
     className?: string;
-}
-
-const AlertDialogTitle = ({ children, className = '' }: AlertDialogTitleProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.h2 className={`${rootClass}-title ${className}`}>{children}</Primitive.h2>;
 };
+
+const AlertDialogTitle = forwardRef<HTMLHeadingElement, AlertDialogTitleProps>(({ children, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    return <Primitive.h2 ref={ref} className={clsx(`${rootClass}-title`, className)} {...props}>{children}</Primitive.h2>;
+});
+
+AlertDialogTitle.displayName = 'AlertDialogTitle';
 
 export default AlertDialogTitle;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
@@ -1,25 +1,35 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef } from 'react';
 import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
+import { DialogPrimitiveContext } from '~/core/primitives/Dialog/context/DialogPrimitiveContext';
+import ButtonPrimitive from '~/core/primitives/Button';
+import { useMergeRefs } from '@floating-ui/react';
 
-import DialogPrimitive from '~/core/primitives/Dialog';
-
-export type AlertDialogTriggerProps = {
-    children: React.ReactNode;
+export type AlertDialogTriggerProps = React.ComponentPropsWithoutRef<'button'> & {
     asChild?: boolean;
     className?: string;
-}
+};
 
-const AlertDialogTrigger = ({ children, asChild, className = '', ...props } : AlertDialogTriggerProps) => {
+const AlertDialogTrigger = forwardRef<HTMLButtonElement, AlertDialogTriggerProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
+    const { handleOpenChange, getReferenceProps, refs } = useContext(DialogPrimitiveContext);
+    const mergedRef = useMergeRefs([refs.setReference as any, ref]);
 
     return (
-        <DialogPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)} asChild={asChild} {...props}>
+        <ButtonPrimitive
+            ref={mergedRef}
+            asChild={asChild}
+            className={clsx(`${rootClass}-trigger`, className)}
+            onClick={() => handleOpenChange(true)}
+            {...getReferenceProps()}
+            {...props}
+        >
             {children}
-        </DialogPrimitive.Trigger>
-
+        </ButtonPrimitive>
     );
-};
+});
+
+AlertDialogTrigger.displayName = 'AlertDialogTrigger';
 
 export default AlertDialogTrigger;

--- a/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
+++ b/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AlertDialog from '../AlertDialog';
+
+describe('AlertDialog forwardRef', () => {
+    test('forwards refs to underlying elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const overlayRef = React.createRef<HTMLDivElement>();
+        const contentRef = React.createRef<HTMLDivElement>();
+        const titleRef = React.createRef<HTMLHeadingElement>();
+        const descRef = React.createRef<HTMLParagraphElement>();
+        const cancelRef = React.createRef<HTMLButtonElement>();
+        const actionRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <AlertDialog.Root ref={rootRef} open={true}>
+                <AlertDialog.Trigger ref={triggerRef}>Trigger</AlertDialog.Trigger>
+                <AlertDialog.Portal>
+                    <AlertDialog.Overlay ref={overlayRef} />
+                    <AlertDialog.Content ref={contentRef}>
+                        <AlertDialog.Title ref={titleRef}>Title</AlertDialog.Title>
+                        <AlertDialog.Description ref={descRef}>Description</AlertDialog.Description>
+                        <AlertDialog.Cancel ref={cancelRef}>Cancel</AlertDialog.Cancel>
+                        <AlertDialog.Action ref={actionRef}>Action</AlertDialog.Action>
+                    </AlertDialog.Content>
+                </AlertDialog.Portal>
+            </AlertDialog.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(overlayRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(titleRef.current).toBeInstanceOf(HTMLHeadingElement);
+        expect(descRef.current).toBeInstanceOf(HTMLParagraphElement);
+        expect(cancelRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(actionRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+});


### PR DESCRIPTION
## Summary
- refactor AlertDialog fragments to forward refs and improve typing
- add tests to confirm AlertDialog pieces forward refs correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b97e170514833192869d9c81d7d168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AlertDialog components now forward refs (Root, Trigger, Overlay, Content, Title, Description, Cancel, Action) for easier integration.
  - Trigger, Cancel, and Action behave as standard buttons with support for common HTML props.
  - Improved focus management within the dialog and optional scroll locking on the overlay.
  - Overlay and Content render only when open, reducing off-screen DOM.
  - Enhanced className composition for easier styling.

- Tests
  - Added comprehensive ref-forwarding tests across all AlertDialog parts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->