### PR TITLE
refactor(alert-dialog): forward refs

### DIFF
--- a/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
@@ -1,22 +1,23 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogActionProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogActionElement = React.ElementRef<typeof DialogPrimitive.Action>;
+type DialogPrimitiveActionProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Action>;
 
-const AlertDialogAction = ({ children, asChild, className = '', ...props } : AlertDialogActionProps) => {
+export type AlertDialogActionProps = DialogPrimitiveActionProps & {
+    className?: string;
+};
+
+const AlertDialogAction = forwardRef<AlertDialogActionElement, AlertDialogActionProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <DialogPrimitive.Action className={`${rootClass}-action ${className}`} {...props}>
+        <DialogPrimitive.Action ref={ref} className={`${rootClass}-action ${className}`} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Action>
 
     );
-};
+});
 
 export default AlertDialogAction;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
@@ -1,22 +1,23 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogCancelProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogCancelElement = React.ElementRef<typeof DialogPrimitive.Cancel>;
+type DialogPrimitiveCancelProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Cancel>;
 
-const AlertDialogCancel = ({ children, asChild, className = '', ...props } : AlertDialogCancelProps) => {
+export type AlertDialogCancelProps = DialogPrimitiveCancelProps & {
+    className?: string;
+};
+
+const AlertDialogCancel = forwardRef<AlertDialogCancelElement, AlertDialogCancelProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <DialogPrimitive.Cancel className={`${rootClass}-cancel ${className}`} {...props}>
+        <DialogPrimitive.Cancel ref={ref} className={`${rootClass}-cancel ${className}`} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Cancel>
     );
-};
+});
 
 export default AlertDialogCancel;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
@@ -1,23 +1,23 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogContentProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+type AlertDialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
+type DialogPrimitiveContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
 
-const AlertDialogContent = ({ children, className = '' } : AlertDialogContentProps) => {
+export type AlertDialogContentProps = DialogPrimitiveContentProps & {
+    className?: string;
+};
+
+const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDialogContentProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <>
-            <DialogPrimitive.Content className={clsx(`${rootClass}-content`, className)} >
-                {children}
-            </DialogPrimitive.Content>
-        </>
+        <DialogPrimitive.Content ref={ref} className={clsx(`${rootClass}-content`, className)} {...props}>
+            {children}
+        </DialogPrimitive.Content>
     );
-};
+});
 
 export default AlertDialogContent;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-const AlertDialogDescription = ({ children, className = '' }: { children: React.ReactNode, className?: string }) => {
+type AlertDialogDescriptionElement = React.ElementRef<typeof Primitive.p>;
+type PrimitivePProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
+
+export type AlertDialogDescriptionProps = PrimitivePProps & { className?: string };
+
+const AlertDialogDescription = forwardRef<AlertDialogDescriptionElement, AlertDialogDescriptionProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.p className={`${rootClass}-description ${className}`}>{children}</Primitive.p>;
-};
+    return <Primitive.p ref={ref} className={`${rootClass}-description ${className}`} {...props}>{children}</Primitive.p>;
+});
 
 export default AlertDialogDescription;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
@@ -1,21 +1,22 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-type AlertDialogOverlayProps = {
-    className?: string;
-}
+type AlertDialogOverlayElement = React.ElementRef<typeof DialogPrimitive.Overlay>;
+type DialogPrimitiveOverlayProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>;
 
-const AlertDialogOverlay = ({ className = '' }: AlertDialogOverlayProps) => {
+type AlertDialogOverlayProps = DialogPrimitiveOverlayProps & {
+    className?: string;
+};
+
+const AlertDialogOverlay = forwardRef<AlertDialogOverlayElement, AlertDialogOverlayProps>(({ className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <>
-            <DialogPrimitive.Overlay className={clsx(`${rootClass}-overlay`, className)}></DialogPrimitive.Overlay>
-        </>
+        <DialogPrimitive.Overlay ref={ref} className={clsx(`${rootClass}-overlay`, className)} {...props}></DialogPrimitive.Overlay>
     );
-};
+});
 
 export default AlertDialogOverlay;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
@@ -1,17 +1,20 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogPortalProps = {
-  children: React.ReactNode;
-};
+type AlertDialogPortalElement = React.ElementRef<'div'>;
+type DialogPrimitivePortalProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Portal>;
 
-const AlertDialogPortal = ({ children }: AlertDialogPortalProps) => {
+export type AlertDialogPortalProps = DialogPrimitivePortalProps;
+
+const AlertDialogPortal = forwardRef<AlertDialogPortalElement, AlertDialogPortalProps>(({ children, ...props }, _ref) => {
     return (
-        <DialogPrimitive.Portal>
+        <DialogPrimitive.Portal {...props}>
             {children}
         </DialogPrimitive.Portal>
     );
-};
+});
+
+AlertDialogPortal.displayName = 'AlertDialogPortal';
 
 export default AlertDialogPortal;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
@@ -1,34 +1,35 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogRootProps = {
-    open?: boolean;
-    children: React.ReactNode;
+type AlertDialogRootElement = React.ElementRef<typeof DialogPrimitive.Root>;
+type DialogPrimitiveRootProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>;
+
+export type AlertDialogRootProps = DialogPrimitiveRootProps & {
     customRootClass?: string;
     className?: string;
-}
+};
 
 const COMPONENT_NAME = 'AlertDialog';
 
-const AlertDialogRoot = ({ children, className = '', customRootClass = '', open = false, ...props } : AlertDialogRootProps) => {
+const AlertDialogRoot = forwardRef<AlertDialogRootElement, AlertDialogRootProps>(({ children, className = '', customRootClass = '', open = false, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const contextProps = { rootClass };
     return (
-        <DialogPrimitive.Root className={clsx(rootClass, className)} {...props}>
+        <DialogPrimitive.Root open={open} className={clsx(rootClass, className)} {...props}>
             <AlertDialogContext.Provider value={contextProps}>
-                <div className={clsx(rootClass, className)}>
+                <div ref={ref} className={clsx(rootClass, className)}>
                     {children}
                 </div>
             </AlertDialogContext.Provider>
         </DialogPrimitive.Root>
     );
-};
+});
 
 AlertDialogRoot.displayName = COMPONENT_NAME;
 export default AlertDialogRoot;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-type AlertDialogTitleProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+type AlertDialogTitleElement = React.ElementRef<typeof Primitive.h2>;
+type PrimitiveH2Props = React.ComponentPropsWithoutRef<typeof Primitive.h2>;
 
-const AlertDialogTitle = ({ children, className = '' }: AlertDialogTitleProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.h2 className={`${rootClass}-title ${className}`}>{children}</Primitive.h2>;
+export type AlertDialogTitleProps = PrimitiveH2Props & {
+    className?: string;
 };
+
+const AlertDialogTitle = forwardRef<AlertDialogTitleElement, AlertDialogTitleProps>(({ children, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    return <Primitive.h2 ref={ref} className={`${rootClass}-title ${className}`} {...props}>{children}</Primitive.h2>;
+});
 
 export default AlertDialogTitle;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
@@ -1,25 +1,26 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogTriggerProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogTriggerElement = React.ElementRef<typeof DialogPrimitive.Trigger>;
+type DialogPrimitiveTriggerProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>;
 
-const AlertDialogTrigger = ({ children, asChild, className = '', ...props } : AlertDialogTriggerProps) => {
+export type AlertDialogTriggerProps = DialogPrimitiveTriggerProps & {
+    className?: string;
+};
+
+const AlertDialogTrigger = forwardRef<AlertDialogTriggerElement, AlertDialogTriggerProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
 
     return (
-        <DialogPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)} asChild={asChild} {...props}>
+        <DialogPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-trigger`, className)} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Trigger>
 
     );
-};
+});
 
 export default AlertDialogTrigger;

--- a/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
+++ b/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
@@ -1,0 +1,61 @@
+import React, { createRef } from 'react';
+import { render } from '@testing-library/react';
+import AlertDialog from '../AlertDialog';
+
+describe('AlertDialog', () => {
+    test('forwards refs to subcomponents', () => {
+        const rootRef = createRef<HTMLDivElement>();
+        const triggerRef = createRef<HTMLButtonElement>();
+        const overlayRef = createRef<HTMLDivElement>();
+        const contentRef = createRef<HTMLDivElement>();
+        const titleRef = createRef<HTMLHeadingElement>();
+        const descriptionRef = createRef<HTMLParagraphElement>();
+        const cancelRef = createRef<HTMLButtonElement>();
+        const actionRef = createRef<HTMLButtonElement>();
+
+        render(
+            <AlertDialog.Root ref={rootRef} open>
+                <AlertDialog.Trigger ref={triggerRef}>Open</AlertDialog.Trigger>
+                <AlertDialog.Overlay ref={overlayRef} />
+                <AlertDialog.Content ref={contentRef}>
+                    <AlertDialog.Title ref={titleRef}>Title</AlertDialog.Title>
+                    <AlertDialog.Description ref={descriptionRef}>Description</AlertDialog.Description>
+                    <AlertDialog.Cancel ref={cancelRef}>Cancel</AlertDialog.Cancel>
+                    <AlertDialog.Action ref={actionRef}>Action</AlertDialog.Action>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(overlayRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(titleRef.current?.tagName).toBe('H2');
+        expect(descriptionRef.current?.tagName).toBe('P');
+        expect(cancelRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(actionRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <AlertDialog.Root open>
+                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                <AlertDialog.Overlay />
+                <AlertDialog.Content>
+                    <AlertDialog.Title>Title</AlertDialog.Title>
+                    <AlertDialog.Description>Description</AlertDialog.Description>
+                    <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+                    <AlertDialog.Action>Action</AlertDialog.Action>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});

--- a/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
@@ -1,18 +1,19 @@
 'use client';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, forwardRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'VisuallyHidden';
 
-export type VisuallyHiddenProps = {
-    children: React.ReactNode;
+type VisuallyHiddenElement = React.ElementRef<typeof Primitive.div>;
+type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
+
+export type VisuallyHiddenProps = PrimitiveDivProps & {
     customRootClass?: string;
     className?: string;
-    asChild?: boolean;
     style?: CSSProperties;
-} & React.HTMLAttributes<HTMLDivElement>;
+};
 
 const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     position: 'absolute',
@@ -29,17 +30,12 @@ const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     userSelect: 'none'
 } as const;
 
-const VisuallyHidden = ({
-    children,
-    customRootClass,
-    className,
-    style = {},
-    ...props
-}: VisuallyHiddenProps) => {
+const VisuallyHidden = forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(({ children, customRootClass, className, style = {}, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
         <Primitive.div
+            ref={ref}
             className={clsx(rootClass, className)}
             style={{ ...VISUALLY_HIDDEN_STYLES, ...style }} // overriding possible
             {...props}
@@ -47,7 +43,7 @@ const VisuallyHidden = ({
             {children}
         </Primitive.div>
     );
-};
+});
 
 VisuallyHidden.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
+++ b/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
@@ -105,6 +105,12 @@ describe('VisuallyHidden Component', () => {
         expect(element).toBeInTheDocument();
     });
 
+    test('forwards ref to the underlying element', () => {
+        const ref = React.createRef();
+        render(<VisuallyHidden ref={ref}>Hidden content</VisuallyHidden>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+
     test('maintains accessibility for screen readers', () => {
         render(
             <VisuallyHidden>

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
@@ -9,10 +9,11 @@ export type DialogPrimitiveActionProps = {
     asChild?: boolean;
 }
 
-const DialogPrimitiveAction = ({ children, asChild, ...props } : DialogPrimitiveActionProps) => {
+const DialogPrimitiveAction = forwardRef<HTMLButtonElement, DialogPrimitiveActionProps>(({ children, asChild, ...props }, ref) => {
     const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
     return (
         <ButtonPrimitive
+            ref={ref}
             asChild={asChild}
             onClick={() => handleOpenChange(false)}
             {...getItemProps()}
@@ -21,6 +22,6 @@ const DialogPrimitiveAction = ({ children, asChild, ...props } : DialogPrimitive
             {children}
         </ButtonPrimitive>
     );
-};
+});
 
 export default DialogPrimitiveAction;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
@@ -9,10 +9,11 @@ export type DialogPrimitiveCancelProps = {
     className?: string;
 }
 
-const DialogPrimitiveCancel = ({ children, asChild, ...props } : DialogPrimitiveCancelProps) => {
+const DialogPrimitiveCancel = forwardRef<HTMLButtonElement, DialogPrimitiveCancelProps>(({ children, asChild, ...props }, ref) => {
     const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
     return (
         <ButtonPrimitive
+            ref={ref}
             asChild={asChild}
             onClick={() => handleOpenChange(false)}
             {...getItemProps()}
@@ -21,6 +22,6 @@ const DialogPrimitiveCancel = ({ children, asChild, ...props } : DialogPrimitive
             {children}
         </ButtonPrimitive>
     );
-};
+});
 
 export default DialogPrimitiveCancel;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
 
@@ -8,20 +8,22 @@ export type DialogPrimitiveContentProps = {
     className?: string;
 }
 
-const DialogPrimitiveContent = ({ children, ...props } : DialogPrimitiveContentProps) => {
+const DialogPrimitiveContent = forwardRef<HTMLDivElement, DialogPrimitiveContentProps>(({ children, ...props }, ref) => {
     const { isOpen, getFloatingProps, floaterContext, refs } = useContext(DialogPrimitiveContext);
+
+    const mergedRef = Floater.useMergeRefs([refs.setFloating, ref]);
 
     return (
         <>
             {isOpen && (
                 <Floater.FocusManager context={floaterContext} returnFocus={true}>
-                    <div ref={refs.setFloating} {...getFloatingProps()} {...props}>
+                    <div ref={mergedRef} {...getFloatingProps()} {...props}>
                         {children}
                     </div>
                 </Floater.FocusManager>
             )}
         </>
     );
-};
+});
 
 export default DialogPrimitiveContent;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import Floater from '~/core/primitives/Floater';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 
@@ -9,13 +9,14 @@ type DialogPrimitiveOverlayProps = {
     className?: string;
 }
 
-const DialogPrimitiveOverlay = ({ ...props }: DialogPrimitiveOverlayProps) => {
+const DialogPrimitiveOverlay = forwardRef<HTMLDivElement, DialogPrimitiveOverlayProps>(({ ...props }, ref) => {
     const { isOpen, handleOverlayClick } = useContext(DialogPrimitiveContext);
     return (
         <>
             {isOpen && (
                 <RemoveScroll>
                     <Floater.Overlay
+                        ref={ref}
                         onClick={handleOverlayClick}
                         {...props}
                     >
@@ -24,6 +25,6 @@ const DialogPrimitiveOverlay = ({ ...props }: DialogPrimitiveOverlayProps) => {
             )}
         </>
     );
-};
+});
 
 export default DialogPrimitiveOverlay;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
 
@@ -13,7 +13,7 @@ export type DialogPrimitiveRootProps = {
 
 const COMPONENT_NAME = 'DialogPrimitive';
 
-const DialogPrimitiveRoot = ({ children, open = false, onOpenChange = () => {}, onClickOutside = () => {}, className, ...props } : DialogPrimitiveRootProps) => {
+const DialogPrimitiveRoot = forwardRef<HTMLDivElement, DialogPrimitiveRootProps>(({ children, open = false, onOpenChange = () => {}, onClickOutside = () => {}, className, ...props }, ref) => {
     const [isOpen, setIsOpen] = useState(open);
     const handleOpenChange = (open: boolean) => {
         setIsOpen(open);
@@ -39,12 +39,12 @@ const DialogPrimitiveRoot = ({ children, open = false, onOpenChange = () => {}, 
     const contextProps = { isOpen, handleOpenChange, floaterContext, handleOverlayClick, getReferenceProps, getFloatingProps, getItemProps, refs, floatingStyles };
     return (
         <DialogPrimitiveContext.Provider value={contextProps}>
-            <div {...props} className={className}>
+            <div ref={ref} {...props} className={className}>
                 {children}
             </div>
         </DialogPrimitiveContext.Provider>
     );
-};
+});
 
 DialogPrimitiveRoot.displayName = COMPONENT_NAME;
 export default DialogPrimitiveRoot;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
@@ -1,7 +1,8 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
+import Floater from '~/core/primitives/Floater';
 
 export type DialogPrimitiveTriggerProps = {
     children: React.ReactNode;
@@ -9,12 +10,14 @@ export type DialogPrimitiveTriggerProps = {
     className?: string;
 }
 
-const DialogPrimitiveTrigger = ({ children, asChild, className = '', ...props } : DialogPrimitiveTriggerProps) => {
+const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTriggerProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { handleOpenChange, getReferenceProps, refs } = useContext(DialogPrimitiveContext);
+
+    const mergedRef = Floater.useMergeRefs([refs.setReference, ref]);
 
     return (
         <ButtonPrimitive
-            ref={refs?.setReference || null}
+            ref={mergedRef}
             asChild={asChild}
             className={className}
             onClick={() => handleOpenChange(true)}
@@ -24,6 +27,6 @@ const DialogPrimitiveTrigger = ({ children, asChild, className = '', ...props } 
             {children}
         </ButtonPrimitive>
     );
-};
+});
 
 export default DialogPrimitiveTrigger;


### PR DESCRIPTION
## Summary
- refactor AlertDialog subcomponents to forward refs to underlying DOM nodes
- wrap VisuallyHidden and dialog primitives with `forwardRef`
- add coverage verifying ref forwarding and warning-free rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98993e6888331ba0b908089b506b4