### PR TITLE
refactor: forward refs in Tooltip

### DIFF
--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,13 +1,25 @@
 'use client';
 
+import React from 'react';
+
 import TooltipRoot from './fragments/TooltipRoot';
 import TooltipTrigger from './fragments/TooltipTrigger';
 import TooltipContent from './fragments/TooltipContent';
 
-const Tooltip = () => {
-    console.warn('Direct usage of Tabs is not supported. Please use Tabs.Root, Tabs.List, etc. instead.');
-    return null;
-};
+interface TooltipComponent extends React.ForwardRefExoticComponent<React.ComponentPropsWithoutRef<'div'> & React.RefAttributes<React.ElementRef<'div'>>> {
+    Root: typeof TooltipRoot;
+    Trigger: typeof TooltipTrigger;
+    Content: typeof TooltipContent;
+}
+
+const Tooltip = React.forwardRef<React.ElementRef<'div'>, React.ComponentPropsWithoutRef<'div'>>(
+    (_props, _ref) => {
+        console.warn('Direct usage of Tooltip is not supported. Please use Tooltip.Root, Tooltip.Trigger, etc. instead.');
+        return null;
+    }
+) as TooltipComponent;
+
+Tooltip.displayName = 'Tooltip';
 
 Tooltip.Root = TooltipRoot;
 Tooltip.Trigger = TooltipTrigger;

--- a/src/components/ui/Tooltip/fragments/TooltipContent.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipContent.tsx
@@ -1,36 +1,50 @@
-import React, { useContext, forwardRef } from 'react';
+import React, { useContext } from 'react';
 import clsx from 'clsx';
 
 import TooltipContext from '../context/TooltipContext';
 import { useMergeRefs, FloatingPortal, FloatingArrow } from '@floating-ui/react';
 import Primitive from '~/core/primitives/Primitive';
 
-const TooltipContent = forwardRef(({ children, showArrow = true, ...props }: { children: React.ReactNode, showArrow?: boolean } & JSX.IntrinsicElements['div'], propRef: React.Ref<HTMLDivElement>) => {
-    const tooltipContext = useContext(TooltipContext);
+export type TooltipContentElement = React.ElementRef<typeof Primitive.div>;
 
-    if (!tooltipContext) {
-        throw new Error('TooltipContent must be used within a TooltipRoot component');
+export type TooltipContentProps = React.ComponentPropsWithoutRef<typeof Primitive.div> & {
+    showArrow?: boolean;
+    children: React.ReactNode;
+};
+
+const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentProps>(
+    ({ children, showArrow = true, ...props }, ref) => {
+        const tooltipContext = useContext(TooltipContext);
+
+        if (!tooltipContext) {
+            throw new Error('TooltipContent must be used within a TooltipRoot component');
+        }
+
+        const { isOpen, data, interactions, context } = tooltipContext;
+        const arrowRef = tooltipContext.arrowRef;
+
+        const mergedRef = useMergeRefs([context.refs.setFloating, ref]);
+
+        if (!isOpen) return null;
+
+        const { getFloatingProps } = interactions;
+
+        return (
+            <FloatingPortal>
+                <Primitive.div
+                    className="rad-ui-tooltip-floating-element"
+                    ref={mergedRef}
+                    style={{ ...data.floatingStyles }}
+                    {...getFloatingProps(props)}
+                >
+                    {showArrow && <FloatingArrow className={clsx('rad-ui-arrow rad-ui-arrow')} ref={arrowRef} context={context} />}
+                    {children}
+                </Primitive.div>
+            </FloatingPortal>
+
+        );
     }
-
-    const { isOpen, data, interactions, context } = tooltipContext;
-    const arrowRef = tooltipContext.arrowRef;
-
-    const ref = useMergeRefs([context.refs.setFloating, propRef]);
-
-    if (!isOpen) return null;
-
-    const { getFloatingProps } = interactions;
-
-    return (
-        <FloatingPortal>
-            <Primitive.div className="rad-ui-tooltip-floating-element" ref={ref} style={{ ...data.floatingStyles }} {...getFloatingProps(props)}>
-                {showArrow && <FloatingArrow className={clsx('rad-ui-arrow rad-ui-arrow')} ref={arrowRef} context={context} />}
-                {children}
-            </Primitive.div>
-        </FloatingPortal>
-
-    );
-});
+);
 
 TooltipContent.displayName = 'TooltipContent';
 

--- a/src/components/ui/Tooltip/fragments/TooltipRoot.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipRoot.tsx
@@ -5,58 +5,83 @@ import { useFloating, offset, flip, shift, useHover, useFocus, useDismiss, useRo
 
 const COMPONENT_NAME = 'Tooltip';
 
-const TooltipRoot = ({ children, placement = 'top' }: { children: React.ReactNode, placement?: 'top' | 'bottom' | 'left' | 'right' | 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end' | 'left-start' | 'left-end' | 'right-start' | 'right-end' } & JSX.IntrinsicElements['div']) => {
-    const arrowRef = useRef<SVGSVGElement>(null);
+type Placement =
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left-start'
+    | 'left-end'
+    | 'right-start'
+    | 'right-end';
 
-    const [isOpen, setIsOpen] = useState(false);
+export type TooltipRootElement = React.ElementRef<'div'>;
 
-    const data = useFloating({
-        placement,
-        strategy: 'fixed',
-        onOpenChange: setIsOpen,
-        middleware: [
-            arrow({
-                element: arrowRef,
-                padding: 4
-            }),
-            offset(5),
-            flip({
-                crossAxis: true,
-                fallbackAxisSideDirection: 'start',
-                padding: 5
-            }),
-            shift({ padding: 5 })
-        ]
-    });
+export interface TooltipRootProps extends React.ComponentPropsWithoutRef<'div'> {
+    children: React.ReactNode;
+    placement?: Placement;
+}
 
-    const context = data.context;
+const TooltipRoot = React.forwardRef<TooltipRootElement, TooltipRootProps>(
+    ({ children, placement = 'top', ...props }, ref) => {
+        const arrowRef = useRef<SVGSVGElement>(null);
 
-    const hover = useHover(context, {
-        move: false
-        // enabled: isOpen// make this controlled open
-    });
+        const [isOpen, setIsOpen] = useState(false);
 
-    const focus = useFocus(context, {
-        // enabled: isOpen // make this controlled open
-    });
+        const data = useFloating({
+            placement,
+            strategy: 'fixed',
+            onOpenChange: setIsOpen,
+            middleware: [
+                arrow({
+                    element: arrowRef,
+                    padding: 4
+                }),
+                offset(5),
+                flip({
+                    crossAxis: true,
+                    fallbackAxisSideDirection: 'start',
+                    padding: 5
+                }),
+                shift({ padding: 5 })
+            ]
+        });
 
-    const dismiss = useDismiss(context);
+        const context = data.context;
 
-    const role = useRole(context, { role: 'tooltip' });
+        const hover = useHover(context, {
+            move: false
+            // enabled: isOpen// make this controlled open
+        });
 
-    const interactions = useInteractions([
-        hover,
-        focus,
-        dismiss,
-        role
-    ]);
+        const focus = useFocus(context, {
+            // enabled: isOpen // make this controlled open
+        });
 
-    return (
-        <TooltipContext.Provider value={{ isOpen, setIsOpen, data, interactions, context, arrowRef }}>
-            {children}
-        </TooltipContext.Provider>
-    );
-};
+        const dismiss = useDismiss(context);
+
+        const role = useRole(context, { role: 'tooltip' });
+
+        const interactions = useInteractions([
+            hover,
+            focus,
+            dismiss,
+            role
+        ]);
+
+        return (
+            <TooltipContext.Provider value={{ isOpen, setIsOpen, data, interactions, context, arrowRef }}>
+                <div ref={ref} {...props}>
+                    {children}
+                </div>
+            </TooltipContext.Provider>
+        );
+    }
+);
 
 TooltipRoot.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Tooltip/fragments/TooltipTrigger.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipTrigger.tsx
@@ -1,30 +1,44 @@
-import React, { useContext, forwardRef } from 'react';
+import React, { useContext } from 'react';
 
 import TooltipContext from '../context/TooltipContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 import { useMergeRefs } from '@floating-ui/react';
 
-const TooltipTrigger = forwardRef(({ children, asChild, ...props }: { children: React.ReactNode, asChild?: boolean } & JSX.IntrinsicElements['button'], propRef: React.Ref<HTMLButtonElement>) => {
-    const tooltipContext = useContext(TooltipContext);
+export type TooltipTriggerElement = React.ElementRef<typeof ButtonPrimitive>;
 
-    if (!tooltipContext) {
-        throw new Error('TooltipTrigger must be used within a TooltipRoot component');
+export type TooltipTriggerProps = React.ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
+    asChild?: boolean;
+    children: React.ReactNode;
+};
+
+const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerProps>(
+    ({ children, asChild, ...props }, ref) => {
+        const tooltipContext = useContext(TooltipContext);
+
+        if (!tooltipContext) {
+            throw new Error('TooltipTrigger must be used within a TooltipRoot component');
+        }
+
+        const { isOpen, interactions, context } = tooltipContext;
+
+        const { getReferenceProps } = interactions;
+
+        const childrenRef = (children as any).ref;
+
+        const mergedRef = useMergeRefs([context.refs.setReference, ref, childrenRef]);
+
+        return (
+            <ButtonPrimitive
+                asChild={asChild}
+                ref={mergedRef}
+                data-state={isOpen ? 'open' : 'closed'}
+                {...getReferenceProps(props)}
+            >
+                {children}
+            </ButtonPrimitive>
+        );
     }
-
-    const { isOpen, interactions, context } = tooltipContext;
-
-    const { getReferenceProps } = interactions;
-
-    const childrenRef = (children as any).ref;
-
-    const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
-
-    return (
-        <ButtonPrimitive asChild={asChild} ref={ref} data-state={isOpen ? 'open' : 'closed'} {...getReferenceProps(props)} >
-            {children}
-        </ButtonPrimitive>
-    );
-});
+);
 
 TooltipTrigger.displayName = 'TooltipTrigger';
 

--- a/src/components/ui/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.test.tsx
@@ -91,4 +91,54 @@ describe('Tooltip', () => {
             expect(screen.getByRole('tooltip')).toBeInTheDocument();
         });
     });
+
+    test('forwards refs to subcomponents', async() => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const contentRef = React.createRef<HTMLDivElement>();
+
+        render(
+            <Tooltip.Root ref={rootRef}>
+                <Tooltip.Trigger ref={triggerRef}>Hover me</Tooltip.Trigger>
+                <Tooltip.Content ref={contentRef}>label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(contentRef.current).toBeNull();
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('maintains accessibility role on content', async() => {
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content>label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        const trigger = screen.getByText('Hover me');
+        await userEvent.hover(trigger);
+        const content = screen.getByRole('tooltip');
+        expect(content).toHaveTextContent('label');
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content>label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- refactor Tooltip to use `forwardRef` and expose typed subcomponents
- wire Tooltip.Root, Trigger, and Content to forward refs to their DOM nodes
- add tests for ref forwarding, accessibility, and console warnings

## Testing
- `npm test --silent`
- `npm run build:rollup`