### PR TITLE
refactor(scrollarea): forward refs

### DIFF
--- a/src/components/ui/ScrollArea/ScrollArea.tsx
+++ b/src/components/ui/ScrollArea/ScrollArea.tsx
@@ -1,15 +1,25 @@
 'use client';
 
+import React from 'react';
 import ScrollAreaRoot from './fragments/ScrollAreaRoot';
 import ScrollAreaViewport from './fragments/ScrollAreaViewport';
 import ScrollAreaScrollbar from './fragments/ScrollAreaScrollbar';
 import ScrollAreaThumb from './fragments/ScrollAreaThumb';
 import ScrollAreaCorner from './fragments/ScrollAreaCorner';
 
+type ScrollAreaElement = React.ElementRef<'div'>;
+type ScrollAreaProps = React.ComponentPropsWithoutRef<'div'>;
+
 // Empty implementation - we don't support direct usage
-const ScrollArea = () => {
+const ScrollArea = React.forwardRef<ScrollAreaElement, ScrollAreaProps>((_props, _ref) => {
     console.warn('Direct usage of ScrollArea is not supported. Please use ScrollArea.Root and ScrollArea.Viewport instead.');
     return null;
+}) as React.ForwardRefExoticComponent<ScrollAreaProps> & {
+    Root: typeof ScrollAreaRoot;
+    Viewport: typeof ScrollAreaViewport;
+    Scrollbar: typeof ScrollAreaScrollbar;
+    Thumb: typeof ScrollAreaThumb;
+    Corner: typeof ScrollAreaCorner;
 };
 
 // Export fragments via direct assignment pattern
@@ -18,5 +28,7 @@ ScrollArea.Viewport = ScrollAreaViewport;
 ScrollArea.Scrollbar = ScrollAreaScrollbar;
 ScrollArea.Thumb = ScrollAreaThumb;
 ScrollArea.Corner = ScrollAreaCorner;
+
+ScrollArea.displayName = 'ScrollArea';
 
 export default ScrollArea;

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaCorner.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaCorner.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 
-const ScrollAreaCorner = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
-    return <div {...props}>{children}</div>;
-};
+type ScrollAreaCornerElement = ElementRef<'div'>;
+type ScrollAreaCornerProps = ComponentPropsWithoutRef<'div'>;
+
+const ScrollAreaCorner = forwardRef<ScrollAreaCornerElement, ScrollAreaCornerProps>(({ children, ...props }, ref) => {
+    return <div ref={ref} {...props}>{children}</div>;
+});
+
+ScrollAreaCorner.displayName = 'ScrollAreaCorner';
 
 export default ScrollAreaCorner;

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import clsx from 'clsx';
 
 import { customClassSwitcher } from '~/core';
@@ -8,13 +8,12 @@ import { ScrollAreaContext } from '../context/ScrollAreaContext';
 
 const COMPONENT_NAME = 'ScrollArea';
 
-type ScrollAreaRootProps = {
-    children: React.ReactNode;
-    className?: string;
+type ScrollAreaRootElement = ElementRef<'div'>;
+type ScrollAreaRootProps = ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
 };
 
-const ScrollAreaRoot = ({ children, className = '', customRootClass = '', ...props }: ScrollAreaRootProps) => {
+const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({ children, className = '', customRootClass = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const scrollXThumbRef = useRef<HTMLDivElement>(null);
     const scrollAreaViewportRef = useRef<HTMLDivElement>(null);
@@ -193,8 +192,10 @@ const ScrollAreaRoot = ({ children, className = '', customRootClass = '', ...pro
     };
 
     return <ScrollAreaContext.Provider value={{ rootClass, scrollXThumbRef, scrollAreaViewportRef, handleScroll, handleScrollbarClick }}>
-        <div className={clsx(rootClass, className)} {...props} >{children}</div>
+        <div ref={ref} className={clsx(rootClass, className)} {...props} >{children}</div>
     </ScrollAreaContext.Provider>;
-};
+});
+
+ScrollAreaRoot.displayName = COMPONENT_NAME;
 
 export default ScrollAreaRoot;

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaScrollbar.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaScrollbar.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import React, { useContext, useRef, useCallback } from 'react';
+import React, { useContext, useRef, useCallback, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { ScrollAreaContext } from '../context/ScrollAreaContext';
 import clsx from 'clsx';
 
-type ScrollAreaScrollbarProps = React.HTMLAttributes<HTMLDivElement> & {
+type ScrollAreaScrollbarElement = ElementRef<'div'>;
+type ScrollAreaScrollbarProps = ComponentPropsWithoutRef<'div'> & {
     orientation?: 'horizontal' | 'vertical';
 };
 
-const ScrollAreaScrollbar = ({ children, className = '', orientation, ...props }: ScrollAreaScrollbarProps) => {
+const ScrollAreaScrollbar = forwardRef<ScrollAreaScrollbarElement, ScrollAreaScrollbarProps>(({ children, className = '', orientation, ...props }, ref) => {
     const { rootClass, handleScrollbarClick, scrollXThumbRef } = useContext(ScrollAreaContext);
     // stores the interval id for the repeated scroll action
     const intervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -106,6 +107,7 @@ const ScrollAreaScrollbar = ({ children, className = '', orientation, ...props }
 
     return (
         <div
+            ref={ref}
             className={clsx(rootClass + '-scrollbar', className)}
             data-orientation={orientation}
             onMouseDown={startContinuousScroll}
@@ -116,6 +118,8 @@ const ScrollAreaScrollbar = ({ children, className = '', orientation, ...props }
             {children}
         </div>
     );
-};
+});
+
+ScrollAreaScrollbar.displayName = 'ScrollAreaScrollbar';
 
 export default ScrollAreaScrollbar;

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaThumb.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaThumb.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import React, { useContext, useRef, useCallback } from 'react';
+import React, { useContext, useRef, useCallback, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { ScrollAreaContext } from '../context/ScrollAreaContext';
 import clsx from 'clsx';
 
-const ScrollAreaThumb = ({ children, className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+type ScrollAreaThumbElement = ElementRef<'div'>;
+type ScrollAreaThumbProps = ComponentPropsWithoutRef<'div'>;
+
+const ScrollAreaThumb = forwardRef<ScrollAreaThumbElement, ScrollAreaThumbProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass, scrollXThumbRef, scrollAreaViewportRef } = useContext(ScrollAreaContext);
     const isDraggingRef = useRef(false);
     const dragStartRef = useRef({ y: 0, scrollTop: 0 });
@@ -82,9 +85,20 @@ const ScrollAreaThumb = ({ children, className = '', ...props }: React.HTMLAttri
         };
     }, [handleDrag, stopDrag]);
 
+    const setRef = (node: ScrollAreaThumbElement | null) => {
+        if (scrollXThumbRef) {
+            (scrollXThumbRef as React.MutableRefObject<ScrollAreaThumbElement | null>).current = node;
+        }
+        if (typeof ref === 'function') {
+            ref(node);
+        } else if (ref) {
+            (ref as React.MutableRefObject<ScrollAreaThumbElement | null>).current = node;
+        }
+    };
+
     return (
         <div
-            ref={scrollXThumbRef}
+            ref={setRef}
             className={clsx(rootClass + '-thumb', className)}
             onMouseDown={startDrag}
             {...props}
@@ -92,6 +106,8 @@ const ScrollAreaThumb = ({ children, className = '', ...props }: React.HTMLAttri
             {children}
         </div>
     );
-};
+});
+
+ScrollAreaThumb.displayName = 'ScrollAreaThumb';
 
 export default ScrollAreaThumb;

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaViewport.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaViewport.tsx
@@ -1,12 +1,28 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { ScrollAreaContext } from '../context/ScrollAreaContext';
 import clsx from 'clsx';
 
-const ScrollAreaViewport = ({ children, className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+type ScrollAreaViewportElement = ElementRef<'div'>;
+type ScrollAreaViewportProps = ComponentPropsWithoutRef<'div'>;
+
+const ScrollAreaViewport = forwardRef<ScrollAreaViewportElement, ScrollAreaViewportProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass, scrollAreaViewportRef, handleScroll } = useContext(ScrollAreaContext);
 
-    return <div ref={scrollAreaViewportRef} className={clsx(rootClass + '-viewport', className)} onScroll={handleScroll} {...props} >{children}</div>;
-};
+    const setRef = (node: ScrollAreaViewportElement | null) => {
+        if (scrollAreaViewportRef) {
+            (scrollAreaViewportRef as React.MutableRefObject<ScrollAreaViewportElement | null>).current = node;
+        }
+        if (typeof ref === 'function') {
+            ref(node);
+        } else if (ref) {
+            (ref as React.MutableRefObject<ScrollAreaViewportElement | null>).current = node;
+        }
+    };
+
+    return <div ref={setRef} className={clsx(rootClass + '-viewport', className)} onScroll={handleScroll} {...props} >{children}</div>;
+});
+
+ScrollAreaViewport.displayName = 'ScrollAreaViewport';
 
 export default ScrollAreaViewport;

--- a/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
+++ b/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ScrollArea from '../ScrollArea';
+
+// Mock ResizeObserver for jsdom
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn()
+})) as unknown as typeof ResizeObserver;
+
+describe('ScrollArea', () => {
+    test('forwards refs and preserves accessibility', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const viewportRef = React.createRef<HTMLDivElement>();
+        const scrollbarRef = React.createRef<HTMLDivElement>();
+        const thumbRef = React.createRef<HTMLDivElement>();
+        const cornerRef = React.createRef<HTMLDivElement>();
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <ScrollArea.Root ref={rootRef} style={{ height: 100 }}>
+                <ScrollArea.Viewport ref={viewportRef}>
+                    <div>content</div>
+                </ScrollArea.Viewport>
+                <ScrollArea.Scrollbar ref={scrollbarRef} orientation='vertical'>
+                    <ScrollArea.Thumb ref={thumbRef} />
+                </ScrollArea.Scrollbar>
+                <ScrollArea.Corner ref={cornerRef} />
+            </ScrollArea.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(viewportRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(scrollbarRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(thumbRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(cornerRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(screen.getByText('content')).toBeInTheDocument();
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- refactor ScrollArea and all fragments to forward refs with React.forwardRef
- add unit test ensuring ScrollArea refs forward correctly and remain accessible

## Testing
- `npm test src/components/ui/ScrollArea/tests/ScrollArea.test.tsx`
- `npm run check:types`