### PR TITLE
feat(numberfield): add ref forwarding

### DIFF
--- a/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldDecrementProps = {
-    className?: string;
-    children?: React.ReactNode
-}
+export type NumberFieldDecrementElement = ElementRef<'button'>;
+export type NumberFieldDecrementProps = ComponentPropsWithoutRef<'button'>;
 
-const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecrementProps) => {
+const NumberFieldDecrement = forwardRef<NumberFieldDecrementElement, NumberFieldDecrementProps>(({ children, className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldDecrement must be used within a NumberField');
@@ -16,6 +14,7 @@ const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecr
     const { handleStep, rootClass, disabled, readOnly } = context;
     return (
         <button
+            ref={ref}
             onClick={() => handleStep({ direction: 'decrement', type: 'small' })}
             className={clsx(`${rootClass}-decrement`, className)}
             disabled={disabled || readOnly}
@@ -24,6 +23,8 @@ const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecr
             {children}
         </button>
     );
-};
+});
+
+NumberFieldDecrement.displayName = 'NumberFieldDecrement';
 
 export default NumberFieldDecrement;

--- a/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldIncrementProps = {
-    className?: string
-    children?: React.ReactNode
-}
+export type NumberFieldIncrementElement = ElementRef<'button'>;
+export type NumberFieldIncrementProps = ComponentPropsWithoutRef<'button'>;
 
-const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncrementProps) => {
+const NumberFieldIncrement = forwardRef<NumberFieldIncrementElement, NumberFieldIncrementProps>(({ children, className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldIncrement must be used within a NumberField');
@@ -17,6 +15,7 @@ const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncr
 
     return (
         <button
+            ref={ref}
             onClick={() => handleStep({ direction: 'increment', type: 'small' })}
             className={clsx(`${rootClass}-increment`, className)}
             disabled={disabled || readOnly}
@@ -25,6 +24,8 @@ const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncr
             {children}
         </button>
     );
-};
+});
+
+NumberFieldIncrement.displayName = 'NumberFieldIncrement';
 
 export default NumberFieldIncrement;

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldInputProps = {
-    className?: string
-}
-const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
+export type NumberFieldInputElement = ElementRef<'input'>;
+export type NumberFieldInputProps = ComponentPropsWithoutRef<'input'>;
+
+const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputProps>(({ className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldInput must be used within a NumberField');
@@ -43,6 +43,7 @@ const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
     };
     return (
         <input
+            ref={ref}
             type="number"
             onKeyDown={handleKeyDown}
             value={inputValue === '' ? '' : inputValue}
@@ -55,6 +56,8 @@ const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
             className={clsx(`${rootClass}-input`, className)}
             {...props}/>
     );
-};
+});
+
+NumberFieldInput.displayName = 'NumberFieldInput';
 
 export default NumberFieldInput;

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { useControllableState } from '~/core/hooks/useControllableState';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import { customClassSwitcher } from '~/core';
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 const COMPONENT_NAME = 'NumberField';
 
+export type NumberFieldRootElement = ElementRef<'div'>;
 export type NumberFieldRootProps = {
     name?: string
     defaultValue?: number | ''
@@ -18,12 +19,9 @@ export type NumberFieldRootProps = {
     disabled?: boolean
     readOnly?: boolean
     required?: boolean
-    id?: string
-    className?: string
-    children?: React.ReactNode
-};
+} & ComponentPropsWithoutRef<'div'>;
 
-const NumberFieldRoot = ({ children, name, defaultValue = '', value, onValueChange, largeStep, step, min, max, disabled, readOnly, required, id, className, ...props }: NumberFieldRootProps) => {
+const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep, step, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
     const [inputValue, setInputValue] = useControllableState<number | ''>(
         value,
@@ -105,12 +103,14 @@ const NumberFieldRoot = ({ children, name, defaultValue = '', value, onValueChan
     };
 
     return (
-        <div className={clsx(`${rootClass}-root`, className)} {...props}>
+        <div ref={ref} className={clsx(`${rootClass}-root`, className)} {...props}>
             <NumberFieldContext.Provider value={contextValues}>
                 {children}
             </NumberFieldContext.Provider>
         </div>
     );
-};
+});
+
+NumberFieldRoot.displayName = COMPONENT_NAME;
 
 export default NumberFieldRoot;

--- a/src/components/ui/NumberField/tests/NumberField.test.tsx
+++ b/src/components/ui/NumberField/tests/NumberField.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NumberField from '../NumberField';
+
+describe('NumberField', () => {
+    test('forwards refs to underlying elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const inputRef = React.createRef<HTMLInputElement>();
+        const incRef = React.createRef<HTMLButtonElement>();
+        const decRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <NumberField.Root ref={rootRef}>
+                <NumberField.Decrement ref={decRef}>-</NumberField.Decrement>
+                <NumberField.Input ref={inputRef} aria-label="value" />
+                <NumberField.Increment ref={incRef}>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+        expect(incRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(decRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('supports accessibility attributes', () => {
+        render(
+            <NumberField.Root>
+                <NumberField.Decrement>-</NumberField.Decrement>
+                <NumberField.Input aria-label="Quantity" />
+                <NumberField.Increment>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(screen.getByLabelText('Quantity')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '+' })).toBeInTheDocument();
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <NumberField.Root>
+                <NumberField.Decrement>-</NumberField.Decrement>
+                <NumberField.Input aria-label="value" />
+                <NumberField.Increment>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- use `forwardRef` in NumberField root and controls
- add refs to input increment and decrement buttons
- test ref forwarding and accessibility

## Testing
- `npm test`
- `npm run check:types`
