### PR TITLE
refactor(kbd): forward refs

### DIFF
--- a/src/components/ui/Kbd/Kbd.tsx
+++ b/src/components/ui/Kbd/Kbd.tsx
@@ -1,24 +1,25 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { useCreateDataAttribute } from '~/core/hooks/createDataAttribute';
+
 const COMPONENT_NAME = 'Kbd';
 
-export type KbdProps = {
-    children: React.ReactNode;
+export type KbdElement = ElementRef<'kbd'>;
+export interface KbdProps extends ComponentPropsWithoutRef<'kbd'> {
     customRootClass?: string;
-    className?: string;
     size?: string;
-    props?: Record<string, any>[];
 }
 
-const Kbd = ({ children, customRootClass, className, size = '', ...props }: KbdProps) => {
+const Kbd = forwardRef<KbdElement, KbdProps>(({ children, customRootClass, className, size = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('kbd', { size });
 
-    return <kbd className={clsx(rootClass, className)} {...dataAttributes()} {...props}>{children}</kbd>;
-};
+    return <kbd ref={ref} className={clsx(rootClass, className)} {...dataAttributes()} {...props}>{children}</kbd>;
+});
+
+Kbd.displayName = COMPONENT_NAME;
 
 export default Kbd;

--- a/src/components/ui/Kbd/tests/Kbd.test.tsx
+++ b/src/components/ui/Kbd/tests/Kbd.test.tsx
@@ -18,5 +18,23 @@ describe('Kbd', () => {
         render(<Kbd data-testid="kbd-element">Ctrl</Kbd>);
         const kbdElement = screen.getByTestId('kbd-element');
         expect(kbdElement).toBeInTheDocument();
+        expect(kbdElement).not.toHaveAttribute('aria-hidden');
+    });
+
+    test('forwards ref to kbd element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Kbd ref={ref}>Ctrl</Kbd>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('KBD');
+    });
+
+    test('renders without console warnings', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<Kbd>Ctrl</Kbd>);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- refactor Kbd component to forward refs with proper TypeScript types
- add tests for ref forwarding, accessibility, and warnings

## Testing
- `npm test src/components/ui/Kbd/tests/Kbd.test.tsx`
- `npm run check:types`
