### PR TITLE
refactor(progress): forward refs

### DIFF
--- a/src/components/ui/Progress/Progress.tsx
+++ b/src/components/ui/Progress/Progress.tsx
@@ -1,13 +1,28 @@
-import ProgressRoot from './fragments/ProgressRoot';
-import ProgressIndicator from './fragments/ProgressIndicator';
+import React, { forwardRef } from "react";
+import ProgressRoot, {
+    ProgressRootElement,
+    ProgressRootProps,
+} from "./fragments/ProgressRoot";
+import ProgressIndicator from "./fragments/ProgressIndicator";
 
-export const COMPONENT_NAME = 'Progress';
+export const COMPONENT_NAME = "Progress";
 
-function Progress() {
-    console.warn('Direct usage of Progress is not supported. Please use Progress.Root, Progress.Indicator, etc. instead.');
-    return null;
-}
+export type ProgressProps = ProgressRootProps;
+type ProgressComponent = React.ForwardRefExoticComponent<
+    ProgressProps & React.RefAttributes<ProgressRootElement>
+> & {
+    Root: typeof ProgressRoot;
+    Indicator: typeof ProgressIndicator;
+};
 
+const Progress = forwardRef<ProgressRootElement, ProgressProps>((props, ref) => {
+    console.warn(
+        "Direct usage of Progress is not supported. Please use Progress.Root, Progress.Indicator, etc. instead.",
+    );
+    return <ProgressRoot ref={ref} {...props} />;
+}) as ProgressComponent;
+
+Progress.displayName = COMPONENT_NAME;
 Progress.Root = ProgressRoot;
 Progress.Indicator = ProgressIndicator;
 

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -1,15 +1,24 @@
-'use client';
-import React, { useContext } from 'react';
+"use client";
+import React, {
+    useContext,
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef,
+} from "react";
 
-import { clsx } from 'clsx';
-import { ProgressContext } from '../contexts/ProgressContext';
-import Primitive from '~/core/primitives/Primitive';
+import { clsx } from "clsx";
+import { ProgressContext } from "../contexts/ProgressContext";
+import Primitive from "~/core/primitives/Primitive";
 
-interface IndicatorProps {
-    asChild?: boolean;
-}
+export type ProgressIndicatorElement = ElementRef<typeof Primitive.div>;
+export type ProgressIndicatorProps = ComponentPropsWithoutRef<
+    typeof Primitive.div
+>;
 
-export default function ProgressIndicator({ asChild }: IndicatorProps) {
+const ProgressIndicator = forwardRef<
+    ProgressIndicatorElement,
+    ProgressIndicatorProps
+>(({ className, style, ...props }, ref) => {
     const { value, minValue, maxValue, rootClass, state } = useContext(ProgressContext);
     // Ensure value stays within bounds in production, use 0 if value is null
     const boundedValue = Math.min(Math.max(value ?? 0, minValue), maxValue);
@@ -17,13 +26,13 @@ export default function ProgressIndicator({ asChild }: IndicatorProps) {
     // Calculate the percentage of completion
     const percentage = ((boundedValue - minValue) / (maxValue - minValue)) * 100;
 
-    const data_attributes: Record<string, string> = {};
+    const { asChild, ...rest } = props;
 
     return (
         <Primitive.div
             role="progressbar"
-            className={clsx(`${rootClass}-indicator`)}
-            style={{ transform: `translateX(-${100 - percentage}%)` }}
+            className={clsx(`${rootClass}-indicator`, className)}
+            style={{ transform: `translateX(-${100 - percentage}%)`, ...style }}
             aria-valuenow={boundedValue}
             aria-valuemax={maxValue}
             aria-valuemin={minValue}
@@ -32,9 +41,12 @@ export default function ProgressIndicator({ asChild }: IndicatorProps) {
             data-max={maxValue}
             data-min={minValue}
             asChild={asChild}
-            {...data_attributes}
-        >
-
-        </Primitive.div>
+            ref={ref}
+            {...rest}
+        />
     );
-}
+});
+
+ProgressIndicator.displayName = "ProgressIndicator";
+
+export default ProgressIndicator;

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,66 +1,103 @@
-'use client';
-import React, { useEffect, useState } from 'react';
-import { clsx } from 'clsx';
-import { customClassSwitcher } from '~/core';
-import { ProgressContext } from '../contexts/ProgressContext';
+"use client";
+import React, {
+    useEffect,
+    useState,
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef,
+} from "react";
+import { clsx } from "clsx";
+import { customClassSwitcher } from "~/core";
+import { ProgressContext } from "../contexts/ProgressContext";
 
-import Primitive from '~/core/primitives/Primitive';
+import Primitive from "~/core/primitives/Primitive";
 
-const COMPONENT_NAME = 'Progress';
+const COMPONENT_NAME = "Progress";
 
-type ProgressRootProps = {
-    asChild?: boolean;
+export type ProgressRootElement = ElementRef<typeof Primitive.div>;
+export type ProgressRootProps = {
     value: number | null;
     minValue: number;
     maxValue: number;
     getValueLabel?: (value: number, minValue: number, maxValue: number) => string;
-    children: React.ReactNode;
     customRootClass?: string;
-}
+    children: React.ReactNode;
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
 
 const STATE_ENUMS = {
-    LOADING: 'loading', // a progress is loading when the value is not null and not equal to the maxValue
-    COMPLETE: 'complete', // a progress is complete when the value is equal to the maxValue
-    INDETERMINATE: 'indeterminate' // a progress is indeterminate when the value is null, by default it's 0
+    LOADING: "loading", // a progress is loading when the value is not null and not equal to the maxValue
+    COMPLETE: "complete", // a progress is complete when the value is equal to the maxValue
+    INDETERMINATE: "indeterminate", // a progress is indeterminate when the value is null, by default it's 0
 } as const;
 
-const ProgressRoot = ({ value = 0, minValue = 0, maxValue = 100, children, customRootClass, asChild, getValueLabel }: ProgressRootProps) => {
-    const [state, setState] = useState<typeof STATE_ENUMS[keyof typeof STATE_ENUMS]>(STATE_ENUMS.LOADING);
+const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
+    (
+        {
+            value = 0,
+            minValue = 0,
+            maxValue = 100,
+            children,
+            customRootClass,
+            getValueLabel,
+            className,
+            ...props
+        },
+        ref,
+    ) => {
+        const [state, setState] = useState<
+            (typeof STATE_ENUMS)[keyof typeof STATE_ENUMS]
+        >(STATE_ENUMS.LOADING);
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? '';
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? "";
 
-    useEffect(() => {
-        setState(value === null ? STATE_ENUMS.INDETERMINATE : value === maxValue ? STATE_ENUMS.COMPLETE : STATE_ENUMS.LOADING);
-    }, [value, maxValue]);
+        useEffect(() => {
+            setState(
+                value === null
+                    ? STATE_ENUMS.INDETERMINATE
+                    : value === maxValue
+                        ? STATE_ENUMS.COMPLETE
+                        : STATE_ENUMS.LOADING,
+            );
+        }, [value, maxValue]);
 
-    const sendValues = {
-        value,
-        minValue,
-        maxValue,
-        rootClass,
-        getValueLabel,
-        ariaLabel,
-        state
-    };
-    return (
-        <ProgressContext.Provider value={sendValues}>
-            <Primitive.div
-                role="progressbar"
-                aria-label={ariaLabel}
-                aria-valuetext={ariaLabel}
-                aria-valuenow={value ?? 0}
-                aria-valuemin={minValue}
-                aria-valuemax={maxValue}
-                data-state={state}
-                data-value={value ?? 0}
-                data-max={maxValue}
-                data-min={minValue}
-                className={clsx(rootClass)}
-                asChild={asChild}
-            >{children}</Primitive.div>
-        </ProgressContext.Provider>
-    );
-};
+        const sendValues = {
+            value,
+            minValue,
+            maxValue,
+            rootClass,
+            getValueLabel,
+            ariaLabel,
+            state,
+        };
+
+        const { asChild, ...rest } = props;
+
+        return (
+            <ProgressContext.Provider value={sendValues}>
+                <Primitive.div
+                    role="progressbar"
+                    aria-label={ariaLabel}
+                    aria-valuetext={ariaLabel}
+                    aria-valuenow={value ?? 0}
+                    aria-valuemin={minValue}
+                    aria-valuemax={maxValue}
+                    data-state={state}
+                    data-value={value ?? 0}
+                    data-max={maxValue}
+                    data-min={minValue}
+                    className={clsx(rootClass, className)}
+                    asChild={asChild}
+                    ref={ref}
+                    {...rest}
+                >
+                    {children}
+                </Primitive.div>
+            </ProgressContext.Provider>
+        );
+    },
+);
+
+ProgressRoot.displayName = COMPONENT_NAME;
 
 export default ProgressRoot;

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -18,6 +18,26 @@ describe('Progress', () => {
         expect(progressBars[0]).toBeInTheDocument();
     });
 
+    test('forwards ref to root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Progress.Root ref={ref} value={50} maxValue={100} minValue={0}>
+                <Progress.Indicator />
+            </Progress.Root>,
+        );
+        expect(ref.current).not.toBeNull();
+    });
+
+    test('forwards ref to indicator element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Progress.Root value={50} maxValue={100} minValue={0}>
+                <Progress.Indicator ref={ref} />
+            </Progress.Root>,
+        );
+        expect(ref.current).not.toBeNull();
+    });
+
     test('renders progress bar with clamped value', () => {
         const { rerender } = render(<ProgressComp value={110} maxValue={100} minValue={0} />);
         const progressBars = screen.getAllByRole('progressbar');


### PR DESCRIPTION
## Summary
- refactor Progress API to forward refs on root and indicator
- type Progress components with ElementRef and ComponentPropsWithoutRef
- test ref forwarding and ARIA behavior remains intact

## Testing
- `npm test src/components/ui/Progress/tests/Progress.test.tsx`
