### PR TITLE
refactor: forward refs for Callout and VisuallyHidden

### DIFF
--- a/src/components/ui/Callout/fragments/CalloutIcon.tsx
+++ b/src/components/ui/Callout/fragments/CalloutIcon.tsx
@@ -2,19 +2,30 @@ import React, { useContext } from 'react';
 import CalloutContext from '../contexts/CalloutContext';
 import clsx from 'clsx';
 import Primitive from '~/core/primitives/Primitive';
-type CalloutIconProps = {
-    children: React.ReactNode;
-    className?: string;
-}
 
-function CalloutIcon({ children, className = '', ...props }:CalloutIconProps) {
-    const { rootClass } = useContext(CalloutContext);
+const COMPONENT_NAME = 'CalloutIcon';
 
-    return (
-        <Primitive.span className={clsx(`${rootClass}-icon`, className)} {...props}>
-            {children}
-        </Primitive.span>
-    );
-}
+type CalloutIconElement = React.ElementRef<typeof Primitive.span>;
+type PrimitiveSpanProps = React.ComponentPropsWithoutRef<typeof Primitive.span>;
+
+type CalloutIconProps = PrimitiveSpanProps;
+
+const CalloutIcon = React.forwardRef<CalloutIconElement, CalloutIconProps>(
+    ({ children, className = '', ...props }, ref) => {
+        const { rootClass } = useContext(CalloutContext);
+
+        return (
+            <Primitive.span
+                ref={ref}
+                className={clsx(`${rootClass}-icon`, className)}
+                {...props}
+            >
+                {children}
+            </Primitive.span>
+        );
+    }
+);
+
+CalloutIcon.displayName = COMPONENT_NAME;
 
 export default CalloutIcon;

--- a/src/components/ui/Callout/fragments/CalloutRoot.tsx
+++ b/src/components/ui/Callout/fragments/CalloutRoot.tsx
@@ -7,31 +7,41 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'Callout';
 
-type CalloutRootProps = {
-    children?: React.ReactNode;
-    className?: string | '' ;
+type CalloutRootElement = React.ElementRef<typeof Primitive.div>;
+type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
+
+type CalloutRootProps = PrimitiveDivProps & {
     color?: string;
     variant?: string;
     size?: string;
     customRootClass?: string;
-    asChild?: boolean
-    props?: Record<any, any>[]
-}
-
-const CalloutRoot = ({ children, asChild = false, className = '', color = '', variant = '', size = '', customRootClass = '', ...props }: CalloutRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const dataAttributes = useCreateDataAttribute('callout', { variant, size });
-    const accentAttributes = useCreateDataAccentColorAttribute(color);
-    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
-
-    return (
-        <CalloutContext.Provider value={{ rootClass }}>
-            <Primitive.div asChild={asChild} className={clsx(rootClass, className)} {...composedAttributes()} {...props}>
-                {children}
-            </Primitive.div>
-        </CalloutContext.Provider>
-    );
 };
+
+const CalloutRoot = React.forwardRef<CalloutRootElement, CalloutRootProps>(
+    (
+        { children, asChild = false, className = '', color = '', variant = '', size = '', customRootClass = '', ...props },
+        ref
+    ) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const dataAttributes = useCreateDataAttribute('callout', { variant, size });
+        const accentAttributes = useCreateDataAccentColorAttribute(color);
+        const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+
+        return (
+            <CalloutContext.Provider value={{ rootClass }}>
+                <Primitive.div
+                    ref={ref}
+                    asChild={asChild}
+                    className={clsx(rootClass, className)}
+                    {...composedAttributes()}
+                    {...props}
+                >
+                    {children}
+                </Primitive.div>
+            </CalloutContext.Provider>
+        );
+    }
+);
 
 CalloutRoot.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Callout/fragments/CalloutText.tsx
+++ b/src/components/ui/Callout/fragments/CalloutText.tsx
@@ -3,19 +3,29 @@ import CalloutContext from '../contexts/CalloutContext';
 import clsx from 'clsx';
 import Primitive from '~/core/primitives/Primitive';
 
-type CalloutTextProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+const COMPONENT_NAME = 'CalloutText';
 
-function CalloutText({ children, className, ...props }:CalloutTextProps) {
-    const { rootClass } = useContext(CalloutContext);
+type CalloutTextElement = React.ElementRef<typeof Primitive.p>;
+type PrimitivePProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
 
-    return (
-        <Primitive.p className={clsx(`${rootClass}-text`, className)} {...props}>
-            {children}
-        </Primitive.p>
-    );
-}
+type CalloutTextProps = PrimitivePProps;
+
+const CalloutText = React.forwardRef<CalloutTextElement, CalloutTextProps>(
+    ({ children, className = '', ...props }, ref) => {
+        const { rootClass } = useContext(CalloutContext);
+
+        return (
+            <Primitive.p
+                ref={ref}
+                className={clsx(`${rootClass}-text`, className)}
+                {...props}
+            >
+                {children}
+            </Primitive.p>
+        );
+    }
+);
+
+CalloutText.displayName = COMPONENT_NAME;
 
 export default CalloutText;

--- a/src/components/ui/Callout/tests/Callout.test.tsx
+++ b/src/components/ui/Callout/tests/Callout.test.tsx
@@ -52,7 +52,28 @@ describe('Callout', () => {
             const element = screen.getByText('Test Content').parentElement;
             expect(element).toHaveAttribute('data-callout-size', 'large');
         });
-    });
+
+        it('forwards ref to root element', () => {
+            const ref = React.createRef<HTMLDivElement>();
+            render(
+                <Callout.Root ref={ref}>
+                    <div>Test Content</div>
+                </Callout.Root>
+            );
+            expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        });
+
+        it('renders without console warnings', () => {
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+            render(
+                <Callout.Root>
+                    <div>Test Content</div>
+                </Callout.Root>
+            );
+            expect(warnSpy).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+        });
 
     describe('Callout.Icon', () => {
         it('renders icon content correctly', () => {
@@ -77,7 +98,19 @@ describe('Callout', () => {
             const iconElement = screen.getByText('Icon').parentElement;
             expect(iconElement).toHaveClass('icon-class');
         });
-    });
+
+        it('forwards ref to icon element', () => {
+            const ref = React.createRef<HTMLSpanElement>();
+            render(
+                <Callout.Root>
+                    <Callout.Icon ref={ref}>
+                        <span>Icon</span>
+                    </Callout.Icon>
+                </Callout.Root>
+            );
+            expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+        });
+        });
 
     describe('Callout.Text', () => {
         it('renders text content correctly', () => {
@@ -98,7 +131,17 @@ describe('Callout', () => {
             const textElement = screen.getByText('Callout Text');
             expect(textElement).toHaveClass('text-class');
         });
-    });
+
+        it('forwards ref to text element', () => {
+            const ref = React.createRef<HTMLParagraphElement>();
+            render(
+                <Callout.Root>
+                    <Callout.Text ref={ref}>Callout Text</Callout.Text>
+                </Callout.Root>
+            );
+            expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+        });
+        });
 
     describe('Callout Composition', () => {
         it('renders complete callout with all parts', () => {

--- a/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
@@ -6,13 +6,13 @@ import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'VisuallyHidden';
 
-export type VisuallyHiddenProps = {
-    children: React.ReactNode;
+type VisuallyHiddenElement = React.ElementRef<typeof Primitive.div>;
+type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
+
+export type VisuallyHiddenProps = PrimitiveDivProps & {
     customRootClass?: string;
-    className?: string;
-    asChild?: boolean;
     style?: CSSProperties;
-} & React.HTMLAttributes<HTMLDivElement>;
+};
 
 const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     position: 'absolute',
@@ -29,25 +29,22 @@ const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     userSelect: 'none'
 } as const;
 
-const VisuallyHidden = ({
-    children,
-    customRootClass,
-    className,
-    style = {},
-    ...props
-}: VisuallyHiddenProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const VisuallyHidden = React.forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(
+    ({ children, customRootClass, className, style = {}, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    return (
-        <Primitive.div
-            className={clsx(rootClass, className)}
-            style={{ ...VISUALLY_HIDDEN_STYLES, ...style }} // overriding possible
-            {...props}
-        >
-            {children}
-        </Primitive.div>
-    );
-};
+        return (
+            <Primitive.div
+                ref={ref}
+                className={clsx(rootClass, className)}
+                style={{ ...VISUALLY_HIDDEN_STYLES, ...style }} // overriding possible
+                {...props}
+            >
+                {children}
+            </Primitive.div>
+        );
+    }
+);
 
 VisuallyHidden.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
+++ b/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
@@ -146,4 +146,17 @@ describe('VisuallyHidden Component', () => {
         expect(screen.getByText('content with')).toBeInTheDocument();
         expect(screen.getByText('formatting')).toBeInTheDocument();
     });
+
+    test('forwards ref to underlying element', () => {
+        const ref = React.createRef();
+        render(<VisuallyHidden ref={ref}>Hidden content</VisuallyHidden>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+
+    test('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<VisuallyHidden>Hidden content</VisuallyHidden>);
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Callout subcomponents to forward refs and support typed props
- add forwardRef + typing to VisuallyHidden
- add tests ensuring refs and warnings behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b989c62f0483318cd85a02a5a322aa