### PR TITLE
refactor(TextArea): forward refs

### DIFF
--- a/src/components/ui/TextArea/TextArea.test.tsx
+++ b/src/components/ui/TextArea/TextArea.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TextArea from './TextArea';
+
+describe('TextArea', () => {
+    it('forwards ref to the root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<TextArea ref={ref}>content</TextArea>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('forwards ref to the input element', () => {
+        const ref = React.createRef<HTMLTextAreaElement>();
+        render(<TextArea.Input ref={ref} placeholder="test" />);
+        expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+    });
+
+    it('forwards ref to the root subcomponent', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<TextArea.Root ref={ref}>child</TextArea.Root>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('is accessible via placeholder', () => {
+        render(<TextArea>hidden</TextArea>);
+        expect(screen.getByPlaceholderText('enter text')).toBeInTheDocument();
+    });
+
+    it('renders without console warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<TextArea>content</TextArea>);
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+
+    it('matches snapshot', () => {
+        const { container } = render(<TextArea>content</TextArea>);
+        expect(container.firstChild).toMatchSnapshot();
+    });
+});

--- a/src/components/ui/TextArea/TextArea.tsx
+++ b/src/components/ui/TextArea/TextArea.tsx
@@ -4,21 +4,27 @@ import { clsx } from 'clsx';
 import TextAreaRoot from './fragments/TextAreaRoot';
 import TextAreaInput from './fragments/TextAreaInput';
 
-export type TextAreaProps = {
-    children: React.ReactNode;
+export type TextAreaProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
-    className?: string;
-}
-
-const TextArea = ({ customRootClass = '', className = '', children, ...props }: TextAreaProps) => {
-    return <TextAreaRoot customRootClass={customRootClass} className={clsx(className)}>
-        <TextAreaInput placeholder="enter text">
-            {children}
-        </TextAreaInput>
-        {children}
-    </TextAreaRoot>;
 };
 
+type TextAreaComponent = React.ForwardRefExoticComponent<TextAreaProps & React.RefAttributes<React.ElementRef<'div'>>> & {
+    Input: typeof TextAreaInput;
+    Root: typeof TextAreaRoot;
+};
+
+const TextArea = React.forwardRef<React.ElementRef<'div'>, TextAreaProps>(({ customRootClass = '', className = '', children, ...props }, ref) => {
+    return (
+        <TextAreaRoot ref={ref} customRootClass={customRootClass} className={clsx(className)} {...props}>
+            <TextAreaInput placeholder="enter text">
+                {children}
+            </TextAreaInput>
+            {children}
+        </TextAreaRoot>
+    );
+}) as TextAreaComponent;
+
+TextArea.displayName = 'TextArea';
 TextArea.Input = TextAreaInput;
 TextArea.Root = TextAreaRoot;
 

--- a/src/components/ui/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/ui/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea matches snapshot 1`] = `
+<div
+  class="rad-ui-text-area"
+>
+  <textarea
+    placeholder="enter text"
+  >
+    content
+  </textarea>
+  content
+</div>
+`;

--- a/src/components/ui/TextArea/fragments/TextAreaInput.tsx
+++ b/src/components/ui/TextArea/fragments/TextAreaInput.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 
-type TextAreaInputProps = {
-    children: React.ReactNode;
-    placeholder?: string;
-}
+export type TextAreaInputProps = React.ComponentPropsWithoutRef<'textarea'>;
 
-const TextAreaInput = ({ children, placeholder = '' }:TextAreaInputProps) => {
-    return <textarea placeholder={placeholder}>
-        {children}
-    </textarea>;
-};
+const TextAreaInput = React.forwardRef<React.ElementRef<'textarea'>, TextAreaInputProps>(
+    ({ children, placeholder = '', ...props }, ref) => (
+        <textarea
+            ref={ref}
+            placeholder={placeholder}
+            defaultValue={typeof children === 'string' ? children : undefined}
+            {...props}
+        />
+    )
+);
+
+TextAreaInput.displayName = 'TextAreaInput';
 
 export default TextAreaInput;

--- a/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
+++ b/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
@@ -4,17 +4,22 @@ import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'TextArea';
 
-export type TextAreaProps = {
-    children: React.ReactNode;
+export type TextAreaRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
-    className?: string;
-}
-
-const TextAreaRoot = ({ children, customRootClass = '', className = '' }:TextAreaProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <div className={clsx(rootClass, className)}>
-        {children}
-    </div>;
 };
+
+const TextAreaRoot = React.forwardRef<React.ElementRef<'div'>, TextAreaRootProps>(
+    ({ children, customRootClass = '', className = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+
+        return (
+            <div ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </div>
+        );
+    }
+);
+
+TextAreaRoot.displayName = COMPONENT_NAME;
 
 export default TextAreaRoot;


### PR DESCRIPTION
## Summary
- refactor TextArea, TextAreaRoot, and TextAreaInput to forward refs with React.forwardRef
- add tests covering ref forwarding, accessibility, and snapshot

## Testing
- `npm test`
- `npm run build:rollup`
