### PR TITLE
refactor(TabNav): forward refs and add tests

### DIFF
--- a/src/components/ui/TabNav/fragments/TabNavLink.tsx
+++ b/src/components/ui/TabNav/fragments/TabNavLink.tsx
@@ -1,23 +1,30 @@
-import React, { useContext, useRef } from 'react';
+import React, { useContext, useRef, forwardRef, useCallback } from 'react';
 import { clsx } from 'clsx';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import Primitive from '~/core/primitives/Primitive';
 import TabNavContext from '../context/TabNav.context';
 
-export type TabNavLinkProps = {
-    children: React.ReactNode,
-    className?: string,
-    href?: string,
+export type TabNavLinkProps = React.ComponentPropsWithoutRef<'a'> & {
     disabled?: boolean,
     asChild?: boolean,
     value?: string
 }
 
-const TabNavLink = ({ value, className = '', href = '#', children, disabled, asChild }: TabNavLinkProps) => {
+const TabNavLink = forwardRef<React.ElementRef<'a'>, TabNavLinkProps>(({ 
+    value, className = '', href = '#', children, disabled, asChild, ...props
+}, forwardedRef) => {
     const { rootClass, tabValue, handleTabChange } = useContext(TabNavContext);
     if (asChild) disabled = false;
 
-    const ref = useRef<HTMLAnchorElement>(null);
+    const ref = useRef<HTMLAnchorElement | null>(null);
+    const composedRef = useCallback((node: HTMLAnchorElement | null) => {
+        (ref as React.MutableRefObject<HTMLAnchorElement | null>).current = node;
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(node);
+        } else if (forwardedRef) {
+            (forwardedRef as React.MutableRefObject<HTMLAnchorElement | null>).current = node;
+        }
+    }, [forwardedRef]);
 
     const isActive = value === tabValue;
 
@@ -34,18 +41,21 @@ const TabNavLink = ({ value, className = '', href = '#', children, disabled, asC
         <RovingFocusGroup.Item
             onFocus={() => value && !disabled && handleFocus(value)}>
             <Primitive.a
-                ref={ref}
+                ref={composedRef}
                 className={clsx(`${rootClass}-link`, className)}
                 asChild={asChild}
                 aria-disabled={disabled}
                 aria-selected={isActive}
                 disabled={disabled}
                 {...disabled ? {} : { href }}
+                {...props}
             >
                 {children}
             </Primitive.a>
         </RovingFocusGroup.Item>
     );
-};
+});
+
+TabNavLink.displayName = 'TabNavLink';
 
 export default TabNavLink;

--- a/src/components/ui/TabNav/fragments/TabNavRoot.tsx
+++ b/src/components/ui/TabNav/fragments/TabNavRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, forwardRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
@@ -7,11 +7,9 @@ import useControllableState from '~/core/hooks/useControllableState';
 
 const COMPONENT_NAME = 'TabNav';
 
-export type TabNavRootProps = {
-    className?: string,
+export type TabNavRootProps = React.ComponentPropsWithoutRef<'div'> & {
     loop?: boolean,
     orientation?: 'horizontal' | 'vertical',
-    children: React.ReactNode,
     customRootClass?: string,
     color?: string;
     value?: string,
@@ -19,11 +17,11 @@ export type TabNavRootProps = {
     onValueChange?: (value: string) => void
 }
 
-const TabNavRoot = ({
+const TabNavRoot = forwardRef<React.ElementRef<'div'>, TabNavRootProps>(({ 
     className, loop = true, orientation = 'horizontal', children, color, customRootClass = '', defaultValue = '',
     onValueChange = () => {},
     value, ...props
-}: TabNavRootProps) => {
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [tabValue, setTabValue] = useControllableState<string>(
@@ -55,13 +53,17 @@ const TabNavRoot = ({
     return (
         <TabNavContext.Provider value={contextValues}>
             <RovingFocusGroup.Root loop={loop} orientation={orientation} >
-                <RovingFocusGroup.Group className={clsx(rootClass, className)} {...props}>
-                    {children}
+                <RovingFocusGroup.Group {...({ asChild: true } as any)}>
+                    <div ref={ref} className={clsx(rootClass, className)} {...props}>
+                        {children}
+                    </div>
                 </RovingFocusGroup.Group>
             </RovingFocusGroup.Root>
         </TabNavContext.Provider>
 
     );
-};
+});
+
+TabNavRoot.displayName = 'TabNavRoot';
 
 export default TabNavRoot;

--- a/src/components/ui/TabNav/tests/TabNav.test.tsx
+++ b/src/components/ui/TabNav/tests/TabNav.test.tsx
@@ -87,4 +87,47 @@ describe('TabNav', () => {
 
         expect(screen.getByText('Tab 2')).toHaveAttribute('aria-selected', 'true');
     });
+
+    it('forwards refs to DOM elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const linkRef = React.createRef<HTMLAnchorElement>();
+
+        render(
+            <TabNav.Root ref={rootRef}>
+                <TabNav.Link ref={linkRef} value="tab1">Tab 1</TabNav.Link>
+            </TabNav.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(linkRef.current).toBeInstanceOf(HTMLAnchorElement);
+    });
+
+    it('renders without console warnings or errors', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <TabNav.Root>
+                <TabNav.Link value="tab1">Tab 1</TabNav.Link>
+            </TabNav.Root>
+        );
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    it('maintains accessibility attributes', () => {
+        render(
+            <TabNav.Root>
+                <TabNav.Link value="tab1">Tab 1</TabNav.Link>
+            </TabNav.Root>
+        );
+
+        const link = screen.getByText('Tab 1');
+        expect(link).toHaveAccessibleName('Tab 1');
+        expect(link).not.toHaveAttribute('aria-hidden');
+    });
 });


### PR DESCRIPTION
## Summary
- refactor TabNav.Root and TabNav.Link to forward refs to their DOM elements
- add comprehensive tests for ref forwarding and accessibility

## Testing
- `npm test -- src/components/ui/TabNav/tests/TabNav.test.tsx`
- `npm run build:rollup`
