### PR TITLE
refactor: forward refs in Theme

### DIFF
--- a/src/components/ui/Theme/Theme.tsx
+++ b/src/components/ui/Theme/Theme.tsx
@@ -1,16 +1,23 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { forwardRef, useState, useEffect, ElementRef, ComponentPropsWithoutRef } from 'react';
 
-type ThemeProps = {
+type ThemeElement = ElementRef<'div'>;
+export type ThemeProps = ComponentPropsWithoutRef<'div'> & {
     appearance?: 'light' | 'dark' | 'system';
     accentColor?: string;
     radius?: string;
     scaling?: string;
-    children: React.ReactNode;
-    id?: string;
-}
+};
 
-const Theme = ({ appearance = 'system', id = 'rad-ui-theme-container', accentColor = '', radius = '', scaling = '', children, ...props }: ThemeProps) => {
+const Theme = forwardRef<ThemeElement, ThemeProps>(function Theme({
+    appearance = 'system',
+    id = 'rad-ui-theme-container',
+    accentColor = '',
+    radius = '',
+    scaling = '',
+    children,
+    ...props
+}, ref) {
     const [theme, setTheme] = useState(appearance);
     const [themeAccentColor, setThemeAccentColor] = useState(accentColor);
     const [themeRadius, setThemeRadius] = useState(radius);
@@ -52,16 +59,21 @@ const Theme = ({ appearance = 'system', id = 'rad-ui-theme-container', accentCol
         }
     }, [scaling]);
 
-    return <div
-        id={id}
-        data-rad-ui-theme={theme}
-        data-rad-ui-accent-color={themeAccentColor}
-        data-rad-ui-radius={themeRadius}
-        data-rad-ui-scaling={themeScaling}
-        {...props}
-    >
-        {children}
-    </div>;
-};
+    return (
+        <div
+            ref={ref}
+            id={id}
+            data-rad-ui-theme={theme}
+            data-rad-ui-accent-color={themeAccentColor}
+            data-rad-ui-radius={themeRadius}
+            data-rad-ui-scaling={themeScaling}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+});
+
+Theme.displayName = 'Theme';
 
 export default Theme;

--- a/src/components/ui/Theme/tests/Theme.test.tsx
+++ b/src/components/ui/Theme/tests/Theme.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, screen } from '@testing-library/react';
 
 import Theme from '../Theme';
 
@@ -44,5 +44,30 @@ describe('Theme', () => {
         unmount();
 
         expect(mediaQueryList.removeEventListener).toHaveBeenCalledWith('change', addedListener);
+    });
+
+    test('forwards ref to underlying div', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Theme ref={ref}>content</Theme>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        expect(ref.current).toContainElement(screen.getByText('content'));
+    });
+
+    test('renders without console warnings', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Theme>content</Theme>);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test('renders children accessibly', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        render(<Theme>content</Theme>);
+        expect(screen.getByText('content')).toBeVisible();
     });
 });


### PR DESCRIPTION
## Summary
- refactor Theme to forward refs and expose generic element types
- test Theme ref forwarding, accessibility, and warning-free rendering

## Testing
- `npm test`
- `npm run build:rollup`
