### PR TITLE
refactor slider with forward refs

### DIFF
--- a/src/components/ui/Slider/Slider.tsx
+++ b/src/components/ui/Slider/Slider.tsx
@@ -1,14 +1,27 @@
 'use client';
 
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, ForwardRefExoticComponent, RefAttributes } from 'react';
 import SliderRoot from './fragments/SliderRoot';
 import SliderTrack from './fragments/SliderTrack';
 import SliderThumb from './fragments/SliderThumb';
 import SliderRange from './fragments/SliderRange';
 
-const Slider = () => {
+export type SliderElement = ElementRef<'div'>;
+export type SliderProps = ComponentPropsWithoutRef<'div'>;
+
+type SliderComponent = ForwardRefExoticComponent<SliderProps & RefAttributes<SliderElement>> & {
+    Root: typeof SliderRoot;
+    Track: typeof SliderTrack;
+    Range: typeof SliderRange;
+    Thumb: typeof SliderThumb;
+};
+
+const Slider = forwardRef<SliderElement, SliderProps>((_props, _ref) => {
     console.warn('Direct usage of Slider is not supported. Please use Slider.Root, Slider.Track, etc. instead.');
     return null;
-};
+}) as SliderComponent;
+
+Slider.displayName = 'Slider';
 
 Slider.Root = SliderRoot;
 Slider.Track = SliderTrack;

--- a/src/components/ui/Slider/fragments/SliderRange.tsx
+++ b/src/components/ui/Slider/fragments/SliderRange.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderRange = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderRange';
+
+export type SliderRangeElement = ElementRef<'div'>;
+export type SliderRangeProps = { children: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderRange = forwardRef<SliderRangeElement, SliderRangeProps>(({ children, ...props }, ref) => {
     const { rootClass, value } = React.useContext(SliderContext);
 
-    return <div className={`${rootClass}-range`} style={{ left: `calc(${value}% - 16px)`, width: `calc(${value}%)` }}>{children}</div>;
-};
+    return <div ref={ref} className={`${rootClass}-range`} style={{ left: `calc(${value}% - 16px)`, width: `calc(${value}%)` }} {...props}>{children}</div>;
+});
+
+SliderRange.displayName = COMPONENT_NAME;
 
 export default SliderRange;

--- a/src/components/ui/Slider/fragments/SliderRoot.tsx
+++ b/src/components/ui/Slider/fragments/SliderRoot.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import clsx from 'clsx';
 
 import { customClassSwitcher } from '~/core/customClassSwitcher';
@@ -7,7 +7,8 @@ import { SliderContext } from '../context/SliderContext';
 
 const COMPONENT_NAME = 'Slider';
 
-type SliderRootProps = {
+export type SliderRootElement = ElementRef<'div'>;
+export type SliderRootProps = {
     children: React.ReactNode;
     className?: string;
     customRootClass?: string;
@@ -19,9 +20,22 @@ type SliderRootProps = {
     readOnly?: boolean;
     orientation?: 'horizontal' | 'vertical';
     valueLabelDisplay?: 'auto' | 'on' | 'off';
-};
+} & ComponentPropsWithoutRef<'div'>;
 
-const SliderRoot = ({ children, className = '', customRootClass = '', defaultValue = 0, min = 0, max = 100, step = 1, disabled = false, readOnly = false, orientation = 'horizontal', valueLabelDisplay = 'auto' }: SliderRootProps) => {
+const SliderRoot = forwardRef<SliderRootElement, SliderRootProps>(({
+    children,
+    className = '',
+    customRootClass = '',
+    defaultValue = 0,
+    min = 0,
+    max = 100,
+    step = 1,
+    disabled = false,
+    readOnly = false,
+    orientation = 'horizontal',
+    valueLabelDisplay = 'auto',
+    ...props
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [value, setValue] = React.useState(defaultValue);
@@ -89,8 +103,10 @@ const SliderRoot = ({ children, className = '', customRootClass = '', defaultVal
     };
 
     return <SliderContext.Provider value={contextValues}>
-        <div className={clsx(rootClass, className)} onClick={handleClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}>{children}</div>
+        <div ref={ref} className={clsx(rootClass, className)} onClick={handleClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} {...props}>{children}</div>
     </SliderContext.Provider>;
-};
+});
+
+SliderRoot.displayName = COMPONENT_NAME;
 
 export default SliderRoot;

--- a/src/components/ui/Slider/fragments/SliderThumb.tsx
+++ b/src/components/ui/Slider/fragments/SliderThumb.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderThumb = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderThumb';
+
+export type SliderThumbElement = ElementRef<'div'>;
+export type SliderThumbProps = { children?: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderThumb = forwardRef<SliderThumbElement, SliderThumbProps>(({ children: _children, ...props }, ref) => {
     const { rootClass, value } = React.useContext(SliderContext);
     const sliderInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -16,10 +21,12 @@ const SliderThumb = ({ children }: { children: React.ReactNode }) => {
         console.log(e.target.value);
     };
 
-    return <div className={`${rootClass}-thumb`} onClick={handleClick} style={{ left: `calc(${value}% - 16px)` }}>
+    return <div ref={ref} className={`${rootClass}-thumb`} onClick={handleClick} style={{ left: `calc(${value}% - 16px)` }} {...props}>
         <span className={`${rootClass}-thumb-value`}></span>
         <input onChange={handleChange} value={value} style={{ display: 'none' }} ref={sliderInputRef} />
     </div>;
-};
+});
+
+SliderThumb.displayName = COMPONENT_NAME;
 
 export default SliderThumb;

--- a/src/components/ui/Slider/fragments/SliderTrack.tsx
+++ b/src/components/ui/Slider/fragments/SliderTrack.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderTrack = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderTrack';
+
+export type SliderTrackElement = ElementRef<'div'>;
+export type SliderTrackProps = { children: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderTrack = forwardRef<SliderTrackElement, SliderTrackProps>(({ children, ...props }, ref) => {
     const { rootClass } = React.useContext(SliderContext);
 
-    return <div className={`${rootClass}-track`}>{children}</div>;
-};
+    return <div ref={ref} className={`${rootClass}-track`} {...props}>{children}</div>;
+});
+
+SliderTrack.displayName = COMPONENT_NAME;
 
 export default SliderTrack;

--- a/src/components/ui/Slider/tests/Slider.test.tsx
+++ b/src/components/ui/Slider/tests/Slider.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Slider from '../Slider';
+
+describe('Slider Component', () => {
+    test('Slider.Root forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root ref={ref}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Track forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track ref={ref}>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Range forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range ref={ref}>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Thumb forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb ref={ref} />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('hidden input is present for accessibility', () => {
+        render(
+            <Slider.Root defaultValue={50}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        const hiddenInput = screen.getByRole('textbox', { hidden: true });
+        expect(hiddenInput).toHaveValue('50');
+    });
+
+    test('renders without warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    test('matches snapshot', () => {
+        const { asFragment } = render(
+            <Slider.Root defaultValue={25}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/src/components/ui/Slider/tests/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/ui/Slider/tests/__snapshots__/Slider.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider Component matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="rad-ui-slider"
+  >
+    <div
+      class="rad-ui-slider-track"
+    >
+      <div
+        class="rad-ui-slider-range"
+        style="left: calc(25% - 16px); width: calc(25%);"
+      >
+        <div
+          class="rad-ui-slider-thumb"
+          style="left: calc(25% - 16px);"
+        >
+          <span
+            class="rad-ui-slider-thumb-value"
+          />
+          <input
+            style="display: none;"
+            value="25"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Summary
- refactor Slider and fragments to forward refs with proper typings
- add tests for ref forwarding, accessibility, warnings, and snapshot

## Testing
- `npm test`
- `npm run build:rollup`
