### PR TITLE
feat: forward refs for radio components

### DIFF
--- a/src/components/ui/Radio/Radio.tsx
+++ b/src/components/ui/Radio/Radio.tsx
@@ -9,7 +9,9 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'Radio';
 
-export type RadioProps = RadioPrimitiveProps & {
+export type RadioElement = React.ElementRef<typeof RadioPrimitive>;
+
+export type RadioProps = Omit<RadioPrimitiveProps, 'size'> & {
     customRootClass?: string;
     className?: string;
     size?: string;
@@ -17,7 +19,10 @@ export type RadioProps = RadioPrimitiveProps & {
     variant?: string;
 };
 
-function Radio({ name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props }: RadioProps) {
+const Radio = React.forwardRef<RadioElement, RadioProps>(function Radio(
+    { name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props },
+    ref
+) {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const [isChecked, setIsChecked] = React.useState(checked);
 
@@ -33,6 +38,7 @@ function Radio({ name, value, id, checked = false, required, onChange, disabled,
     };
     return (
         <RadioPrimitive
+            ref={ref}
             name={name}
             id={id}
             value={value}
@@ -48,6 +54,8 @@ function Radio({ name, value, id, checked = false, required, onChange, disabled,
         />
 
     );
-}
+});
+
+Radio.displayName = COMPONENT_NAME;
 
 export default Radio;

--- a/src/components/ui/Radio/tests/Radio.test.tsx
+++ b/src/components/ui/Radio/tests/Radio.test.tsx
@@ -66,4 +66,10 @@ describe('Radio', () => {
         expect(radio).toHaveAttribute('data-button-size', 'lg');
         expect(radio).toHaveAttribute('data-rad-ui-accent-color', 'red');
     });
+
+    it('forwards refs', () => {
+        const ref = React.createRef<HTMLInputElement>();
+        render(<Radio {...baseProps} ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
 });

--- a/src/components/ui/RadioCards/fragments/RadioCardsItem.tsx
+++ b/src/components/ui/RadioCards/fragments/RadioCardsItem.tsx
@@ -4,15 +4,21 @@ import { RadioCardsContext } from '../context/RadioCardsContext';
 
 import clsx from 'clsx';
 
-export type RadioCardsItemProps = {
-    children?: React.ReactNode
-    className?: string
-    value: string
-} & RadioGroupPrimitiveProps.Item
+export type RadioCardsItemElement = React.ElementRef<typeof RadioGroupPrimitive.Item>;
 
-const RadioCardsItem = ({ children, className = '', value, ...props }: RadioCardsItemProps) => {
-    const { rootClass } = useContext(RadioCardsContext);
-    return <RadioGroupPrimitive.Item className={clsx(`${rootClass}-item`, className)} {...props} value={value}>{children}</RadioGroupPrimitive.Item>;
-};
+export type RadioCardsItemProps = {
+    children?: React.ReactNode;
+    className?: string;
+    value: string;
+} & RadioGroupPrimitiveProps.Item;
+
+const RadioCardsItem = React.forwardRef<RadioCardsItemElement, RadioCardsItemProps>(
+    ({ children, className = '', value, ...props }, ref) => {
+        const { rootClass } = useContext(RadioCardsContext);
+        return <RadioGroupPrimitive.Item ref={ref} className={clsx(`${rootClass}-item`, className)} {...props} value={value}>{children}</RadioGroupPrimitive.Item>;
+    }
+);
+
+RadioCardsItem.displayName = 'RadioCardsItem';
 
 export default RadioCardsItem;

--- a/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
+++ b/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
@@ -8,6 +8,8 @@ import { RadioCardsContext } from '../context/RadioCardsContext';
 
 const COMPONENT_NAME = 'RadioCards';
 
+export type RadioCardsRootElement = React.ElementRef<typeof RadioGroupPrimitive.Root>;
+
 type RadioCardsRootProps = {
     children: React.ReactNode;
     className?: string;
@@ -17,16 +19,20 @@ type RadioCardsRootProps = {
     color?: string;
 } & RadioGroupPrimitiveProps.Root;
 
-const RadioCardsRoot = ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }: RadioCardsRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const RadioCardsRoot = React.forwardRef<RadioCardsRootElement, RadioCardsRootProps>(
+    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    const dataAttributes = useCreateDataAttribute('radio-cards', { variant, size });
-    const accentAttributes = useCreateDataAccentColorAttribute(color);
-    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+        const dataAttributes = useCreateDataAttribute('radio-cards', { variant, size });
+        const accentAttributes = useCreateDataAccentColorAttribute(color);
+        const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
-    return <RadioCardsContext.Provider value={{ rootClass }}>
-        <RadioGroupPrimitive.Root className={clsx(rootClass, className)} {...composedAttributes} {...props}>{children}</RadioGroupPrimitive.Root>
-    </RadioCardsContext.Provider>;
-};
+        return <RadioCardsContext.Provider value={{ rootClass }}>
+            <RadioGroupPrimitive.Root ref={ref} className={clsx(rootClass, className)} {...composedAttributes()} {...props}>{children}</RadioGroupPrimitive.Root>
+        </RadioCardsContext.Provider>;
+    }
+);
+
+RadioCardsRoot.displayName = 'RadioCardsRoot';
 
 export default RadioCardsRoot;

--- a/src/components/ui/RadioCards/tests/RadioCards.test.tsx
+++ b/src/components/ui/RadioCards/tests/RadioCards.test.tsx
@@ -78,4 +78,20 @@ describe('RadioCards', () => {
         const { container } = renderRadioCards({ className: 'custom-root' });
         expect(container.firstChild).toHaveClass('custom-root');
     });
+
+    it('forwards refs to root and item', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <RadioCards.Root ref={rootRef} name="group" defaultValue={options[0].value}>
+                <RadioCards.Item ref={itemRef} value={options[0].value}>
+                    {options[0].label}
+                </RadioCards.Item>
+            </RadioCards.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
 });

--- a/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
@@ -3,18 +3,24 @@ import RadioGroupPrimitive, { RadioGroupPrimitiveProps } from '~/core/primitives
 import clsx from 'clsx';
 import { RadioGroupContext } from '../context/RadioGroupContext';
 
+export type RadioGroupIndicatorElement = React.ElementRef<typeof RadioGroupPrimitive.Indicator>;
+
 export type RadioGroupIndicatorProps = {
-    children?: React.ReactNode
-    className?: string
+    children?: React.ReactNode;
+    className?: string;
 } & RadioGroupPrimitiveProps.Indicator;
 
-const RadioGroupIndicator = ({ className = '', children, ...props }: RadioGroupIndicatorProps) => {
-    const { rootClass } = React.useContext(RadioGroupContext);
-    return (
-        <RadioGroupPrimitive.Indicator className={clsx(`${rootClass}-indicator`, className)} {...props} >
-            {children}
-        </RadioGroupPrimitive.Indicator>
-    );
-};
+const RadioGroupIndicator = React.forwardRef<RadioGroupIndicatorElement, RadioGroupIndicatorProps>(
+    ({ className = '', children, ...props }, ref) => {
+        const { rootClass } = React.useContext(RadioGroupContext);
+        return (
+            <RadioGroupPrimitive.Indicator ref={ref} className={clsx(`${rootClass}-indicator`, className)} {...props} >
+                {children}
+            </RadioGroupPrimitive.Indicator>
+        );
+    }
+);
+
+RadioGroupIndicator.displayName = 'RadioGroupIndicator';
 
 export default RadioGroupIndicator;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
@@ -3,15 +3,21 @@ import RadioGroupPrimitive, { RadioGroupPrimitiveProps } from '~/core/primitives
 import { RadioGroupContext } from '../context/RadioGroupContext';
 import clsx from 'clsx';
 
-export type RadioGroupItemProps = {
-    children: React.ReactNode
-    className?: string
-    value: string
-} & RadioGroupPrimitiveProps.Item
+export type RadioGroupItemElement = React.ElementRef<typeof RadioGroupPrimitive.Item>;
 
-const RadioGroupItem = ({ children, className = '', value, ...props }: RadioGroupItemProps) => {
-    const { rootClass } = useContext(RadioGroupContext);
-    return <RadioGroupPrimitive.Item className={clsx(`${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
-};
+export type RadioGroupItemProps = {
+    children: React.ReactNode;
+    className?: string;
+    value: string;
+} & RadioGroupPrimitiveProps.Item;
+
+const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
+    ({ children, className = '', value, ...props }, ref) => {
+        const { rootClass } = useContext(RadioGroupContext);
+        return <RadioGroupPrimitive.Item ref={ref} className={clsx(`${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
+    }
+);
+
+RadioGroupItem.displayName = 'RadioGroupItem';
 
 export default RadioGroupItem;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
@@ -3,15 +3,17 @@ import Primitive from '~/core/primitives/Primitive';
 import clsx from 'clsx';
 import { RadioGroupContext } from '../context/RadioGroupContext';
 
-export type RadioGroupLabelProps = {
-    children?: React.ReactNode
-    className?: string
-    asChild?: boolean
-}
+export type RadioGroupLabelElement = React.ElementRef<typeof Primitive.label>;
 
-const RadioGroupLabel = ({ className = '', asChild = false, children, ...props }: RadioGroupLabelProps) => {
-    const { rootClass } = React.useContext(RadioGroupContext);
-    return <Primitive.label {...props} className={clsx(`${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
-};
+export type RadioGroupLabelProps = React.ComponentPropsWithoutRef<typeof Primitive.label>;
+
+const RadioGroupLabel = React.forwardRef<RadioGroupLabelElement, RadioGroupLabelProps>(
+    ({ className = '', asChild = false, children, ...props }, ref) => {
+        const { rootClass } = React.useContext(RadioGroupContext);
+        return <Primitive.label ref={ref} {...props} className={clsx(`${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
+    }
+);
+
+RadioGroupLabel.displayName = 'RadioGroupLabel';
 
 export default RadioGroupLabel;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
@@ -10,6 +10,8 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'RadioGroup';
 
+export type RadioGroupRootElement = React.ElementRef<typeof RadioGroupPrimitive.Root>;
+
 type RadioGroupRootProps = {
     children: React.ReactNode;
     className?: string;
@@ -20,16 +22,20 @@ type RadioGroupRootProps = {
 
 } & RadioGroupPrimitiveProps.Root;
 
-const RadioGroupRoot = ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }: RadioGroupRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
+const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootProps>(
+    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
 
-    const accentAttributes = useCreateDataAccentColorAttribute(color);
-    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+        const accentAttributes = useCreateDataAccentColorAttribute(color);
+        const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
-    return <RadioGroupContext.Provider value={{ rootClass }}>
-        <RadioGroupPrimitive.Root className={clsx(`${rootClass}-root`, className)} {...composedAttributes()} {...props}> {children} </RadioGroupPrimitive.Root>
-    </RadioGroupContext.Provider>;
-};
+        return <RadioGroupContext.Provider value={{ rootClass }}>
+            <RadioGroupPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, className)} {...composedAttributes()} {...props}> {children} </RadioGroupPrimitive.Root>
+        </RadioGroupContext.Provider>;
+    }
+);
+
+RadioGroupRoot.displayName = 'RadioGroupRoot';
 
 export default RadioGroupRoot;

--- a/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
+++ b/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
@@ -97,4 +97,22 @@ describe('RadioGroup (fragments)', () => {
         );
         spy.mockRestore();
     });
+
+    it('forwards refs to root, item, and indicator', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        const indicatorRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <RadioGroup.Root ref={rootRef} defaultValue="html">
+                <RadioGroup.Item ref={itemRef} value="html">
+                    <RadioGroup.Indicator ref={indicatorRef} />
+                </RadioGroup.Item>
+            </RadioGroup.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(indicatorRef.current).toBeInstanceOf(HTMLSpanElement);
+    });
 });

--- a/src/core/primitives/Radio/index.tsx
+++ b/src/core/primitives/Radio/index.tsx
@@ -1,37 +1,41 @@
 import React from 'react';
 import Primitive from '../Primitive';
 
-export type RadioPrimitiveProps = {
+export type RadioPrimitiveElement = React.ElementRef<'input'>;
+
+export type RadioPrimitiveProps = Omit<React.ComponentPropsWithoutRef<'input'>, 'onChange'> & {
     name: string;
     value: string;
     id: string;
     onChange?: () => void;
-    checked?: boolean;
-    required?: boolean;
-    disabled?: boolean;
     asChild?: boolean;
     className?: string;
-}
+};
 
-function RadioPrimitive({ name, value, id, checked, required, onChange, disabled, asChild, className, ...props }: RadioPrimitiveProps) {
-    return (
-        <Primitive.input
-            type="radio"
-            checked={checked}
-            name={name}
-            tabIndex={-1}
-            value={value}
-            onChange={onChange}
-            id={id}
-            aria-disabled={disabled}
-            disabled={disabled}
-            required={required}
-            aria-required={required}
-            asChild={asChild}
-            className={className}
-            {...props}
-        />
-    );
-}
+const RadioPrimitive = React.forwardRef<RadioPrimitiveElement, RadioPrimitiveProps>(
+    ({ name, value, id, checked, required, onChange, disabled, asChild, className, ...props }, forwardedRef) => {
+        return (
+            <Primitive.input
+                ref={forwardedRef}
+                type="radio"
+                checked={checked}
+                name={name}
+                tabIndex={-1}
+                value={value}
+                onChange={onChange}
+                id={id}
+                aria-disabled={disabled}
+                disabled={disabled}
+                required={required}
+                aria-required={required}
+                asChild={asChild}
+                className={className}
+                {...props}
+            />
+        );
+    }
+);
+
+RadioPrimitive.displayName = 'RadioPrimitive';
 
 export default RadioPrimitive;

--- a/src/core/primitives/Radio/tests/Radio.test.tsx
+++ b/src/core/primitives/Radio/tests/Radio.test.tsx
@@ -45,4 +45,10 @@ describe('RadioPrimitive', () => {
         const radio = screen.getByRole('radio');
         expect(radio).toBeInTheDocument();
     });
+
+    it('forwards refs', () => {
+        const ref = React.createRef<HTMLInputElement>();
+        render(<RadioPrimitive {...baseProps} ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
 });

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import RadioGroupPrimitiveItemContext from '../context/RadioGroupPrimitiveItemContext';
 import Primitive from '~/core/primitives/Primitive';
 
-export type RadioGroupPrimitiveIndicatorProps = {
-    children?: React.ReactNode
-    className?: string
-    asChild?: boolean
-}
-const RadioGroupPrimitiveIndicator = ({ children, className, asChild = false, ...props }: RadioGroupPrimitiveIndicatorProps) => {
-    const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
+export type RadioGroupPrimitiveIndicatorElement = React.ElementRef<typeof Primitive.span>;
 
-    if (!itemSelected) return null;
-    return <Primitive.span className={className} asChild={asChild} {...props}>{children}</Primitive.span>;
-};
+export type RadioGroupPrimitiveIndicatorProps = React.ComponentPropsWithoutRef<typeof Primitive.span>;
+
+const RadioGroupPrimitiveIndicator = React.forwardRef<RadioGroupPrimitiveIndicatorElement, RadioGroupPrimitiveIndicatorProps>(
+    ({ children, className, asChild = false, ...props }, ref) => {
+        const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
+
+        if (!itemSelected) return null;
+        return <Primitive.span ref={ref} className={className} asChild={asChild} {...props}>{children}</Primitive.span>;
+    }
+);
+
+RadioGroupPrimitiveIndicator.displayName = 'RadioGroupPrimitiveIndicator';
 
 export default RadioGroupPrimitiveIndicator;

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
@@ -1,50 +1,52 @@
-import React, { PropsWithChildren, useContext } from 'react';
+import React, { useContext } from 'react';
 import RadioGroupContext from '../context/RadioGroupContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import RadioGroupPrimitiveItemContext from '../context/RadioGroupPrimitiveItemContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
-export type RadioGroupPrimitiveItemProps = PropsWithChildren<{
+export type RadioGroupPrimitiveItemElement = React.ElementRef<typeof ButtonPrimitive>;
+
+export type RadioGroupPrimitiveItemProps = React.ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     value: string;
-    disabled?: boolean
-    children?: React.ReactNode;
-    required?: boolean
-    className?: string
-    asChild?: boolean
-}>;
-
-const RadioGroupPrimitiveItem = ({ value, children, disabled, required = false, className = '', asChild = false, ...props }: RadioGroupPrimitiveItemProps) => {
-    const context = useContext(RadioGroupContext);
-    if (!context) {
-        throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
-    }
-    const { groupDisabled, selectedValue, setSelectedValue } = context;
-
-    const itemSelected = value === selectedValue;
-    return (
-
-        <RovingFocusGroup.Item >
-            <ButtonPrimitive
-                role="radio"
-                type="button"
-                disabled={groupDisabled || disabled}
-                onClick={() => setSelectedValue(value)}
-                onFocus={() => setSelectedValue(value)}
-                aria-disabled={groupDisabled || disabled}
-                aria-checked={value === selectedValue}
-                data-checked={value === selectedValue}
-                aria-required={required}
-                asChild={asChild}
-                className={className}
-                {...props}
-            >
-                <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
-                    {children}
-                </RadioGroupPrimitiveItemContext.Provider>
-            </ButtonPrimitive>
-        </RovingFocusGroup.Item>
-
-    );
 };
+
+const RadioGroupPrimitiveItem = React.forwardRef<RadioGroupPrimitiveItemElement, RadioGroupPrimitiveItemProps>(
+    ({ value, children, disabled, required = false, className = '', asChild = false, ...props }, ref) => {
+        const context = useContext(RadioGroupContext);
+        if (!context) {
+            throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
+        }
+        const { groupDisabled, selectedValue, setSelectedValue } = context;
+
+        const itemSelected = value === selectedValue;
+        return (
+
+            <RovingFocusGroup.Item >
+                <ButtonPrimitive
+                    ref={ref}
+                    role="radio"
+                    type="button"
+                    disabled={groupDisabled || disabled}
+                    onClick={() => setSelectedValue(value)}
+                    onFocus={() => setSelectedValue(value)}
+                    aria-disabled={groupDisabled || disabled}
+                    aria-checked={value === selectedValue}
+                    data-checked={value === selectedValue}
+                    aria-required={required}
+                    asChild={asChild}
+                    className={className}
+                    {...props}
+                >
+                    <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
+                        {children}
+                    </RadioGroupPrimitiveItemContext.Provider>
+                </ButtonPrimitive>
+            </RovingFocusGroup.Item>
+
+        );
+    }
+);
+
+RadioGroupPrimitiveItem.displayName = 'RadioGroupPrimitiveItem';
 
 export default RadioGroupPrimitiveItem;

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
@@ -1,12 +1,12 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import Primitive from '../../Primitive';
 import RadioGroupContext from '../context/RadioGroupContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import useControllableState from '~/core/hooks/useControllableState';
 
-export type RadioGroupPrimitiveRootProps = PropsWithChildren<{
-    className?: string;
-    customRootClass?: string;
+export type RadioGroupPrimitiveRootElement = React.ElementRef<typeof Primitive.div>;
+
+export type RadioGroupPrimitiveRootProps = React.ComponentPropsWithoutRef<typeof Primitive.div> & {
     value?: string;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
@@ -14,16 +14,17 @@ export type RadioGroupPrimitiveRootProps = PropsWithChildren<{
     required?: boolean;
     name?: string;
     orientation?: 'horizontal' | 'vertical' | 'both';
-    loop?: boolean,
+    loop?: boolean;
     dir?: 'ltr' | 'rtl';
-}>;
+};
 
-const RadioGroupPrimitiveRoot = ({ value, defaultValue = '', onValueChange, children, disabled: groupDisabled = false, required = false, name = '', orientation = 'horizontal', loop = false, dir = 'ltr', ...props }: RadioGroupPrimitiveRootProps) => {
-    const [selectedValue, setSelectedValue] = useControllableState(
-        value,
-        defaultValue,
-        onValueChange
-    );
+const RadioGroupPrimitiveRoot = React.forwardRef<RadioGroupPrimitiveRootElement, RadioGroupPrimitiveRootProps>(
+    ({ value, defaultValue = '', onValueChange, children, disabled: groupDisabled = false, required = false, name = '', orientation = 'horizontal', loop = false, dir = 'ltr', ...props }, ref) => {
+        const [selectedValue, setSelectedValue] = useControllableState(
+            value,
+            defaultValue,
+            onValueChange
+        );
 
     const sendItems = {
         selectedValue,
@@ -31,21 +32,24 @@ const RadioGroupPrimitiveRoot = ({ value, defaultValue = '', onValueChange, chil
         groupDisabled
     };
 
-    return (
-        <Primitive.div {...props} aria-required={required} role='radiogroup' aria-disabled={groupDisabled}>
-            <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
-                <RadioGroupContext.Provider value={sendItems}>
-                    <RovingFocusGroup.Group>
+        return (
+            <Primitive.div ref={ref} {...props} aria-required={required} role='radiogroup' aria-disabled={groupDisabled}>
+                <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
+                    <RadioGroupContext.Provider value={sendItems}>
+                        <RovingFocusGroup.Group>
 
-                        {children}
+                            {children}
 
-                    </RovingFocusGroup.Group>
-                </RadioGroupContext.Provider>
-            </RovingFocusGroup.Root>
-            <input type='radio' hidden name={name} value={selectedValue} disabled={groupDisabled} required={required}/>
-        </Primitive.div>
-    )
-    ;
-};
+                        </RovingFocusGroup.Group>
+                    </RadioGroupContext.Provider>
+                </RovingFocusGroup.Root>
+                <input type='radio' hidden name={name} value={selectedValue} disabled={groupDisabled} required={required}/>
+            </Primitive.div>
+        )
+        ;
+    }
+);
+
+RadioGroupPrimitiveRoot.displayName = 'RadioGroupPrimitiveRoot';
 
 export default RadioGroupPrimitiveRoot;

--- a/src/core/primitives/RadioGroup/tests/RadioGroupPrimtive.test.tsx
+++ b/src/core/primitives/RadioGroup/tests/RadioGroupPrimtive.test.tsx
@@ -85,4 +85,22 @@ describe('RadioGroupPrimitive', () => {
         }).toThrow('RadioGroup.Item must be used within a RadioGroup.Root');
         spy.mockRestore();
     });
+
+    it('forwards refs to root, item, and indicator', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        const indicatorRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <RadioGroupPrimitive.Root ref={rootRef} value="a" name="group">
+                <RadioGroupPrimitive.Item ref={itemRef} value="a">
+                    <RadioGroupPrimitive.Indicator ref={indicatorRef}>*</RadioGroupPrimitive.Indicator>
+                </RadioGroupPrimitive.Item>
+            </RadioGroupPrimitive.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(indicatorRef.current).toBeInstanceOf(HTMLSpanElement);
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Radio primitives and UI components to forward refs
- forward refs through RadioGroup and RadioCards subcomponents
- verify ref forwarding and accessibility in tests

## Testing
- `npm test`