### PR TITLE
refactor(BlockQuote): forward ref support

### DIFF
--- a/src/components/ui/BlockQuote/BlockQuote.tsx
+++ b/src/components/ui/BlockQuote/BlockQuote.tsx
@@ -5,34 +5,38 @@ import { customClassSwitcher } from '~/core';
 
 const COMPONENT_NAME = 'BlockQuote';
 
-export type BlockQuoteProps = {
-    children: React.ReactNode;
+export type BlockQuoteProps = React.ComponentPropsWithoutRef<'blockquote'> & {
     customRootClass?: string;
-    className?: string;
     color?: string;
     variant?: string;
     size?: string;
-    props?: Record<string, any>[]
-}
-const BlockQuote = ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }: BlockQuoteProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-
-    const data_attributes: Record<string, string> = {};
-
-    if (variant) {
-        data_attributes['data-block-quote-variant'] = variant;
-    }
-
-    if (size) {
-        data_attributes['data-block-quote-size'] = size;
-    }
-
-    if (color) {
-        data_attributes['data-rad-ui-accent-color'] = color;
-    }
-
-    return <blockquote className={clsx(rootClass, className)} {...props} {...data_attributes}> {children}</blockquote>;
 };
+
+const BlockQuote = React.forwardRef<React.ElementRef<'blockquote'>, BlockQuoteProps>(
+    ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+
+        const data_attributes: Record<string, string> = {};
+
+        if (variant) {
+            data_attributes['data-block-quote-variant'] = variant;
+        }
+
+        if (size) {
+            data_attributes['data-block-quote-size'] = size;
+        }
+
+        if (color) {
+            data_attributes['data-rad-ui-accent-color'] = color;
+        }
+
+        return (
+            <blockquote ref={ref} className={clsx(rootClass, className)} {...props} {...data_attributes}>
+                {children}
+            </blockquote>
+        );
+    }
+);
 
 BlockQuote.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/BlockQuote/tests/BlockQuote.test.tsx
+++ b/src/components/ui/BlockQuote/tests/BlockQuote.test.tsx
@@ -31,4 +31,17 @@ describe('BlockQuote', () => {
         render(<BlockQuote className='mr-2' color='blue'>BlockQuote</BlockQuote>);
         expect(screen.getByText('BlockQuote')).toHaveAttribute('data-rad-ui-accent-color', 'blue');
     });
+
+    test('forwards refs to the underlying element', () => {
+        const ref = React.createRef<HTMLQuoteElement>();
+        render(<BlockQuote ref={ref}>BlockQuote</BlockQuote>);
+        expect(ref.current).not.toBeNull();
+    });
+
+    test('applies variant and size data attributes', () => {
+        render(<BlockQuote variant='quote' size='lg'>BlockQuote</BlockQuote>);
+        const quoteElement = screen.getByText('BlockQuote');
+        expect(quoteElement).toHaveAttribute('data-block-quote-variant', 'quote');
+        expect(quoteElement).toHaveAttribute('data-block-quote-size', 'lg');
+    });
 });


### PR DESCRIPTION
## Summary
- refactor BlockQuote to forward refs and use typed props
- test ref forwarding and data attributes for BlockQuote

## Testing
- `npm test src/components/ui/BlockQuote/tests/BlockQuote.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - BlockQuote now supports ref forwarding.
  - Consistent data attributes for variant/size/color; accepts standard blockquote attributes.

- Refactor
  - Simplified props by extending native blockquote props.
  - Added customRootClass; removed legacy miscellaneous props.
  - Switched to a default export; className handled via native props.

- Tests
  - Added tests for ref forwarding and data-attribute rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->