### PR TITLE
refactor: forward refs in Code component

### DIFF
--- a/src/components/ui/Code/Code.tsx
+++ b/src/components/ui/Code/Code.tsx
@@ -5,15 +5,22 @@ import { customClassSwitcher } from '~/core';
 
 const COMPONENT_NAME = 'Code';
 
-export type CodeProps= {
-    children: React.ReactNode;
+export type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
     customRootClass?: string;
     variant?: string;
     size?: string;
     color?: string;
-}
+};
 
-const Code = ({ children, customRootClass = '', color = '', variant = '', size = '' }: CodeProps) => {
+const Code = React.forwardRef<React.ElementRef<'code'>, CodeProps>(({
+    children,
+    customRootClass = '',
+    color = '',
+    variant = '',
+    size = '',
+    className,
+    ...props
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const data_attributes: Record<string, string> = {};
@@ -30,9 +37,11 @@ const Code = ({ children, customRootClass = '', color = '', variant = '', size =
         data_attributes['data-rad-ui-accent-color'] = color;
     }
 
-    return <code className={clsx(rootClass)} {...data_attributes}>
+    return <code ref={ref} className={clsx(rootClass, className)} {...data_attributes} {...props}>
         {children}
     </code>;
-};
+});
+
+Code.displayName = COMPONENT_NAME;
 
 export default Code;

--- a/src/components/ui/Code/tests/Code.test.tsx
+++ b/src/components/ui/Code/tests/Code.test.tsx
@@ -1,14 +1,22 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Code from '../Code';
 
 describe('Code Component', () => {
-    it('renders without crashing', () => {
-        const { container } = render(<Code>console.log('Hello world!');</Code>);
+    it('renders content accessible to screen readers', () => {
+        render(<Code>console.log('Hello world!');</Code>);
 
-        const codeElement = container.querySelector('code');
+        const codeElement = screen.getByText("console.log('Hello world!');");
         expect(codeElement).toBeInTheDocument();
-        expect(codeElement).toHaveTextContent('console.log(\'Hello world!\');');
+        expect(codeElement.tagName).toBe('CODE');
+        expect(codeElement).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('forwards ref to the code element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Code ref={ref}>ref test</Code>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName).toBe('CODE');
     });
 
     it('renders Code component with correct color', () => {
@@ -17,5 +25,17 @@ describe('Code Component', () => {
         const codeElement = container.querySelector('code');
         expect(codeElement).toBeInTheDocument();
         expect(codeElement).toHaveAttribute('data-rad-ui-accent-color', 'blue');
+    });
+
+    it('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Code>console.log('Hello world!');</Code>);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- use forwardRef in Code component and support native code props
- expand tests to cover ref forwarding and console warnings

## Testing
- `npm test src/components/ui/Code/tests/Code.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Code component now supports native <code> props plus variant, size, color, and customRootClass.
  - Ref forwarding to the underlying code element for easier integration.
  - Applies data attributes for variant, size, and color to enable styling.
- Refactor
  - Migrated Code to a forwardRef implementation and set a display name for clearer debugging.
- Tests
  - Added tests for ref forwarding, accessibility (visible to screen readers), and absence of console warnings.
  - Updated queries to use screen-based access; retained color rendering test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->