### PR TITLE
refactor: forward refs in Strong component

### DIFF
--- a/src/components/ui/Strong/Strong.tsx
+++ b/src/components/ui/Strong/Strong.tsx
@@ -1,20 +1,25 @@
+"use client";
 import React from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
+
 const COMPONENT_NAME = 'Strong';
 
-export type StrongProps = {
-    children: React.ReactNode,
-    className?: string,
-    customRootClass?: string
-} & React.ComponentProps<'strong'>
-
-const Strong = ({ children, className, customRootClass, ...props }: StrongProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return (
-        <strong className={clsx(rootClass, className)} {...props} >{children}</strong>
-    );
+export type StrongProps = React.ComponentPropsWithoutRef<'strong'> & {
+    customRootClass?: string;
+    className?: string;
 };
+
+const Strong = React.forwardRef<React.ElementRef<'strong'>, StrongProps>(
+    ({ children, className, customRootClass, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        return (
+            <strong ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </strong>
+        );
+    }
+);
 
 Strong.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Strong/tests/Strong.test.tsx
+++ b/src/components/ui/Strong/tests/Strong.test.tsx
@@ -3,35 +3,57 @@ import { render, screen } from '@testing-library/react';
 import Strong from '../Strong';
 
 describe('Strong Component', () => {
-    const Component = () => <Strong className='font-bold'>I am Strong!</Strong>;
+    it('renders content accessible to screen readers', () => {
+        render(<Strong>I am Strong!</Strong>);
 
-    test('renders Strong component', () => {
-        render(<Component />);
-        expect(screen.getByText('I am Strong!')).toBeInTheDocument();
+        const strongElement = screen.getByText('I am Strong!');
+        expect(strongElement).toBeInTheDocument();
+        expect(strongElement.tagName).toBe('STRONG');
+        expect(strongElement).not.toHaveAttribute('aria-hidden');
     });
 
-    test('renders Strong component with className', () => {
-        render(<Component />);
+    it('forwards ref to the strong element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Strong ref={ref}>ref test</Strong>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName).toBe('STRONG');
+    });
+
+    it('renders Strong component with className', () => {
+        render(<Strong className='font-bold'>I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveClass('font-bold');
     });
 
-    test('renders Strong component with custom className', () => {
+    it('renders Strong component with custom className', () => {
         render(<Strong className="text-gray-1000">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveClass('text-gray-1000');
     });
 
-    test('renders Strong component with custom style', () => {
+    it('renders Strong component with custom style', () => {
         render(<Strong style={{ color: 'red' }}>I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveStyle('color: red');
     });
 
-    test('renders Strong component with custom id', () => {
+    it('renders Strong component with custom id', () => {
         render(<Strong id="strong-id">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveAttribute('id', 'strong-id');
     });
 
-    test('renders Strong component with custom data attribute', () => {
+    it('renders Strong component with custom data attribute', () => {
         render(<Strong data-testid="strong-data">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveAttribute('data-testid', 'strong-data');
+    });
+
+    it('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Strong>I am Strong!</Strong>);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- refactor `Strong` to use `React.forwardRef`
- add tests for ref forwarding, accessibility, and warning-free rendering

## Testing
- `npm test`
- `npm run build:rollup`
