### PR TITLE
refactor: forward ref for Em

### DIFF
--- a/src/components/ui/Em/Em.tsx
+++ b/src/components/ui/Em/Em.tsx
@@ -1,22 +1,22 @@
 'use client';
-import React from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
+
 const COMPONENT_NAME = 'Em';
 
-export type EmProps = {
-    children: React.ReactNode;
+export type EmProps = ComponentPropsWithoutRef<'em'> & {
     customRootClass?: string;
-    className?: string;
-    props: Record<string, any>[]
-}
-
-const Em = ({ children, customRootClass, className, ...props }: EmProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <em className={clsx(rootClass, className)} {...props}>
-        {children}
-    </em>;
 };
+
+const Em = React.forwardRef<ElementRef<'em'>, EmProps>(({ children, customRootClass, className, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    return (
+        <em ref={ref} className={clsx(rootClass, className)} {...props}>
+            {children}
+        </em>
+    );
+});
 
 Em.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Em/tests/Em.test.tsx
+++ b/src/components/ui/Em/tests/Em.test.tsx
@@ -32,4 +32,20 @@ describe('Em', () => {
         render(<>Welcome to <Em data-testid="em-data">RadUI</Em></>);
         expect(screen.getByText('RadUI')).toHaveAttribute('data-testid', 'em-data');
     });
+
+    test('forwards refs to the underlying element', () => {
+        const ref = React.createRef<HTMLElement>();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Em ref={ref}>RadUI</Em>);
+
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName.toLowerCase()).toBe('em');
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Em component to forward refs and simplify prop typing
- add test coverage for ref forwarding and warnings

## Testing
- `npm test src/components/ui/Em/tests/Em.test.tsx`
