### PR TITLE
refactor: forward refs for checkbox components

### DIFF
--- a/src/components/ui/Checkbox/fragments/CheckboxIndicator.tsx
+++ b/src/components/ui/Checkbox/fragments/CheckboxIndicator.tsx
@@ -1,16 +1,17 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxPrimitiveIndicator from '~/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator';
 import CheckboxContext from '../context/CheckboxContext';
 import clsx from 'clsx';
 
+export type CheckboxIndicatorElement = ElementRef<typeof CheckboxPrimitiveIndicator>;
 export type CheckboxIndicatorProps = {
     children?: React.ReactNode;
     className?: string;
-}
+} & Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitiveIndicator>, 'children'>;
 
-const CheckboxIndicator = ({ children, className = '', ...props }: CheckboxIndicatorProps) => {
+const CheckboxIndicator = forwardRef<CheckboxIndicatorElement, CheckboxIndicatorProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(CheckboxContext);
-    return <CheckboxPrimitiveIndicator {...props}>
+    return <CheckboxPrimitiveIndicator ref={ref} {...props}>
         <svg
             width="15"
             height="15"
@@ -28,6 +29,8 @@ const CheckboxIndicator = ({ children, className = '', ...props }: CheckboxIndic
         </svg>
         {children}
     </CheckboxPrimitiveIndicator>;
-};
+});
+
+CheckboxIndicator.displayName = 'CheckboxIndicator';
 
 export default CheckboxIndicator;

--- a/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
+++ b/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import CheckboxPrimitiveRoot, { CheckboxPrimitiveRootProps } from '~/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import CheckboxPrimitiveRoot from '~/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot';
 import { customClassSwitcher } from '~/core';
 import CheckboxContext from '../context/CheckboxContext';
 import { clsx } from 'clsx';
@@ -7,14 +7,15 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'Checkbox';
 
+export type CheckboxRootElement = ElementRef<typeof CheckboxPrimitiveRoot>;
 export type CheckboxRootProps = {
     customRootClass?: string;
     color?: string;
     variant?: string;
     size?: string;
-} & CheckboxPrimitiveRootProps
+} & ComponentPropsWithoutRef<typeof CheckboxPrimitiveRoot>;
 
-const CheckboxRoot = ({ children, className = '', customRootClass, color = '', variant, size, ...props }: CheckboxRootProps) => {
+const CheckboxRoot = forwardRef<CheckboxRootElement, CheckboxRootProps>(({ children, className = '', customRootClass, color = '', variant, size, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('checkbox', { variant, size });
@@ -22,10 +23,12 @@ const CheckboxRoot = ({ children, className = '', customRootClass, color = '', v
     const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
     return <CheckboxContext.Provider value={{ rootClass }}>
-        <CheckboxPrimitiveRoot className={clsx(rootClass, className)} {...props} {...composedAttributes()}>
+        <CheckboxPrimitiveRoot ref={ref} className={clsx(rootClass, className)} {...props} {...composedAttributes()}>
             {children}
         </CheckboxPrimitiveRoot>
     </CheckboxContext.Provider>;
-};
+});
+
+CheckboxRoot.displayName = COMPONENT_NAME;
 
 export default CheckboxRoot;

--- a/src/components/ui/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox/tests/Checkbox.test.tsx
@@ -120,6 +120,23 @@ describe('Checkbox', () => {
         expect(button).toHaveClass('my-checkbox');
     });
 
+    it('forwards ref to the trigger', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const { container } = render(
+            <Checkbox.Root ref={ref}>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button');
+        expect(ref.current).toBe(button);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
     it('warns and renders null on direct Checkbox usage', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const { container } = render(<Checkbox />);

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsContent.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsContent.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 
-export type CheckboxCardsItemProps ={
-    children: React.ReactNode
-}
-const CheckboxCardsContent = ({ children, ...props }: CheckboxCardsItemProps) => {
+export type CheckboxCardsContentElement = ElementRef<typeof CheckboxGroupPrimitive.Content>;
+export type CheckboxCardsContentProps = ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Content>;
+
+const CheckboxCardsContent = forwardRef<CheckboxCardsContentElement, CheckboxCardsContentProps>(({ children, ...props }, ref) => {
     const { rootClass } = React.useContext(CheckboxCardsRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Content className={`${rootClass}-content`} {...props} >{children}</CheckboxGroupPrimitive.Content>
+        <CheckboxGroupPrimitive.Content ref={ref} className={`${rootClass}-content`} {...props} >{children}</CheckboxGroupPrimitive.Content>
     );
-};
+});
+
+CheckboxCardsContent.displayName = 'CheckboxCardsContent';
 
 export default CheckboxCardsContent;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsIndicator.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsIndicator.tsx
@@ -1,20 +1,17 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 import clsx from 'clsx';
 
-const TickIcon = ({ className }: {className?: string}) => (
-    <svg width="15" height="15" viewBox="0 0 15 15" className={className} fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>
-);
+export type CheckboxCardsIndicatorElement = ElementRef<'svg'>;
+export type CheckboxCardsIndicatorProps = ComponentPropsWithoutRef<'svg'>;
 
-export type CheckboxCardsIndicatorProps = {
-    className?: string
-}
-
-const CheckboxCardsIndicator = ({ className }: CheckboxCardsIndicatorProps) => {
+const CheckboxCardsIndicator = forwardRef<CheckboxCardsIndicatorElement, CheckboxCardsIndicatorProps>(({ className, ...props }, ref) => {
     const { rootClass } = useContext(CheckboxCardsRootContext);
     return (
-        <TickIcon className={clsx(`${rootClass}-tick-icon`, className)}/>
+        <svg ref={ref} width="15" height="15" viewBox="0 0 15 15" className={clsx(`${rootClass}-tick-icon`, className)} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>
     );
-};
+});
+
+CheckboxCardsIndicator.displayName = 'CheckboxCardsIndicator';
 
 export default CheckboxCardsIndicator;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsItem.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsItem.tsx
@@ -1,21 +1,23 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import clsx from 'clsx';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 
+export type CheckboxCardsItemElement = ElementRef<typeof CheckboxGroupPrimitive.Trigger>;
 export type CheckboxCardsItemProps = {
-    children?: React.ReactNode
-    className?: string
-    value: string
-}
-const CheckboxCardsItem = ({ children, className = '', value, ...props }: CheckboxCardsItemProps) => {
+    value: string;
+} & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Trigger>;
+
+const CheckboxCardsItem = forwardRef<CheckboxCardsItemElement, CheckboxCardsItemProps>(({ children, className = '', value, ...props }, ref) => {
     const { rootClass } = React.useContext(CheckboxCardsRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Trigger className={clsx(`${rootClass}-item`, className)} value={value} {...props}>
+        <CheckboxGroupPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-item`, className)} value={value} {...props}>
             {children}
         </CheckboxGroupPrimitive.Trigger>
     );
-};
+});
+
+CheckboxCardsItem.displayName = 'CheckboxCardsItem';
 
 export default CheckboxCardsItem;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
@@ -7,17 +7,15 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'CheckboxCards';
 
+export type CheckboxCardsRootElement = ElementRef<typeof CheckboxGroupPrimitive.Root>;
 export type CheckboxCardsRootProps = {
-    children: React.ReactNode;
-    className?: string
-    customRootClass?: string
-    color?: string
-    variant?: string
-    size?: string
-    name?: string
-}& CheckboxGroupPrimitiveProps.Root
+    customRootClass?: string;
+    color?: string;
+    variant?: string;
+    size?: string;
+} & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Root>;
 
-const CheckboxCardsRoot = ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }: CheckboxCardsRootProps) => {
+const CheckboxCardsRoot = forwardRef<CheckboxCardsRootElement, CheckboxCardsRootProps>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('checkbox-cards', { variant, size });
@@ -26,7 +24,7 @@ const CheckboxCardsRoot = ({ children, customRootClass = '', className = '', col
 
     return (
 
-        <CheckboxGroupPrimitive.Root className={clsx(`${rootClass}-root`, rootClass, className)} {...props} {...composedAttributes()}>
+        <CheckboxGroupPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, rootClass, className)} {...props} {...composedAttributes()}>
             <CheckboxCardsRootContext.Provider value={{ rootClass }}>
 
                 {children}
@@ -34,6 +32,8 @@ const CheckboxCardsRoot = ({ children, customRootClass = '', className = '', col
             </CheckboxCardsRootContext.Provider>
         </CheckboxGroupPrimitive.Root>
     );
-};
+});
+
+CheckboxCardsRoot.displayName = COMPONENT_NAME;
 
 export default CheckboxCardsRoot;

--- a/src/components/ui/CheckboxCards/tests/CheckboxCards.test.tsx
+++ b/src/components/ui/CheckboxCards/tests/CheckboxCards.test.tsx
@@ -132,4 +132,26 @@ describe('CheckboxCards', () => {
         );
         warn.mockRestore();
     });
+
+    it('forwards ref to item trigger', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(
+            <CheckboxCards.Root name="fruits">
+                <CheckboxCards.Item value="apple" ref={ref}>
+          Apple
+                    <CheckboxCards.Content>
+                        <CheckboxCards.Indicator />
+                    </CheckboxCards.Content>
+                </CheckboxCards.Item>
+            </CheckboxCards.Root>
+        );
+        const checkbox = screen.getByRole('checkbox');
+        expect(ref.current).toBe(checkbox);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupIndicator.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupIndicator.tsx
@@ -1,20 +1,17 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxGroupRootContext from '../context/CheckboxGroupRootContext';
 import clsx from 'clsx';
 
-const TickIcon = ({ className }: {className?: string}) => (
-    <svg width="15" height="15" viewBox="0 0 15 15" className={className} fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>
-);
+export type CheckboxGroupIndicatorElement = ElementRef<'svg'>;
+export type CheckboxGroupIndicatorProps = ComponentPropsWithoutRef<'svg'>;
 
-export type CheckboxGroupIndicatorProps = {
-    className?: string
-}
-
-const CheckboxGroupIndicator = ({ className }: CheckboxGroupIndicatorProps) => {
+const CheckboxGroupIndicator = forwardRef<CheckboxGroupIndicatorElement, CheckboxGroupIndicatorProps>(({ className, ...props }, ref) => {
     const { rootClass } = useContext(CheckboxGroupRootContext);
     return (
-        <TickIcon className={clsx(`${rootClass}-tick-icon`, className)}/>
+        <svg ref={ref} width="15" height="15" viewBox="0 0 15 15" className={clsx(`${rootClass}-tick-icon`, className)} fill="none" xmlns="http://www.w3.org/2000/svg" {...props}><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>
     );
-};
+});
+
+CheckboxGroupIndicator.displayName = 'CheckboxGroupIndicator';
 
 export default CheckboxGroupIndicator;

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupLabel.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupLabel.tsx
@@ -1,21 +1,21 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxGroupRootContext from '../context/CheckboxGroupRootContext';
 import clsx from 'clsx';
 import Primitive from '~/core/primitives/Primitive';
 
-export type CheckboxGroupLabelProps = {
-    children: React.ReactNode
-    className?: string
-}
+export type CheckboxGroupLabelElement = ElementRef<typeof Primitive.label>;
+export type CheckboxGroupLabelProps = ComponentPropsWithoutRef<typeof Primitive.label>;
 
-const CheckboxGroupLabel = ({ children, className = '' }: CheckboxGroupLabelProps) => {
+const CheckboxGroupLabel = forwardRef<CheckboxGroupLabelElement, CheckboxGroupLabelProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(CheckboxGroupRootContext);
 
     return (
-        <Primitive.label className={clsx(`${rootClass}-label`, className)} >
+        <Primitive.label ref={ref} className={clsx(`${rootClass}-label`, className)} {...props}>
             {children}
         </Primitive.label>
     );
-};
+});
+
+CheckboxGroupLabel.displayName = 'CheckboxGroupLabel';
 
 export default CheckboxGroupLabel;

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxGroupRootContext from '../context/CheckboxGroupRootContext';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
@@ -7,17 +7,15 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'CheckboxGroup';
 
+export type CheckboxGroupRootElement = ElementRef<typeof CheckboxGroupPrimitive.Root>;
 export type CheckboxGroupRootProps = {
-    children: React.ReactNode;
-    className?: string
-    customRootClass?: string
-    color?: string
-    variant?: string
-    size?: string
-    name?: string
-}& CheckboxGroupPrimitiveProps.Root
+    customRootClass?: string;
+    color?: string;
+    variant?: string;
+    size?: string;
+} & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Root>;
 
-const CheckboxGroupRoot = ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }: CheckboxGroupRootProps) => {
+const CheckboxGroupRoot = forwardRef<CheckboxGroupRootElement, CheckboxGroupRootProps>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('checkbox-group', { variant, size });
@@ -26,7 +24,7 @@ const CheckboxGroupRoot = ({ children, customRootClass = '', className = '', col
 
     return (
 
-        <CheckboxGroupPrimitive.Root className={clsx(`${rootClass}-root`, rootClass, className)} {...props} {...composedAttributes()}>
+        <CheckboxGroupPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, rootClass, className)} {...props} {...composedAttributes()}>
             <CheckboxGroupRootContext.Provider value={{ rootClass }}>
 
                 {children}
@@ -34,6 +32,8 @@ const CheckboxGroupRoot = ({ children, customRootClass = '', className = '', col
             </CheckboxGroupRootContext.Provider>
         </CheckboxGroupPrimitive.Root>
     );
-};
+});
+
+CheckboxGroupRoot.displayName = COMPONENT_NAME;
 
 export default CheckboxGroupRoot;

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupTrigger.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupTrigger.tsx
@@ -1,23 +1,25 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import clsx from 'clsx';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxGroupRootContext from '../context/CheckboxGroupRootContext';
 
+export type CheckboxGroupTriggerElement = ElementRef<typeof CheckboxGroupPrimitive.Trigger>;
 export type CheckboxGroupTriggerProps = {
-    children?: React.ReactNode
-    className?: string
-    value?: string
-}& CheckboxGroupPrimitiveProps.Trigger
-const CheckboxGroupTrigger = ({ children, className = '', value, ...props }: CheckboxGroupTriggerProps) => {
+    value?: string;
+} & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Trigger>;
+
+const CheckboxGroupTrigger = forwardRef<CheckboxGroupTriggerElement, CheckboxGroupTriggerProps>(({ children, className = '', value, ...props }, ref) => {
     const { rootClass } = React.useContext(CheckboxGroupRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)} value={value} {...props}>
-            <CheckboxGroupPrimitive.Content >
+        <CheckboxGroupPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-trigger`, className)} value={value} {...props}>
+            <CheckboxGroupPrimitive.Content>
                 {children}
             </CheckboxGroupPrimitive.Content>
         </CheckboxGroupPrimitive.Trigger>
     );
-};
+});
+
+CheckboxGroupTrigger.displayName = 'CheckboxGroupTrigger';
 
 export default CheckboxGroupTrigger;

--- a/src/components/ui/CheckboxGroup/tests/CheckboxGroup.test.tsx
+++ b/src/components/ui/CheckboxGroup/tests/CheckboxGroup.test.tsx
@@ -135,4 +135,26 @@ describe('CheckboxGroup', () => {
         );
         warn.mockRestore();
     });
+
+    it('forwards ref to trigger', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(
+            <CheckboxGroup.Root name="fruits">
+                <CheckboxGroup.Label>
+                    <CheckboxGroup.Trigger value="apple" ref={ref}>
+                        <CheckboxGroup.Indicator />
+                    </CheckboxGroup.Trigger>
+          Apple
+                </CheckboxGroup.Label>
+            </CheckboxGroup.Root>
+        );
+        const checkbox = screen.getByRole('checkbox', { name: 'Apple' });
+        expect(ref.current).toBe(checkbox);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
@@ -1,18 +1,16 @@
 'use client';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'VisuallyHidden';
 
+export type VisuallyHiddenElement = ElementRef<typeof Primitive.div>;
 export type VisuallyHiddenProps = {
-    children: React.ReactNode;
     customRootClass?: string;
-    className?: string;
-    asChild?: boolean;
     style?: CSSProperties;
-} & React.HTMLAttributes<HTMLDivElement>;
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
 
 const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     position: 'absolute',
@@ -29,17 +27,12 @@ const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     userSelect: 'none'
 } as const;
 
-const VisuallyHidden = ({
-    children,
-    customRootClass,
-    className,
-    style = {},
-    ...props
-}: VisuallyHiddenProps) => {
+const VisuallyHidden = forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(({ children, customRootClass, className, style = {}, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
         <Primitive.div
+            ref={ref}
             className={clsx(rootClass, className)}
             style={{ ...VISUALLY_HIDDEN_STYLES, ...style }} // overriding possible
             {...props}
@@ -47,7 +40,7 @@ const VisuallyHidden = ({
             {children}
         </Primitive.div>
     );
-};
+});
 
 VisuallyHidden.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
+++ b/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
@@ -146,4 +146,16 @@ describe('VisuallyHidden Component', () => {
         expect(screen.getByText('content with')).toBeInTheDocument();
         expect(screen.getByText('formatting')).toBeInTheDocument();
     });
+
+    test('forwards ref to underlying element', () => {
+        const ref = React.createRef();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<VisuallyHidden ref={ref}>Hidden content</VisuallyHidden>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
@@ -1,19 +1,21 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 
-export type CheckboxPrimitiveIndicatorProps = {
-    className?: string
-    children: React.ReactNode
-}
+export type CheckboxPrimitiveIndicatorElement = ElementRef<'span'>;
+export type CheckboxPrimitiveIndicatorProps = ComponentPropsWithoutRef<'span'> & {
+    children: React.ReactNode;
+};
 
-const CheckboxPrimitiveIndicator = ({ children, className = '', ...props }: CheckboxPrimitiveIndicatorProps) => {
+const CheckboxPrimitiveIndicator = forwardRef<CheckboxPrimitiveIndicatorElement, CheckboxPrimitiveIndicatorProps>(({ children, className = '', ...props }, ref) => {
     const { isChecked } = React.useContext(CheckboxPrimitiveContext);
 
     if (!isChecked) return null;
 
-    return <span className={className} {...props}>{children}</span>;
-};
+    return <span ref={ref} className={className} {...props}>{children}</span>;
+});
+
+CheckboxPrimitiveIndicator.displayName = 'CheckboxPrimitiveIndicator';
 
 export default CheckboxPrimitiveIndicator;

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
@@ -1,24 +1,22 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 import CheckboxPrimitiveTrigger from './CheckboxPrimitiveTrigger';
 import useControllableState from '~/core/hooks/useControllableState';
 
+export type CheckboxPrimitiveRootElement = ElementRef<typeof CheckboxPrimitiveTrigger>;
 export type CheckboxPrimitiveRootProps = {
-    children: React.ReactNode,
-    className?: string,
-    checked?: boolean,
-    defaultChecked? : boolean,
-    onCheckedChange? : () => void,
-    disabled?: boolean
-    required?: boolean
-    name?: string
-    value?: string
-    id?: string
-};
+    children: React.ReactNode;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    onCheckedChange?: () => void;
+    name?: string;
+    value?: string;
+    id?: string;
+} & ComponentPropsWithoutRef<typeof CheckboxPrimitiveTrigger>;
 
-const CheckboxPrimitiveRoot = ({ children, className = '', checked, defaultChecked = false, onCheckedChange, disabled, required, name, value, id, ...props }: CheckboxPrimitiveRootProps) => {
+const CheckboxPrimitiveRoot = forwardRef<CheckboxPrimitiveRootElement, CheckboxPrimitiveRootProps>(({ children, className = '', checked, defaultChecked = false, onCheckedChange, disabled, required, name, value, id, ...props }, ref) => {
     const [isChecked, setIsChecked] = useControllableState(
         checked,
         defaultChecked,
@@ -34,7 +32,7 @@ const CheckboxPrimitiveRoot = ({ children, className = '', checked, defaultCheck
     };
 
     return <CheckboxPrimitiveContext.Provider value={contextValues}>
-        <CheckboxPrimitiveTrigger className={className} {...props}>
+        <CheckboxPrimitiveTrigger ref={ref} className={className} disabled={disabled} required={required} {...props}>
             {children}
         </CheckboxPrimitiveTrigger>
         <input
@@ -46,6 +44,8 @@ const CheckboxPrimitiveRoot = ({ children, className = '', checked, defaultCheck
                 transform: 'translateX(-100%)'
             }} name={name} value={value} checked={isChecked} disabled={disabled} required={required} readOnly {...props}/>
     </CheckboxPrimitiveContext.Provider>;
-};
+});
+
+CheckboxPrimitiveRoot.displayName = 'CheckboxPrimitiveRoot';
 
 export default CheckboxPrimitiveRoot;

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import React, { HTMLAttributes } from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 
-export type CheckboxPrimitiveTriggerProps = {
-     children: React.ReactNode;
-     className?: string;
-    }& HTMLAttributes<HTMLButtonElement>;
+export type CheckboxPrimitiveTriggerElement = ElementRef<typeof ButtonPrimitive>;
+export type CheckboxPrimitiveTriggerProps = ComponentPropsWithoutRef<typeof ButtonPrimitive>;
 
-const CheckboxPrimitiveTrigger = ({ children, className = '', ...props }: CheckboxPrimitiveTriggerProps) => {
+const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, CheckboxPrimitiveTriggerProps>(({ children, className = '', ...props }, ref) => {
     const { isChecked, setIsChecked, id, required, disabled } = React.useContext(CheckboxPrimitiveContext);
-    return <ButtonPrimitive onClick={() => setIsChecked(!isChecked)} role="checkbox" id={id} aria-checked={isChecked} aria-required={required} data-checked={isChecked} disabled={disabled} data-disabled={disabled} {...props} className={className}>{children}</ButtonPrimitive>;
-};
+    return <ButtonPrimitive ref={ref} onClick={() => setIsChecked(!isChecked)} role="checkbox" id={id} aria-checked={isChecked} aria-required={required} data-checked={isChecked} disabled={disabled} data-disabled={disabled} className={className} {...props}>{children}</ButtonPrimitive>;
+});
+
+CheckboxPrimitiveTrigger.displayName = 'CheckboxPrimitiveTrigger';
 
 export default CheckboxPrimitiveTrigger;

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveContent.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveContent.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import CheckboxGroupPrimitiveTriggerContext from '../context/CheckboxGroupPrimitiveTriggerContext';
 
-export type CheckboxGroupPrimitiveContentProps = {
-    children?: React.ReactNode
-    className?: string
-}
-const CheckboxGroupPrimitiveContent = ({ children, className }: CheckboxGroupPrimitiveContentProps) => {
+export type CheckboxGroupPrimitiveContentElement = ElementRef<'span'>;
+export type CheckboxGroupPrimitiveContentProps = ComponentPropsWithoutRef<'span'>;
+
+const CheckboxGroupPrimitiveContent = forwardRef<CheckboxGroupPrimitiveContentElement, CheckboxGroupPrimitiveContentProps>(({ children, className, ...props }, ref) => {
     const { isChecked } = React.useContext(CheckboxGroupPrimitiveTriggerContext);
 
-    return <span className={className}>
+    return <span ref={ref} className={className} {...props}>
         {isChecked ? children : null}
     </span>;
-};
+});
+
+CheckboxGroupPrimitiveContent.displayName = 'CheckboxGroupPrimitiveContent';
 
 export default CheckboxGroupPrimitiveContent;

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveRoot.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveRoot.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import { useControllableState } from '~/core/hooks/useControllableState';
 import CheckboxGroupPrimitiveContext from '../context/CheckboxGroupPrimitiveContext';
 
+export type CheckboxGroupPrimitiveRootElement = ElementRef<'div'>;
 export type CheckboxGroupPrimitiveRootProps = {
-    children: React.ReactNode;
-    className?: string
     name?: string;
     required?: boolean;
     disabled?: boolean;
@@ -15,9 +14,9 @@ export type CheckboxGroupPrimitiveRootProps = {
     defaultValue?: string[];
     value?: string[];
     onValueChange?: (value: string[]) => void;
-}
+} & ComponentPropsWithoutRef<'div'>;
 
-const CheckboxGroupPrimitiveRoot = ({ dir, orientation, loop, defaultValue = [], value, onValueChange, children, name, required, disabled, className = '', ...props }: CheckboxGroupPrimitiveRootProps) => {
+const CheckboxGroupPrimitiveRoot = forwardRef<CheckboxGroupPrimitiveRootElement, CheckboxGroupPrimitiveRootProps>(({ dir, orientation, loop, defaultValue = [], value, onValueChange, children, name, required, disabled, className = '', ...props }, ref) => {
     const [checkedValues, setCheckedValues] = useControllableState(
         value,
         defaultValue,
@@ -25,7 +24,7 @@ const CheckboxGroupPrimitiveRoot = ({ dir, orientation, loop, defaultValue = [],
     );
 
     return (
-        <div className={className} {...props}>
+        <div ref={ref} className={className} {...props}>
             <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
                 <CheckboxGroupPrimitiveContext.Provider value={{ checkedValues, setCheckedValues, name, required, disabled }}>
                     <RovingFocusGroup.Group>
@@ -35,6 +34,8 @@ const CheckboxGroupPrimitiveRoot = ({ dir, orientation, loop, defaultValue = [],
             </RovingFocusGroup.Root>
         </div>
     );
-};
+});
+
+CheckboxGroupPrimitiveRoot.displayName = 'CheckboxGroupPrimitiveRoot';
 
 export default CheckboxGroupPrimitiveRoot;

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveTrigger.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveTrigger.tsx
@@ -1,29 +1,32 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import CheckboxGroupPrimitiveContext from '../context/CheckboxGroupPrimitiveContext';
 import CheckboxGroupPrimitiveTriggerContext from '../context/CheckboxGroupPrimitiveTriggerContext';
 
+export type CheckboxGroupPrimitiveTriggerElement = ElementRef<'button'>;
 export type CheckboxGroupPrimitiveTriggerProps = {
-    children?: React.ReactNode
-    value: string
-    className?: string
-    required?: boolean
-    disabled?: boolean
-    checked?: boolean
-    onCheckedChange?: (checked: boolean) => void
-}
-const CheckboxGroupPrimitiveTrigger = ({ children, className = '', value, required, disabled, checked, onCheckedChange }: CheckboxGroupPrimitiveTriggerProps) => {
+    value: string;
+    required?: boolean;
+    disabled?: boolean;
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+} & ComponentPropsWithoutRef<'button'>;
+
+const CheckboxGroupPrimitiveTrigger = forwardRef<CheckboxGroupPrimitiveTriggerElement, CheckboxGroupPrimitiveTriggerProps>(({ children, className = '', value, required, disabled, checked, onCheckedChange, onClick, ...props }, ref) => {
     const { checkedValues, setCheckedValues, name, required: groupRequired, disabled: groupDisabled } = React.useContext(CheckboxGroupPrimitiveContext);
 
     const isChecked = checkedValues.includes(value);
 
-    const handleClick = (event : React.MouseEvent) => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
         event.preventDefault();
         event.stopPropagation();
         if (checkedValues.includes(value)) {
             setCheckedValues(checkedValues.filter((v) => v !== value));
+            onCheckedChange?.(false);
         } else if (!checkedValues.includes(value)) {
             setCheckedValues([...checkedValues, value]);
+            onCheckedChange?.(true);
         }
     };
 
@@ -31,18 +34,28 @@ const CheckboxGroupPrimitiveTrigger = ({ children, className = '', value, requir
         <div>
             <CheckboxGroupPrimitiveTriggerContext.Provider value={{ isChecked }}>
                 <RovingFocusGroup.Item>
-
-                    <button role="checkbox" type="button" onClick={handleClick} className={className} aria-checked={isChecked} disabled={disabled || groupDisabled} aria-required={required || groupRequired}>
+                    <button
+                        ref={ref}
+                        role="checkbox"
+                        type="button"
+                        onClick={handleClick}
+                        className={className}
+                        aria-checked={isChecked}
+                        disabled={disabled || groupDisabled}
+                        aria-required={required || groupRequired}
+                        {...props}
+                    >
                         {children}
                     </button>
-
                 </RovingFocusGroup.Item>
             </CheckboxGroupPrimitiveTriggerContext.Provider>
 
-            <input type="checkbox" checked={isChecked} name={name} value={value} style={{ display: 'none' }} required={required || groupRequired} disabled={disabled || groupDisabled} readOnly/>
+            <input type="checkbox" checked={isChecked} name={name} value={value} style={{ display: 'none' }} required={required || groupRequired} disabled={disabled || groupDisabled} readOnly />
 
         </div>
     );
-};
+});
+
+CheckboxGroupPrimitiveTrigger.displayName = 'CheckboxGroupPrimitiveTrigger';
 
 export default CheckboxGroupPrimitiveTrigger;


### PR DESCRIPTION
## Summary
- refactor Checkbox, CheckboxGroup, CheckboxCards, and VisuallyHidden to forward refs
- ensure primitive checkbox elements forward refs to DOM
- add tests covering ref forwarding and accessibility behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b989e21bcc8331a4807df74a793a2c