### PR TITLE
refactor(switch): forward refs

### DIFF
--- a/src/components/ui/Switch/fragments/SwitchRoot.tsx
+++ b/src/components/ui/Switch/fragments/SwitchRoot.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import { customClassSwitcher } from '~/core';
 import { SwitchContext } from '../context/SwitchContext';
-import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
+import {
+    useCreateDataAttribute,
+    useComposeAttributes,
+    useCreateDataAccentColorAttribute
+} from '~/core/hooks/createDataAttribute';
 import useControllableState from '~/core/hooks/useControllableState';
 
 const COMPONENT_NAME = 'Switch';
 
-export type SwitchRootProps = {
+export type SwitchRootElement = ElementRef<typeof ButtonPrimitive>;
+export type SwitchRootProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     children: React.ReactNode;
     customRootClass?: string;
     color?: string;
@@ -25,7 +30,7 @@ export type SwitchRootProps = {
     asChild?: boolean;
 };
 
-const SwitchRoot = ({
+const SwitchRoot = forwardRef<SwitchRootElement, SwitchRootProps>(({
     children,
     customRootClass,
     color = '',
@@ -40,7 +45,7 @@ const SwitchRoot = ({
     value,
     asChild = false,
     ...props
-}: SwitchRootProps) => {
+}, ref) => {
     const [isChecked, setIsChecked] = useControllableState(
         checked,
         defaultChecked,
@@ -83,6 +88,7 @@ const SwitchRoot = ({
     return (
         <SwitchContext.Provider value={contextValues}>
             <ButtonPrimitive
+                ref={ref}
                 onClick={handleCheckedChange}
                 className={rootClass}
                 asChild={asChild}
@@ -92,6 +98,8 @@ const SwitchRoot = ({
             </ButtonPrimitive>
         </SwitchContext.Provider>
     );
-};
+});
+
+SwitchRoot.displayName = COMPONENT_NAME;
 
 export default SwitchRoot;

--- a/src/components/ui/Switch/fragments/SwitchThumb.tsx
+++ b/src/components/ui/Switch/fragments/SwitchThumb.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import { SwitchContext } from '../context/SwitchContext';
 
-export type SwitchThumbProps = {
+export type SwitchThumbElement = ElementRef<typeof Primitive.span>;
+export type SwitchThumbProps = ComponentPropsWithoutRef<typeof Primitive.span> & {
     asChild?: boolean;
     className?: string;
     children?: React.ReactNode;
 };
 
-const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchThumbProps) => {
+const SwitchThumb = forwardRef<SwitchThumbElement, SwitchThumbProps>(({ asChild = false, className, children, ...props }, ref) => {
     const { checked, rootClass, disabled } = useContext(SwitchContext);
 
     const dataAttributes: Record<string, string> = {};
@@ -21,6 +22,7 @@ const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchT
 
     return (
         <Primitive.span
+            ref={ref}
             role='switch'
             className={`${rootClass}-indicator ${className || ''}`}
             asChild={asChild}
@@ -30,6 +32,8 @@ const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchT
             {children}
         </Primitive.span>
     );
-};
+});
+
+SwitchThumb.displayName = 'SwitchThumb';
 
 export default SwitchThumb;

--- a/src/components/ui/Switch/tests/Switch.test.tsx
+++ b/src/components/ui/Switch/tests/Switch.test.tsx
@@ -4,6 +4,7 @@ import Switch from '../Switch';
 
 describe('Switch Component', () => {
     test('renders correctly with composable API', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const { container } = render(
             <Switch.Root>
                 <Switch.Thumb />
@@ -12,6 +13,8 @@ describe('Switch Component', () => {
         expect(container.firstChild).toBeInTheDocument();
         const switchElement = container.querySelector('[role="switch"]');
         expect(switchElement).toBeInTheDocument();
+        expect(consoleSpy).not.toHaveBeenCalled();
+        consoleSpy.mockRestore();
     });
 
     test('warns when using Switch directly', () => {
@@ -23,6 +26,26 @@ describe('Switch Component', () => {
         );
 
         consoleSpy.mockRestore();
+    });
+
+    test('forwards ref to Switch.Root', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <Switch.Root ref={ref}>
+                <Switch.Thumb />
+            </Switch.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('forwards ref to Switch.Thumb', () => {
+        const ref = React.createRef<HTMLSpanElement>();
+        render(
+            <Switch.Root>
+                <Switch.Thumb ref={ref} />
+            </Switch.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLSpanElement);
     });
 
     test('toggles state correctly', () => {
@@ -39,6 +62,18 @@ describe('Switch Component', () => {
 
         fireEvent.click(switchButton!);
         expect(switchButton).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    test('aria-checked updates with state', () => {
+        const { container } = render(
+            <Switch.Root>
+                <Switch.Thumb />
+            </Switch.Root>
+        );
+        const switchButton = container.querySelector('button')!;
+        expect(switchButton).toHaveAttribute('aria-checked', 'false');
+        fireEvent.click(switchButton);
+        expect(switchButton).toHaveAttribute('aria-checked', 'true');
     });
 
     test('thumb indicator reflects switch state', () => {


### PR DESCRIPTION
## Summary
- forward Switch.Root and Switch.Thumb refs to underlying primitives
- strengthen Switch typings with ElementRef and ComponentPropsWithoutRef
- add tests for ref forwarding and accessibility attributes

## Testing
- `npm test -- src/components/ui/Switch/tests/Switch.test.tsx`
- `npm run build:rollup`
