### PR TITLE
refactor: forward refs for CheckboxCards and VisuallyHidden

### DIFF
--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsContent.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsContent.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 
-export type CheckboxCardsItemProps ={
-    children: React.ReactNode
-}
-const CheckboxCardsContent = ({ children, ...props }: CheckboxCardsItemProps) => {
+export type CheckboxCardsContentProps = React.ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Content>;
+
+const CheckboxCardsContent = React.forwardRef<
+    React.ElementRef<typeof CheckboxGroupPrimitive.Content>,
+    CheckboxCardsContentProps
+>(({ children, ...props }, ref) => {
     const { rootClass } = React.useContext(CheckboxCardsRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Content className={`${rootClass}-content`} {...props} >{children}</CheckboxGroupPrimitive.Content>
+        <CheckboxGroupPrimitive.Content
+            ref={ref}
+            className={`${rootClass}-content`}
+            {...props}
+        >
+            {children}
+        </CheckboxGroupPrimitive.Content>
     );
-};
+});
+
+CheckboxCardsContent.displayName = 'CheckboxCardsContent';
 
 export default CheckboxCardsContent;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsIndicator.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsIndicator.tsx
@@ -2,19 +2,34 @@ import React, { useContext } from 'react';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 import clsx from 'clsx';
 
-const TickIcon = ({ className }: {className?: string}) => (
-    <svg width="15" height="15" viewBox="0 0 15 15" className={className} fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path></svg>
-);
+export type CheckboxCardsIndicatorProps = React.ComponentPropsWithoutRef<'svg'>;
 
-export type CheckboxCardsIndicatorProps = {
-    className?: string
-}
-
-const CheckboxCardsIndicator = ({ className }: CheckboxCardsIndicatorProps) => {
+const CheckboxCardsIndicator = React.forwardRef<
+    SVGSVGElement,
+    CheckboxCardsIndicatorProps
+>(({ className, ...props }, ref) => {
     const { rootClass } = useContext(CheckboxCardsRootContext);
     return (
-        <TickIcon className={clsx(`${rootClass}-tick-icon`, className)}/>
+        <svg
+            ref={ref}
+            width="15"
+            height="15"
+            viewBox="0 0 15 15"
+            className={clsx(`${rootClass}-tick-icon`, className)}
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                d="M11.4669 3.72684C11.7558 3.91574 11.8369 4.30308 11.648 4.59198L7.39799 11.092C7.29783 11.2452 7.13556 11.3467 6.95402 11.3699C6.77247 11.3931 6.58989 11.3355 6.45446 11.2124L3.70446 8.71241C3.44905 8.48022 3.43023 8.08494 3.66242 7.82953C3.89461 7.57412 4.28989 7.55529 4.5453 7.78749L6.75292 9.79441L10.6018 3.90792C10.7907 3.61902 11.178 3.53795 11.4669 3.72684Z"
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+            ></path>
+        </svg>
     );
-};
+});
+
+CheckboxCardsIndicator.displayName = 'CheckboxCardsIndicator';
 
 export default CheckboxCardsIndicator;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsItem.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsItem.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import clsx from 'clsx';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 
-export type CheckboxCardsItemProps = {
-    children?: React.ReactNode
-    className?: string
-    value: string
-}
-const CheckboxCardsItem = ({ children, className = '', value, ...props }: CheckboxCardsItemProps) => {
+export type CheckboxCardsItemProps = React.ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Trigger>;
+
+const CheckboxCardsItem = React.forwardRef<
+    React.ElementRef<typeof CheckboxGroupPrimitive.Trigger>,
+    CheckboxCardsItemProps
+>(({ children, className = '', value, ...props }, ref) => {
     const { rootClass } = React.useContext(CheckboxCardsRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Trigger className={clsx(`${rootClass}-item`, className)} value={value} {...props}>
+        <CheckboxGroupPrimitive.Trigger
+            ref={ref}
+            className={clsx(`${rootClass}-item`, className)}
+            value={value}
+            {...props}
+        >
             {children}
         </CheckboxGroupPrimitive.Trigger>
     );
-};
+});
+
+CheckboxCardsItem.displayName = 'CheckboxCardsItem';
 
 export default CheckboxCardsItem;

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CheckboxGroupPrimitive, { CheckboxGroupPrimitiveProps } from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
+import CheckboxGroupPrimitive from '~/core/primitives/CheckboxGroup/CheckboxGroupPrimitive';
 import CheckboxCardsRootContext from '../context/CheckboxCardsRootContext';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
@@ -7,17 +7,17 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'CheckboxCards';
 
-export type CheckboxCardsRootProps = {
-    children: React.ReactNode;
-    className?: string
-    customRootClass?: string
-    color?: string
-    variant?: string
-    size?: string
-    name?: string
-}& CheckboxGroupPrimitiveProps.Root
+export type CheckboxCardsRootProps = React.ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Root> & {
+    customRootClass?: string;
+    color?: string;
+    variant?: string;
+    size?: string;
+};
 
-const CheckboxCardsRoot = ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }: CheckboxCardsRootProps) => {
+const CheckboxCardsRoot = React.forwardRef<
+    React.ElementRef<typeof CheckboxGroupPrimitive.Root>,
+    CheckboxCardsRootProps
+>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('checkbox-cards', { variant, size });
@@ -25,15 +25,19 @@ const CheckboxCardsRoot = ({ children, customRootClass = '', className = '', col
     const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
     return (
-
-        <CheckboxGroupPrimitive.Root className={clsx(`${rootClass}-root`, rootClass, className)} {...props} {...composedAttributes()}>
+        <CheckboxGroupPrimitive.Root
+            ref={ref}
+            className={clsx(`${rootClass}-root`, rootClass, className)}
+            {...props}
+            {...composedAttributes()}
+        >
             <CheckboxCardsRootContext.Provider value={{ rootClass }}>
-
                 {children}
-
             </CheckboxCardsRootContext.Provider>
         </CheckboxGroupPrimitive.Root>
     );
-};
+});
+
+CheckboxCardsRoot.displayName = COMPONENT_NAME;
 
 export default CheckboxCardsRoot;

--- a/src/components/ui/CheckboxCards/tests/CheckboxCards.test.tsx
+++ b/src/components/ui/CheckboxCards/tests/CheckboxCards.test.tsx
@@ -123,6 +123,45 @@ describe('CheckboxCards', () => {
         expect(values).toEqual(expect.arrayContaining(['apple', 'banana']));
     });
 
+    it('forwards refs to subcomponents', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        const contentRef = React.createRef<HTMLSpanElement>();
+        const indicatorRef = React.createRef<SVGSVGElement>();
+
+        render(
+            <CheckboxCards.Root ref={rootRef} name="fruits" defaultValue={["apple"]}>
+                <CheckboxCards.Item ref={itemRef} value="apple">
+                    Apple
+                    <CheckboxCards.Content ref={contentRef}>
+                        <CheckboxCards.Indicator ref={indicatorRef} />
+                    </CheckboxCards.Content>
+                </CheckboxCards.Item>
+            </CheckboxCards.Root>
+        );
+
+        expect(rootRef.current?.tagName).toBe('DIV');
+        expect(itemRef.current?.tagName).toBe('BUTTON');
+        expect(contentRef.current?.tagName).toBe('SPAN');
+        expect(indicatorRef.current?.tagName.toLowerCase()).toBe('svg');
+    });
+
+    it('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(
+            <CheckboxCards.Root name="fruits">
+                <CheckboxCards.Item value="apple">
+                    Apple
+                    <CheckboxCards.Content>
+                        <CheckboxCards.Indicator />
+                    </CheckboxCards.Content>
+                </CheckboxCards.Item>
+            </CheckboxCards.Root>
+        );
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
     it('CheckboxCards itself renders null and warns', () => {
         const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const { container } = render(<CheckboxCards />);

--- a/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
@@ -6,13 +6,10 @@ import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'VisuallyHidden';
 
-export type VisuallyHiddenProps = {
-    children: React.ReactNode;
+export type VisuallyHiddenProps = React.ComponentPropsWithoutRef<typeof Primitive.div> & {
     customRootClass?: string;
-    className?: string;
-    asChild?: boolean;
     style?: CSSProperties;
-} & React.HTMLAttributes<HTMLDivElement>;
+};
 
 const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     position: 'absolute',
@@ -29,17 +26,15 @@ const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     userSelect: 'none'
 } as const;
 
-const VisuallyHidden = ({
-    children,
-    customRootClass,
-    className,
-    style = {},
-    ...props
-}: VisuallyHiddenProps) => {
+const VisuallyHidden = React.forwardRef<
+    React.ElementRef<typeof Primitive.div>,
+    VisuallyHiddenProps
+>(({ children, customRootClass, className, style = {}, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     return (
         <Primitive.div
+            ref={ref}
             className={clsx(rootClass, className)}
             style={{ ...VISUALLY_HIDDEN_STYLES, ...style }} // overriding possible
             {...props}
@@ -47,7 +42,7 @@ const VisuallyHidden = ({
             {children}
         </Primitive.div>
     );
-};
+});
 
 VisuallyHidden.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
+++ b/src/components/ui/VisuallyHidden/tests/VisuallyHidden.test.js
@@ -146,4 +146,11 @@ describe('VisuallyHidden Component', () => {
         expect(screen.getByText('content with')).toBeInTheDocument();
         expect(screen.getByText('formatting')).toBeInTheDocument();
     });
+
+    test('forwards ref to the underlying element', () => {
+        const ref = React.createRef();
+        render(<VisuallyHidden ref={ref}>Hidden content</VisuallyHidden>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current.tagName).toBe('DIV');
+    });
 });

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveContent.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveContent.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import CheckboxGroupPrimitiveTriggerContext from '../context/CheckboxGroupPrimitiveTriggerContext';
 
-export type CheckboxGroupPrimitiveContentProps = {
-    children?: React.ReactNode
-    className?: string
-}
-const CheckboxGroupPrimitiveContent = ({ children, className }: CheckboxGroupPrimitiveContentProps) => {
+export type CheckboxGroupPrimitiveContentProps = React.ComponentPropsWithoutRef<'span'>;
+
+const CheckboxGroupPrimitiveContent = React.forwardRef<
+    HTMLSpanElement,
+    CheckboxGroupPrimitiveContentProps
+>(({ children, className, ...props }, ref) => {
     const { isChecked } = React.useContext(CheckboxGroupPrimitiveTriggerContext);
 
-    return <span className={className}>
-        {isChecked ? children : null}
-    </span>;
-};
+    return (
+        <span ref={ref} className={className} {...props}>
+            {isChecked ? children : null}
+        </span>
+    );
+});
+
+CheckboxGroupPrimitiveContent.displayName = 'CheckboxGroupPrimitiveContent';
 
 export default CheckboxGroupPrimitiveContent;

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveRoot.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveRoot.tsx
@@ -17,24 +17,28 @@ export type CheckboxGroupPrimitiveRootProps = {
     onValueChange?: (value: string[]) => void;
 }
 
-const CheckboxGroupPrimitiveRoot = ({ dir, orientation, loop, defaultValue = [], value, onValueChange, children, name, required, disabled, className = '', ...props }: CheckboxGroupPrimitiveRootProps) => {
-    const [checkedValues, setCheckedValues] = useControllableState(
-        value,
-        defaultValue,
-        onValueChange
-    );
+const CheckboxGroupPrimitiveRoot = React.forwardRef<HTMLDivElement, CheckboxGroupPrimitiveRootProps>(
+    ({ dir, orientation, loop, defaultValue = [], value, onValueChange, children, name, required, disabled, className = '', ...props }, ref) => {
+        const [checkedValues, setCheckedValues] = useControllableState(
+            value,
+            defaultValue,
+            onValueChange
+        );
 
-    return (
-        <div className={className} {...props}>
-            <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
-                <CheckboxGroupPrimitiveContext.Provider value={{ checkedValues, setCheckedValues, name, required, disabled }}>
-                    <RovingFocusGroup.Group>
-                        {children}
-                    </RovingFocusGroup.Group>
-                </CheckboxGroupPrimitiveContext.Provider>
-            </RovingFocusGroup.Root>
-        </div>
-    );
-};
+        return (
+            <div ref={ref} className={className} {...props}>
+                <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
+                    <CheckboxGroupPrimitiveContext.Provider value={{ checkedValues, setCheckedValues, name, required, disabled }}>
+                        <RovingFocusGroup.Group>
+                            {children}
+                        </RovingFocusGroup.Group>
+                    </CheckboxGroupPrimitiveContext.Provider>
+                </RovingFocusGroup.Root>
+            </div>
+        );
+    }
+);
+
+CheckboxGroupPrimitiveRoot.displayName = 'CheckboxGroupPrimitiveRoot';
 
 export default CheckboxGroupPrimitiveRoot;

--- a/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveTrigger.tsx
+++ b/src/core/primitives/CheckboxGroup/fragments/CheckboxGroupPrimitiveTrigger.tsx
@@ -4,20 +4,21 @@ import CheckboxGroupPrimitiveContext from '../context/CheckboxGroupPrimitiveCont
 import CheckboxGroupPrimitiveTriggerContext from '../context/CheckboxGroupPrimitiveTriggerContext';
 
 export type CheckboxGroupPrimitiveTriggerProps = {
-    children?: React.ReactNode
-    value: string
-    className?: string
-    required?: boolean
-    disabled?: boolean
-    checked?: boolean
-    onCheckedChange?: (checked: boolean) => void
-}
-const CheckboxGroupPrimitiveTrigger = ({ children, className = '', value, required, disabled, checked, onCheckedChange }: CheckboxGroupPrimitiveTriggerProps) => {
+    value: string;
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    required?: boolean;
+} & React.ComponentPropsWithoutRef<'button'>;
+
+const CheckboxGroupPrimitiveTrigger = React.forwardRef<
+    HTMLButtonElement,
+    CheckboxGroupPrimitiveTriggerProps
+>(({ children, className = '', value, required, disabled, checked, onCheckedChange, ...props }, ref) => {
     const { checkedValues, setCheckedValues, name, required: groupRequired, disabled: groupDisabled } = React.useContext(CheckboxGroupPrimitiveContext);
 
     const isChecked = checkedValues.includes(value);
 
-    const handleClick = (event : React.MouseEvent) => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         event.stopPropagation();
         if (checkedValues.includes(value)) {
@@ -31,18 +32,36 @@ const CheckboxGroupPrimitiveTrigger = ({ children, className = '', value, requir
         <div>
             <CheckboxGroupPrimitiveTriggerContext.Provider value={{ isChecked }}>
                 <RovingFocusGroup.Item>
-
-                    <button role="checkbox" type="button" onClick={handleClick} className={className} aria-checked={isChecked} disabled={disabled || groupDisabled} aria-required={required || groupRequired}>
+                    <button
+                        ref={ref}
+                        role="checkbox"
+                        type="button"
+                        onClick={handleClick}
+                        className={className}
+                        aria-checked={isChecked}
+                        disabled={disabled || groupDisabled}
+                        aria-required={required || groupRequired}
+                        {...props}
+                    >
                         {children}
                     </button>
-
                 </RovingFocusGroup.Item>
             </CheckboxGroupPrimitiveTriggerContext.Provider>
 
-            <input type="checkbox" checked={isChecked} name={name} value={value} style={{ display: 'none' }} required={required || groupRequired} disabled={disabled || groupDisabled} readOnly/>
-
+            <input
+                type="checkbox"
+                checked={isChecked}
+                name={name}
+                value={value}
+                style={{ display: 'none' }}
+                required={required || groupRequired}
+                disabled={disabled || groupDisabled}
+                readOnly
+            />
         </div>
     );
-};
+});
+
+CheckboxGroupPrimitiveTrigger.displayName = 'CheckboxGroupPrimitiveTrigger';
 
 export default CheckboxGroupPrimitiveTrigger;


### PR DESCRIPTION
## Summary
- use `React.forwardRef` on VisuallyHidden to expose underlying DOM node
- forward refs through CheckboxCards and CheckboxGroup primitives
- add tests covering ref forwarding and absence of warnings

## Testing
- `npm test`
