### PR TITLE
fix: refine navigation menu typing

### DIFF
--- a/src/components/ui/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/ui/NavigationMenu/NavigationMenu.tsx
@@ -4,14 +4,13 @@ import NavigationMenuTrigger from './fragments/NavigationMenuTrigger';
 import NavigationMenuContent from './fragments/NavigationMenuContent';
 import NavigationMenuLink from './fragments/NavigationMenuLink';
 
-
 const NavigationMenu = {
     Root: NavigationMenuRoot,
     Item: NavigationMenuItem,
     Trigger: NavigationMenuTrigger,
     Content: NavigationMenuContent,
     Link: NavigationMenuLink
-
 };
 
-export default NavigationMenu
+export default NavigationMenu;
+

--- a/src/components/ui/NavigationMenu/contexts/NavigationMenuRootContext.tsx
+++ b/src/components/ui/NavigationMenu/contexts/NavigationMenuRootContext.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
 export interface NavigationMenuRootContextProps {
-   isOpen: string,
-   setIsOpen: React.Dispatch<React.SetStateAction<string>>
-   rootClass: string
+    isOpen: string;
+    setIsOpen: React.Dispatch<React.SetStateAction<string>>;
+    rootClass: string;
 }
 
-const NavigationMenuRootContext = React.createContext<NavigationMenuRootContextProps|null>(null);
+const NavigationMenuRootContext = React.createContext<NavigationMenuRootContextProps>({
+    isOpen: '',
+    setIsOpen: () => {},
+    rootClass: ''
+});
 
 export default NavigationMenuRootContext;

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
@@ -1,33 +1,38 @@
-import React, { useEffect } from 'react'
+import React, { useEffect } from 'react';
 import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import NavigationMenuItemContext from '../contexts/NavigationMenyItemContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import clsx from 'clsx';
 
+export interface NavigationMenuContentProps {
+    children: React.ReactNode;
+    className?: string;
+}
 
-const NavigationMenuContent = ({children, className}:any) => {
-    const {itemOpen} = React.useContext(NavigationMenuItemContext);
-    const {rootClass} = React.useContext(NavigationMenuRootContext);
+const NavigationMenuContent = ({ children, className }: NavigationMenuContentProps) => {
+    const { itemOpen } = React.useContext(NavigationMenuItemContext);
+    const { rootClass } = React.useContext(NavigationMenuRootContext);
     const contentRef = React.useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (!contentRef.current) return
-        if ( contentRef.current.children[0].children[0]) {
-          contentRef.current.children[0]?.children[0].firstChild.focus();
-        }
-      }, [itemOpen]);
+        const firstFocusable = contentRef.current?.querySelector<HTMLElement>('*');
+        firstFocusable?.focus();
+    }, [itemOpen]);
 
-   if (!itemOpen) return null
+    if (!itemOpen) return null;
+
     return (
-
-        <div ref={contentRef} className={clsx(`${rootClass}-content`, className)} data-state={itemOpen ? 'open' : 'closed'}>
+        <div
+            ref={contentRef}
+            className={clsx(`${rootClass}-content`, className)}
+            data-state={itemOpen ? 'open' : 'closed'}
+        >
             <RovingFocusGroup.Root>
-                <RovingFocusGroup.Group >
-            {children}
-                </RovingFocusGroup.Group>
+                <RovingFocusGroup.Group>{children}</RovingFocusGroup.Group>
             </RovingFocusGroup.Root>
         </div>
-    )
-}
+    );
+};
 
-export default NavigationMenuContent
+export default NavigationMenuContent;
+

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuItem.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuItem.tsx
@@ -1,28 +1,40 @@
-import React from 'react'
+import React from 'react';
 import NavigationMenuItemContext from '../contexts/NavigationMenyItemContext';
 import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import clsx from 'clsx';
 
-const NavigationMenuItem = ({value, children, className}:any) => {
-    const {isOpen, setIsOpen, rootClass} = React.useContext(NavigationMenuRootContext);
+export interface NavigationMenuItemProps {
+    value: string;
+    children: React.ReactNode;
+    className?: string;
+}
+
+const NavigationMenuItem = ({ value, children, className }: NavigationMenuItemProps) => {
+    const { isOpen, setIsOpen, rootClass } = React.useContext(NavigationMenuRootContext);
 
     const itemOpen = isOpen === value;
-    
 
     const handleTrigger = () => {
         setIsOpen(itemOpen ? '' : value);
-    }
+    };
 
     const handleEscape = (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (e.key === 'Escape') setIsOpen('');
-    }
-    return (
-        <NavigationMenuItemContext.Provider value={{itemOpen, handleTrigger}} >
-        <div  onMouseEnter={handleTrigger} onMouseLeave={handleTrigger} className={clsx(`${rootClass}-item`, className)} onKeyDown={handleEscape}>
-            {children}
-        </div>
-        </NavigationMenuItemContext.Provider>
-    )
-}
+    };
 
-export default NavigationMenuItem
+    return (
+        <NavigationMenuItemContext.Provider value={{ itemOpen, handleTrigger }}>
+            <div
+                onMouseEnter={handleTrigger}
+                onMouseLeave={handleTrigger}
+                className={clsx(`${rootClass}-item`, className)}
+                onKeyDown={handleEscape}
+            >
+                {children}
+            </div>
+        </NavigationMenuItemContext.Provider>
+    );
+};
+
+export default NavigationMenuItem;
+

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuLink.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuLink.tsx
@@ -1,23 +1,24 @@
-import React from 'react'
-import RovingFocusGroup from '~/core/utils/RovingFocusGroup'
-import  NavigationMenuRootContext  from '../contexts/NavigationMenuRootContext'
-import clsx from 'clsx'
+import React from 'react';
+import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
+import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
+import clsx from 'clsx';
 
-export type NavigationMenuLinkProps = {
-    href: string
-    children: React.ReactNode
-    className?: string
+export interface NavigationMenuLinkProps {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
 }
 
-const NavigationMenuLink = ({children, href, className}:NavigationMenuLinkProps) => {
-    const {rootClass} = React.useContext(NavigationMenuRootContext);
+const NavigationMenuLink = ({ children, href, className }: NavigationMenuLinkProps) => {
+    const { rootClass } = React.useContext(NavigationMenuRootContext);
     return (
         <RovingFocusGroup.Item>
-        <a href={href} className={clsx(`${rootClass}-link`, className)}>
-            {children}
-        </a>
+            <a href={href} className={clsx(`${rootClass}-link`, className)}>
+                {children}
+            </a>
         </RovingFocusGroup.Item>
-    )
-}
+    );
+};
 
-export default NavigationMenuLink
+export default NavigationMenuLink;
+

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
@@ -1,39 +1,45 @@
-import React from 'react'
+import React from 'react';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import { useControllableState } from '~/core/hooks/useControllableState';
-import  NavigationMenuRootContext  from '../contexts/NavigationMenuRootContext';
+import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import { customClassSwitcher } from '~/core';
-import  clsx from 'clsx';
+import clsx from 'clsx';
 
 const COMPONENT_NAME = 'NavigationMenu';
 
-export type NavigationMenuRootProps = {
-    children: React.ReactNode
-    value?: string
-    defaultValue?: string
-    onValueChange?: (value: string) => void
-    customRootClass?: string
-    className?: string
+export interface NavigationMenuRootProps extends React.HTMLAttributes<HTMLDivElement> {
+    children: React.ReactNode;
+    value?: string;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
+    customRootClass?: string;
+    className?: string;
 }
-const NavigationMenuRoot = ({children, value, defaultValue = '', onValueChange, customRootClass, className, ...props}:NavigationMenuRootProps) => {
+
+const NavigationMenuRoot = ({
+    children,
+    value,
+    defaultValue = '',
+    onValueChange,
+    customRootClass,
+    className,
+    ...props
+}: NavigationMenuRootProps) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const [ isOpen, setIsOpen ] = useControllableState(
-        value,
-        defaultValue,
-        onValueChange
-    );
+    const [isOpen, setIsOpen] = useControllableState(value, defaultValue, onValueChange);
 
     return (
-        <div >
-            <NavigationMenuRootContext.Provider value={{isOpen, setIsOpen, rootClass}} >
-            <RovingFocusGroup.Root>
-                <RovingFocusGroup.Group className={clsx(`${rootClass}-root`, className)}>
-                    {children}
-                </RovingFocusGroup.Group>
-            </RovingFocusGroup.Root>
+        <div {...props}>
+            <NavigationMenuRootContext.Provider value={{ isOpen, setIsOpen, rootClass }}>
+                <RovingFocusGroup.Root>
+                    <RovingFocusGroup.Group className={clsx(`${rootClass}-root`, className)}>
+                        {children}
+                    </RovingFocusGroup.Group>
+                </RovingFocusGroup.Root>
             </NavigationMenuRootContext.Provider>
         </div>
-    )
-}
+    );
+};
 
-export default NavigationMenuRoot
+export default NavigationMenuRoot;
+

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuTrigger.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuTrigger.tsx
@@ -1,19 +1,26 @@
-import React from 'react'
+import React from 'react';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import NavigationMenuItemContext from '../contexts/NavigationMenyItemContext';
 import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import clsx from 'clsx';
 
-const NavigationMenuTrigger = ({children, className}:any) => {
-    const {handleTrigger} = React.useContext(NavigationMenuItemContext);
-    const {rootClass} = React.useContext(NavigationMenuRootContext);
+export interface NavigationMenuTriggerProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+const NavigationMenuTrigger = ({ children, className }: NavigationMenuTriggerProps) => {
+    const { handleTrigger } = React.useContext(NavigationMenuItemContext);
+    const { rootClass } = React.useContext(NavigationMenuRootContext);
+
     return (
         <RovingFocusGroup.Item>
             <button onClick={handleTrigger} className={clsx(`${rootClass}-trigger`, className)}>
                 {children}
             </button>
         </RovingFocusGroup.Item>
-    )
-}
+    );
+};
 
-export default NavigationMenuTrigger
+export default NavigationMenuTrigger;
+

--- a/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
+++ b/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import NavigationMenu from '../NavigationMenu';
+
+describe('NavigationMenu component', () => {
+    test('renders content when trigger is clicked', () => {
+        const { getByText, queryByText } = render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content>
+                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(queryByText('Item 1 Content')).toBeNull();
+        fireEvent.click(getByText('Open'));
+        expect(getByText('Item 1 Content')).toBeInTheDocument();
+    });
+
+    test('closes content on second trigger click', () => {
+        const { getByText, queryByText } = render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content>
+                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        const trigger = getByText('Open');
+        fireEvent.click(trigger);
+        expect(getByText('Item 1 Content')).toBeInTheDocument();
+        fireEvent.click(trigger);
+        expect(queryByText('Item 1 Content')).toBeNull();
+    });
+
+    test('renders link with correct href', () => {
+        const { getByText } = render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Link href="/about">About</NavigationMenu.Link>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        const link = getByText('About');
+        expect(link).toHaveAttribute('href', '/about');
+    });
+});
+

--- a/src/components/ui/Splitter/stories/Splitter.stories.tsx
+++ b/src/components/ui/Splitter/stories/Splitter.stories.tsx
@@ -3,8 +3,24 @@ import Splitter from '../Splitter';
 import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
 
 // Sample content components
-const SamplePanel = ({ title, children }: { title: string; children?: React.ReactNode }) => (
-    <div style={{ padding: '20px', height: '100%', display: 'flex', flexDirection: 'column', backgroundColor: 'var(--rad-ui-color-gray-300)' }}>
+const SamplePanel = ({
+    title,
+    children,
+    color = 'var(--rad-ui-color-gray-300)'
+}: {
+    title: string;
+    children?: React.ReactNode;
+    color?: string;
+}) => (
+    <div
+        style={{
+            padding: '20px',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: color
+        }}
+    >
         <h3 style={{ margin: '0 0 10px 0', fontSize: '18px' }}>{title}</h3>
         <div style={{ flex: 1, overflow: 'auto' }}>
             {children || (

--- a/src/components/ui/Tree/contexts/TreeContext.tsx
+++ b/src/components/ui/Tree/contexts/TreeContext.tsx
@@ -1,6 +1,11 @@
-import { createContext } from 'react';
+import { createContext, MutableRefObject } from 'react';
 
-export const TreeContext = createContext({
+export interface TreeContextProps {
+    rootClass: string;
+    treeRef: MutableRefObject<HTMLElement | null>;
+}
+
+export const TreeContext = createContext<TreeContextProps>({
     rootClass: '',
-    treeRef: null
+    treeRef: { current: null }
 });

--- a/src/components/ui/Tree/fragments/TreeRoot.tsx
+++ b/src/components/ui/Tree/fragments/TreeRoot.tsx
@@ -5,7 +5,7 @@ import { TreeContext } from '../contexts/TreeContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import Primitive from '~/core/primitives/Primitive';
 import { customClassSwitcher } from '~/core';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 const COMPONENT_NAME = 'Tree';
 
@@ -19,7 +19,7 @@ type TreeRootProps = {
 };
 
 const TreeRoot = ({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }: TreeRootProps) => {
-    const treeRef = useRef(null);
+    const treeRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const treeContextValue = {


### PR DESCRIPTION
## Summary
- add strong typing for NavigationMenu fragments and context
- cover NavigationMenu interactions with new tests
- clean up misc type issues in Tree context and Splitter story

## Testing
- `npm run check:types`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97e0a380883319e2be3261d3e368e