### PR TITLE
feat: add ref forwarding to heading

### DIFF
--- a/src/components/ui/Heading/Heading.tsx
+++ b/src/components/ui/Heading/Heading.tsx
@@ -14,34 +14,27 @@ export type HeadingProps = {
     as?: HeadingTag;
     /** Custom root class for specialized styling */
     customRootClass?: string;
-    /** Additional class names to apply */
-    className?: string;
-    /** Content of the heading */
-    children?: React.ReactNode;
-} & React.HTMLAttributes<HTMLHeadingElement>;
+} & React.ComponentPropsWithoutRef<'h1'>;
 
 /**
  * Renders a heading element with customizable tag and styling
  */
-const Heading = ({
+const Heading = React.forwardRef<React.ElementRef<'h1'>, HeadingProps>(({
     children,
     as = 'h1',
     customRootClass = '',
     className = '',
     ...props
-}: HeadingProps) => {
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, as);
+    const Tag: HeadingTag = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(as) ? as : 'h1';
 
-    // Check if the heading tag is valid
-    if (!['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(as)) {
-        as = 'h1';
-    }
-
-    return React.createElement(as, {
+    return React.createElement(Tag, {
         className: clsx(rootClass, className),
+        ref,
         ...props
     }, children);
-};
+});
 
 Heading.displayName = 'Heading';
 

--- a/src/components/ui/Heading/tests/Heading.test.js
+++ b/src/components/ui/Heading/tests/Heading.test.js
@@ -37,4 +37,26 @@ describe('Heading', () => {
         const element = screen.getByTestId('heading-element');
         expect(element).toBeInTheDocument();
     });
+
+    test('forwards ref to the DOM element', () => {
+        const ref = React.createRef();
+        render(<Heading ref={ref}>Test Content</Heading>);
+        expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+    });
+
+    test('visually hidden headings remain accessible to screen readers', () => {
+        render(<Heading className="sr-only">Hidden Heading</Heading>);
+        const element = screen.getByRole('heading', { name: 'Hidden Heading' });
+        expect(element).toBeInTheDocument();
+    });
+
+    test('renders without console warnings', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<Heading>Test Content</Heading>);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Heading to forward refs to the DOM element with proper TypeScript types
- add tests for ref forwarding, accessibility, and console warnings

## Testing
- `npm test`
