### PR TITLE
refactor: forward refs in Text component

### DIFF
--- a/src/components/ui/Text/Text.tsx
+++ b/src/components/ui/Text/Text.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 
@@ -16,21 +16,28 @@ export type TextProps = {
     customRootClass?: string;
     className?: string;
     as?: string;
-} & React.ComponentProps<'p'>;
+} & ComponentPropsWithoutRef<'p'>;
 
-const Text = ({ children, customRootClass = '', className = '', as = 'p', ...props }: TextProps) => {
-    const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME);
+type TextElement = ElementRef<'p'>;
 
-    if (!TAGS.includes(as)) {
-        as = 'p';
+const Text = forwardRef<TextElement, TextProps>(
+    (
+        { children, customRootClass = '', className = '', as = 'p', ...props },
+        ref
+    ) => {
+        const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME);
+
+        if (!TAGS.includes(as)) {
+            as = 'p';
+        }
+
+        return React.createElement(
+            as,
+            { ref, className: clsx(rootClassName, className), ...props },
+            children
+        );
     }
-
-    return React.createElement(
-        as,
-        { className: clsx(rootClassName, className), ...props },
-        children
-    );
-};
+);
 
 Text.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Text/tests/Text.test.js
+++ b/src/components/ui/Text/tests/Text.test.js
@@ -87,4 +87,26 @@ describe('Text Component', () => {
         render(<Text as={true} >I am Text!</Text>);
         expect(screen.getByText('I am Text!')).toHaveProperty('tagName', 'P');
     });
+
+    test('forwards ref to the underlying element', () => {
+        const ref = React.createRef();
+        render(<Text ref={ref}>I am Text!</Text>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current.tagName).toBe('P');
+    });
+
+    test('passes through accessibility attributes', () => {
+        render(<Text aria-label='hidden text'>Hidden content</Text>);
+        expect(screen.getByLabelText('hidden text')).toBeInTheDocument();
+    });
+
+    test('renders without console warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Text>I am Text!</Text>);
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Text component to use `forwardRef`
- add tests for ref forwarding and accessibility

## Testing
- `npx jest src/components/ui/Text/tests/Text.test.js`
- `npm run build:rollup`
