### PR TITLE
refactor: forward refs in Separator

### DIFF
--- a/src/components/ui/Separator/Separator.tsx
+++ b/src/components/ui/Separator/Separator.tsx
@@ -2,54 +2,59 @@ import React from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import Primitive from '~/core/primitives/Primitive';
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
 const COMPONENT_NAME = 'Separator';
 
+type SeparatorElement = ElementRef<typeof Primitive.div>;
+type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+
 export type SeparatorProps = {
     orientation?: 'horizontal' | 'vertical';
-    className?: string;
     customRootClass?: string;
     color?: string;
-    asChild?: boolean;
     decorative?: boolean;
-    props?: any;
-} & React.ComponentProps<'div'>;
+} & PrimitiveDivProps;
 
-const Separator = ({
-    orientation = 'horizontal',
-    className,
-    customRootClass,
-    color = '',
-    asChild = false,
-    decorative = false,
-    ...props
-}: SeparatorProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const orientationClass = orientation === 'vertical' ? `${rootClass}-vertical` : `${rootClass}-horizontal`;
-    const data_attributes: Record<string, string> = {};
+const Separator = React.forwardRef<SeparatorElement, SeparatorProps>(
+    (
+        {
+            orientation = 'horizontal',
+            className,
+            customRootClass,
+            color = '',
+            decorative = false,
+            ...props
+        },
+        ref
+    ) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const orientationClass = orientation === 'vertical' ? `${rootClass}-vertical` : `${rootClass}-horizontal`;
+        const data_attributes: Record<string, string> = {};
 
-    // Add data-orientation attribute
-    data_attributes['data-orientation'] = orientation;
+        // Add data-orientation attribute
+        data_attributes['data-orientation'] = orientation;
 
-    if (color) {
-        data_attributes['data-rad-ui-accent-color'] = color;
+        if (color) {
+            data_attributes['data-rad-ui-accent-color'] = color;
+        }
+
+        // Add decorative role if specified
+        if (decorative) {
+            data_attributes.role = 'separator';
+            data_attributes['aria-hidden'] = 'true';
+        }
+
+        return (
+            <Primitive.div
+                ref={ref}
+                className={clsx(rootClass, orientationClass, className)}
+                {...data_attributes}
+                {...props}
+            />
+        );
     }
-
-    // Add decorative role if specified
-    if (decorative) {
-        data_attributes.role = 'separator';
-        data_attributes['aria-hidden'] = 'true';
-    }
-
-    return (
-        <Primitive.div
-            className={clsx(rootClass, orientationClass, className)}
-            asChild={asChild}
-            {...data_attributes}
-            {...props}
-        />
-    );
-};
+);
 
 Separator.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Separator/tests/Separator.test.tsx
+++ b/src/components/ui/Separator/tests/Separator.test.tsx
@@ -28,6 +28,29 @@ describe('Separator Component', () => {
         expect(screen.getByTestId('separator')).toHaveAttribute('data-rad-ui-accent-color', 'blue');
     });
 
+    test('forwards ref to underlying DOM element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Separator ref={ref} data-testid="separator" />);
+        expect(ref.current).toBe(screen.getByTestId('separator'));
+    });
+
+    test('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Separator data-testid="separator" />);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test('non-decorative separator is accessible to screen readers', () => {
+        render(<Separator data-testid="separator" />);
+        const separator = screen.getByTestId('separator');
+        expect(separator).not.toHaveAttribute('aria-hidden');
+        expect(separator).not.toHaveAttribute('role');
+    });
+
     // New tests for the GitHub issue #1269 features
     describe('New Props and Features', () => {
         test('asChild prop works correctly', () => {


### PR DESCRIPTION
## Summary
- refactor Separator to forward refs via React.forwardRef
- cover ref forwarding and accessibility in tests

## Testing
- `npm test src/components/ui/Separator/tests/Separator.test.tsx`
- `npm run build:rollup`
