### PR TITLE
refactor: forward refs in Quote

### DIFF
--- a/src/components/ui/Quote/Quote.tsx
+++ b/src/components/ui/Quote/Quote.tsx
@@ -2,19 +2,23 @@
 import React from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
+
 const COMPONENT_NAME = 'Quote';
 
-export type QuoteProps = {
-    children: React.ReactNode;
+export type QuoteProps = React.ComponentPropsWithoutRef<'q'> & {
     customRootClass?: string;
-    className?: string;
-    props?: Record<string, any>[]
-}
-
-const Quote = ({ children, customRootClass, className, ...props }: QuoteProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <q className={clsx(rootClass, className)} {...props}>{children}</q>;
 };
+
+const Quote = React.forwardRef<React.ElementRef<'q'>, QuoteProps>(
+    ({ children, customRootClass, className, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        return (
+            <q ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </q>
+        );
+    }
+);
 
 Quote.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Quote/tests/Quote.test.tsx
+++ b/src/components/ui/Quote/tests/Quote.test.tsx
@@ -1,36 +1,52 @@
 import React from 'react';
-import { render, RenderResult } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+
 import Quote from '../Quote';
 
-describe('Quote Component', () => {
-    it('renders without crashing', () => {
-        const { container } = render(
+describe('Quote', () => {
+    test('renders quote text', () => {
+        render(
             <Quote>
-                You must be the change you wish to see in the world. - Mahatma
-                Gandhi
+                You must be the change you wish to see in the world. - Mahatma Gandhi
             </Quote>
         );
-        const quoteElements = container.querySelectorAll('q');
 
-        expect(quoteElements.length).toEqual(1);
-        expect(quoteElements[0]).toBeTruthy();
-        expect(quoteElements[0].textContent).toEqual(
-            'You must be the change you wish to see in the world. - Mahatma Gandhi'
-        );
+        expect(
+            screen.getByText(
+                'You must be the change you wish to see in the world. - Mahatma Gandhi'
+            )
+        ).toBeInTheDocument();
     });
 
-    it('renders with custom root class and custom class name', () => {
-        const { container } = render(
-            <Quote
-                customRootClass="acme-corp"
-                className="custom-class-name">
-                You must be the change you wish to see in the world. - Mahatma
-                Gandhi
+    test('supports custom classes', () => {
+        render(
+            <Quote customRootClass='acme-corp' className='custom-class-name'>
+                You must be the change you wish to see in the world. - Mahatma Gandhi
             </Quote>
         );
 
-        const quoteElement = container.querySelector('q');
+        const quoteElement = screen.getByText(
+            'You must be the change you wish to see in the world. - Mahatma Gandhi'
+        );
         expect(quoteElement).toHaveClass('acme-corp-quote');
         expect(quoteElement).toHaveClass('custom-class-name');
     });
+
+    test('forwards refs to the underlying element', () => {
+        const ref = React.createRef<HTMLQuoteElement>();
+        render(<Quote ref={ref}>Quote</Quote>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('Q');
+    });
+
+    test('renders without console errors', () => {
+        const consoleError = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        render(<Quote>Quote</Quote>);
+        expect(consoleError).not.toHaveBeenCalled();
+        consoleError.mockRestore();
+    });
 });
+


### PR DESCRIPTION
## Summary
- refactor Quote component to forward refs and type props
- add tests for Quote ref forwarding and console warnings

## Testing
- `npm test src/components/ui/Quote/tests/Quote.test.tsx`

