### PR TITLE
refactor(Tree): forward refs and add tests

### DIFF
--- a/src/components/ui/Tree/Tree.tsx
+++ b/src/components/ui/Tree/Tree.tsx
@@ -1,24 +1,31 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import TreeRoot from './fragments/TreeRoot';
 import TreeItem from './fragments/TreeItem';
 
 const COMPONENT_NAME = 'Tree';
 
-// Empty props type - only supporting fragment exports
-export type TreeProps = React.HTMLAttributes<HTMLDivElement> & {
+export type TreeElement = HTMLDivElement;
+export type TreeProps = React.ComponentPropsWithoutRef<'div'> & {
     children?: React.ReactNode;
 };
 
-// Empty implementation - we don't support direct usage
-const Tree = () => {
-    console.warn('Direct usage of Tree is not supported. Please use Tree.Root and Tree.Item instead.');
-    return null;
+type TreeComponent = React.ForwardRefExoticComponent<TreeProps & React.RefAttributes<TreeElement>> & {
+    Root: typeof TreeRoot;
+    Item: typeof TreeItem;
 };
+
+const Tree = forwardRef<TreeElement, TreeProps>(({ children, ...props }, ref) => {
+    console.warn('Direct usage of Tree is not supported. Please use Tree.Root and Tree.Item instead.');
+    return (
+        <div ref={ref} {...props}>
+            {children}
+        </div>
+    );
+}) as TreeComponent;
 
 Tree.displayName = COMPONENT_NAME;
 
-// Export fragments via direct assignment pattern
 Tree.Root = TreeRoot;
 Tree.Item = TreeItem;
 

--- a/src/components/ui/Tree/fragments/TreeRoot.tsx
+++ b/src/components/ui/Tree/fragments/TreeRoot.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
+import type { ElementRef, ComponentPropsWithoutRef } from 'react';
 
 import { TreeContext } from '../contexts/TreeContext';
 
@@ -9,17 +10,16 @@ import clsx from 'clsx';
 
 const COMPONENT_NAME = 'Tree';
 
-type TreeRootProps = {
-    children: React.ReactNode;
-    className?: string;
+export type TreeRootElement = ElementRef<typeof Primitive.div>;
+export type TreeRootProps = {
     customRootClass?: string;
     'aria-label'?: string;
     'aria-labelledby'?: string;
-    [key: string]: any;
-};
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
 
-const TreeRoot = ({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }: TreeRootProps) => {
-    const treeRef = useRef<HTMLDivElement | null>(null);
+const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }, ref) => {
+    const treeRef = useRef<TreeRootElement>(null);
+    useImperativeHandle(ref, () => treeRef.current as TreeRootElement);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const treeContextValue = {
@@ -33,11 +33,11 @@ const TreeRoot = ({ children, className = '', customRootClass = '', 'aria-label'
                 <RovingFocusGroup.Group>
                     <Primitive.div
                         className={clsx(rootClass, className)}
-                        {...props}
                         ref={treeRef}
                         role="tree"
                         aria-label={ariaLabel}
                         aria-labelledby={ariaLabelledBy}
+                        {...props}
                     >
                         {children}
                     </Primitive.div>
@@ -45,6 +45,9 @@ const TreeRoot = ({ children, className = '', customRootClass = '', 'aria-label'
             </RovingFocusGroup.Root>
         </TreeContext.Provider>
     );
-};
+});
+
+TreeRoot.displayName = COMPONENT_NAME;
 
 export default TreeRoot;
+

--- a/src/components/ui/Tree/tests/Tree.test.tsx
+++ b/src/components/ui/Tree/tests/Tree.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Tree from '../Tree';
+
+describe('Tree', () => {
+    test('forwards ref to root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Tree.Root ref={ref} aria-label='Files'>
+                <Tree.Item item={{ label: 'Item' }}>Item</Tree.Item>
+            </Tree.Root>
+        );
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('DIV');
+    });
+
+    test('forwards ref to item element', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <Tree.Root aria-label='Files'>
+                <Tree.Item ref={ref} item={{ label: 'Item' }}>Item</Tree.Item>
+            </Tree.Root>
+        );
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('BUTTON');
+    });
+
+    test('applies aria-label for accessibility', () => {
+        render(
+            <Tree.Root aria-label='File explorer'>
+                <Tree.Item item={{ label: 'Item' }}>Item</Tree.Item>
+            </Tree.Root>
+        );
+        expect(screen.getByRole('tree')).toHaveAttribute('aria-label', 'File explorer');
+    });
+
+    test('renders children when expanded', async () => {
+        const user = userEvent.setup();
+        const item = { label: 'Parent', items: [{ label: 'Child', items: [] }] };
+        render(
+            <Tree.Root aria-label='Files'>
+                <Tree.Item item={item}>{item.label}</Tree.Item>
+            </Tree.Root>
+        );
+        expect(screen.queryByText('Child')).toBeNull();
+        await user.click(screen.getByText('Parent'));
+        expect(screen.getByText('Child')).toBeInTheDocument();
+    });
+
+    test('renders without console errors or warnings', () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(
+            <Tree.Root aria-label='Files'>
+                <Tree.Item item={{ label: 'Item' }}>Item</Tree.Item>
+            </Tree.Root>
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+        expect(consoleWarn).not.toHaveBeenCalled();
+        consoleError.mockRestore();
+        consoleWarn.mockRestore();
+    });
+});
+


### PR DESCRIPTION
## Summary
- refactor Tree, TreeRoot, and TreeItem to forward refs with proper typing
- add accessibility and ref-forwarding tests for Tree

## Testing
- `npm test`
- `npm run build:rollup`
