### PR TITLE
refactor: forwardRef Disclosure components

### DIFF
--- a/src/components/ui/Disclosure/Disclosure.tsx
+++ b/src/components/ui/Disclosure/Disclosure.tsx
@@ -1,18 +1,24 @@
 import React from 'react';
-import DisclosureRoot from './fragments/DisclosureRoot';
+import DisclosureRoot, { DisclosureRootProps } from './fragments/DisclosureRoot';
 import DisclosureItem from './fragments/DisclosureItem';
 import DisclosureTrigger from './fragments/DisclosureTrigger';
 import DisclosureContent from './fragments/DisclosureContent';
 
-export type DisclosureProps = {
-
+export type DisclosureProps = DisclosureRootProps & {
      items:{title:string, content: React.ReactNode}[]
+};
+
+interface DisclosureComponent extends React.ForwardRefExoticComponent<DisclosureProps & React.RefAttributes<React.ElementRef<'div'>>> {
+    Root: typeof DisclosureRoot;
+    Item: typeof DisclosureItem;
+    Trigger: typeof DisclosureTrigger;
+    Content: typeof DisclosureContent;
 }
 
-const Disclosure = ({ items }:DisclosureProps) => {
+const Disclosure = React.forwardRef<React.ElementRef<'div'>, DisclosureProps>(({ items, ...props }, ref) => {
     return (
 
-        <DisclosureRoot>
+        <DisclosureRoot ref={ref} {...props}>
             {items.map((item, index) => (
                 <DisclosureItem key={index} value={index}>
                     <DisclosureTrigger>
@@ -27,11 +33,13 @@ const Disclosure = ({ items }:DisclosureProps) => {
 
         </DisclosureRoot>
     );
-};
+}) as DisclosureComponent;
 
 Disclosure.Root = DisclosureRoot;
 Disclosure.Item = DisclosureItem;
 Disclosure.Trigger = DisclosureTrigger;
 Disclosure.Content = DisclosureContent;
+
+Disclosure.displayName = 'Disclosure';
 
 export default Disclosure;

--- a/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
@@ -4,19 +4,17 @@ import { DisclosureContext } from '../contexts/DisclosureContext';
 import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 
-export type DisclosureContentProps = {
-      children: React.ReactNode;
-      className?: string;
+export type DisclosureContentProps = React.ComponentPropsWithoutRef<'div'>;
 
-}
-
-const DisclosureContent = ({ children, className = '' }:DisclosureContentProps) => {
+const DisclosureContent = React.forwardRef<React.ElementRef<'div'>, DisclosureContentProps>(({ children, className = '', ...props }, forwardedRef) => {
     const { activeItem, rootClass } = useContext(DisclosureContext);
     const { itemValue } = useContext(DisclosureItemContext);
     return (
         itemValue !== activeItem
             ? null
             : <CollapsiblePrimitive.Content
+                {...props}
+                ref={forwardedRef}
                 className={clsx(`${rootClass}-content`, className)}
 
                 role="region"
@@ -25,6 +23,8 @@ const DisclosureContent = ({ children, className = '' }:DisclosureContentProps) 
                 {children}
             </CollapsiblePrimitive.Content>
     );
-};
+});
+
+DisclosureContent.displayName = 'DisclosureContent';
 
 export default DisclosureContent;

--- a/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
@@ -1,17 +1,14 @@
-import React, { useContext, useEffect, useRef, useState, useId } from 'react';
+import React, { useContext, useEffect, useState, useId } from 'react';
 import { DisclosureContext } from '../contexts/DisclosureContext';
 import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import { clsx } from 'clsx';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 
-export type DisclosureItemProps = {
-    children: React.ReactNode;
-    className?: string;
+export type DisclosureItemProps = React.ComponentPropsWithoutRef<'div'> & {
     value: number;
-}
+};
 
-const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps) => {
-    const disclosureItemRef = useRef<HTMLDivElement>(null);
+const DisclosureItem = React.forwardRef<React.ElementRef<'div'>, DisclosureItemProps>(({ children, className = '', value, ...props }, forwardedRef) => {
     const { activeItem, rootClass } = useContext(DisclosureContext);
 
     const [itemValue, setItemValue] = useState<number>(value);
@@ -36,8 +33,9 @@ const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps)
                 asChild
             >
                 <div
+                    {...props}
                     className={clsx(`${rootClass}-item`, className)}
-                    ref={disclosureItemRef}
+                    ref={forwardedRef}
                     data-state={isOpen ? 'open' : 'closed'}
                     id={`disclosure-data-item-${id}`}
                     role="region"
@@ -50,6 +48,8 @@ const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps)
 
         </DisclosureItemContext.Provider>
     );
-};
+});
+
+DisclosureItem.displayName = 'DisclosureItem';
 
 export default DisclosureItem;

--- a/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { DisclosureContext } from '../contexts/DisclosureContext';
@@ -7,19 +7,25 @@ import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 
 const COMPONENT_NAME = 'Disclosure';
 
-export type DisclosureRootProps = {
-     children: React.ReactNode;
+export type DisclosureRootProps = React.ComponentPropsWithoutRef<'div'> & {
      customRootClass?: string;
      defaultOpen?: number | null;
-     'aria-label'?: string;
+};
 
-}
-
-const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:DisclosureRootProps) => {
-    const disclosureRef = useRef(null);
+const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, ...props }, forwardedRef) => {
+    const disclosureRef = useRef<React.ElementRef<'div'> | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [activeItem, setActiveItem] = useState<number | null>(null);
+
+    const setRefs = useCallback((node: React.ElementRef<'div'> | null) => {
+        disclosureRef.current = node;
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(node);
+        } else if (forwardedRef) {
+            (forwardedRef as React.MutableRefObject<React.ElementRef<'div'> | null>).current = node;
+        }
+    }, [forwardedRef]);
 
     return (
 
@@ -34,8 +40,9 @@ const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:D
             <RovingFocusGroup.Root>
                 <RovingFocusGroup.Group className={clsx(`${rootClass}-root`)}>
                     <div
+                        {...props}
                         className={clsx(`${rootClass}-root`)}
-                        ref={disclosureRef}
+                        ref={setRefs}
                         role="region"
                         aria-label={ariaLabel}
                         data-testid='disclosure-root'
@@ -48,6 +55,8 @@ const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:D
 
         </DisclosureContext.Provider>
     );
-};
+});
+
+DisclosureRoot.displayName = 'DisclosureRoot';
 
 export default DisclosureRoot;

--- a/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
@@ -5,12 +5,9 @@ import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 
-export type DisclosureTriggerProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+export type DisclosureTriggerProps = React.ComponentPropsWithoutRef<'button'>;
 
-const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
+const DisclosureTrigger = React.forwardRef<React.ElementRef<'button'>, DisclosureTriggerProps>(({ children, className, onClick, ...props }, forwardedRef) => {
     const { activeItem, setActiveItem, rootClass } = useContext(DisclosureContext);
     const { itemValue } = useContext(DisclosureItemContext);
 
@@ -20,12 +17,15 @@ const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
         } else if (activeItem !== itemValue) {
             setActiveItem(itemValue);
         }
+        if (onClick) onClick(e);
     };
 
     return (
         <RovingFocusGroup.Item>
             <CollapsiblePrimitive.Trigger asChild>
                 <button
+                    {...props}
+                    ref={forwardedRef}
                     type='button'
                     className={clsx(`${rootClass}-trigger`, className)}
                     onClick={onClickHandler}
@@ -38,6 +38,8 @@ const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
             </CollapsiblePrimitive.Trigger>
         </RovingFocusGroup.Item>
     );
-};
+});
+
+DisclosureTrigger.displayName = 'DisclosureTrigger';
 
 export default DisclosureTrigger;

--- a/src/components/ui/Disclosure/tests/Disclosure.test.tsx
+++ b/src/components/ui/Disclosure/tests/Disclosure.test.tsx
@@ -9,27 +9,74 @@ const items = [
 
 describe('Disclosure', () => {
     test('renders Disclosure component', () => {
-        render(<Disclosure items={[]} />);
+        render(<Disclosure items={[]} aria-label="test" />);
         expect(screen.getByTestId('disclosure-root')).toBeInTheDocument();
     });
 
+    test('forwards refs', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const contentRef = React.createRef<HTMLDivElement>();
+
+        render(
+            <Disclosure.Root ref={rootRef} aria-label="test">
+                <Disclosure.Item ref={itemRef} value={0}>
+                    <Disclosure.Trigger ref={triggerRef}>Item</Disclosure.Trigger>
+                    <Disclosure.Content ref={contentRef}>Content</Disclosure.Content>
+                </Disclosure.Item>
+            </Disclosure.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(contentRef.current).toBeNull();
+        fireEvent.click(triggerRef.current!);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('forwards ref through main component', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Disclosure ref={ref} items={items} aria-label="test" />);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
     test('renders all item titles', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         items.forEach(item => {
             expect(screen.getByText(item.title)).toBeInTheDocument();
         });
     });
 
     test('shows content when an item is clicked', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         fireEvent.click(screen.getByText('Item 1'));
         expect(screen.getByText('Content 1')).toBeInTheDocument();
     });
 
     test('hides content when the same item is clicked again', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         const button = screen.getByText('Item 1');
         fireEvent.click(button);
-        expect(screen.getByText('Content 1')).not.toHaveAttribute('');
+        fireEvent.click(button);
+        expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    });
+
+    test('has proper accessibility attributes', () => {
+        render(<Disclosure items={items} aria-label="accordion" />);
+        const root = screen.getByTestId('disclosure-root');
+        expect(root).toHaveAttribute('aria-label', 'accordion');
+        const trigger = screen.getByText('Item 1');
+        fireEvent.click(trigger);
+        const content = screen.getByText('Content 1');
+        expect(content).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    test('renders without warnings', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Disclosure items={items} aria-label="test" />);
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- refactor `Disclosure` and its fragments to forward refs with strict typing
- test ref forwarding and a11y attributes for `Disclosure`

## Testing
- `npm test`

