### PR TITLE
refactor: forward refs for RadioGroup

### DIFF
--- a/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
@@ -1,20 +1,23 @@
-import React from 'react';
-import RadioGroupPrimitive, { RadioGroupPrimitiveProps } from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
+import RadioGroupPrimitive from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
 import clsx from 'clsx';
 import { RadioGroupContext } from '../context/RadioGroupContext';
 
-export type RadioGroupIndicatorProps = {
-    children?: React.ReactNode
-    className?: string
-} & RadioGroupPrimitiveProps.Indicator;
+export type RadioGroupIndicatorElement = ElementRef<typeof RadioGroupPrimitive.Indicator>;
 
-const RadioGroupIndicator = ({ className = '', children, ...props }: RadioGroupIndicatorProps) => {
+export type RadioGroupIndicatorProps = ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Indicator> & {
+    className?: string;
+};
+
+const RadioGroupIndicator = React.forwardRef<RadioGroupIndicatorElement, RadioGroupIndicatorProps>(({ className = '', children, ...props }, forwardedRef) => {
     const { rootClass } = React.useContext(RadioGroupContext);
     return (
-        <RadioGroupPrimitive.Indicator className={clsx(`${rootClass}-indicator`, className)} {...props} >
+        <RadioGroupPrimitive.Indicator ref={forwardedRef} className={clsx(`${rootClass}-indicator`, className)} {...props} >
             {children}
         </RadioGroupPrimitive.Indicator>
     );
-};
+});
+
+RadioGroupIndicator.displayName = 'RadioGroupIndicator';
 
 export default RadioGroupIndicator;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
@@ -1,17 +1,20 @@
-import React, { useContext } from 'react';
-import RadioGroupPrimitive, { RadioGroupPrimitiveProps } from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
+import React, { ComponentPropsWithoutRef, ElementRef, useContext } from 'react';
+import RadioGroupPrimitive from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
 import { RadioGroupContext } from '../context/RadioGroupContext';
 import clsx from 'clsx';
 
-export type RadioGroupItemProps = {
-    children: React.ReactNode
-    className?: string
-    value: string
-} & RadioGroupPrimitiveProps.Item
+export type RadioGroupItemElement = ElementRef<typeof RadioGroupPrimitive.Item>;
 
-const RadioGroupItem = ({ children, className = '', value, ...props }: RadioGroupItemProps) => {
-    const { rootClass } = useContext(RadioGroupContext);
-    return <RadioGroupPrimitive.Item className={clsx(`${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
+export type RadioGroupItemProps = ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> & {
+    className?: string;
+    value: string;
 };
+
+const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(({ children, className = '', value, ...props }, forwardedRef) => {
+    const { rootClass } = useContext(RadioGroupContext);
+    return <RadioGroupPrimitive.Item ref={forwardedRef} className={clsx(`${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
+});
+
+RadioGroupItem.displayName = 'RadioGroupItem';
 
 export default RadioGroupItem;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import clsx from 'clsx';
 import { RadioGroupContext } from '../context/RadioGroupContext';
 
-export type RadioGroupLabelProps = {
-    children?: React.ReactNode
-    className?: string
-    asChild?: boolean
-}
+export type RadioGroupLabelElement = ElementRef<typeof Primitive.label>;
 
-const RadioGroupLabel = ({ className = '', asChild = false, children, ...props }: RadioGroupLabelProps) => {
-    const { rootClass } = React.useContext(RadioGroupContext);
-    return <Primitive.label {...props} className={clsx(`${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
+export type RadioGroupLabelProps = ComponentPropsWithoutRef<typeof Primitive.label> & {
+    className?: string;
+    asChild?: boolean;
 };
+
+const RadioGroupLabel = React.forwardRef<RadioGroupLabelElement, RadioGroupLabelProps>(({ className = '', asChild = false, children, ...props }, forwardedRef) => {
+    const { rootClass } = React.useContext(RadioGroupContext);
+    return <Primitive.label ref={forwardedRef} {...props} className={clsx(`${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
+});
+
+RadioGroupLabel.displayName = 'RadioGroupLabel';
 
 export default RadioGroupLabel;

--- a/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import RadioGroupPrimitive, { RadioGroupPrimitiveProps } from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
+import RadioGroupPrimitive from '~/core/primitives/RadioGroup/RadioGroupPrimitive';
 
 import clsx from 'clsx';
 import { customClassSwitcher } from '~/core';
@@ -10,17 +10,17 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'RadioGroup';
 
-type RadioGroupRootProps = {
-    children: React.ReactNode;
+export type RadioGroupRootElement = ElementRef<typeof RadioGroupPrimitive.Root>;
+
+export type RadioGroupRootProps = ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & {
     className?: string;
     customRootClass?: string;
     variant?: string;
     size?: string;
     color?: string;
+};
 
-} & RadioGroupPrimitiveProps.Root;
-
-const RadioGroupRoot = ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }: RadioGroupRootProps) => {
+const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootProps>(({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, forwardedRef) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
 
@@ -28,8 +28,10 @@ const RadioGroupRoot = ({ children, className = '', customRootClass = '', varian
     const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
     return <RadioGroupContext.Provider value={{ rootClass }}>
-        <RadioGroupPrimitive.Root className={clsx(`${rootClass}-root`, className)} {...composedAttributes()} {...props}> {children} </RadioGroupPrimitive.Root>
+        <RadioGroupPrimitive.Root ref={forwardedRef} className={clsx(`${rootClass}-root`, className)} {...composedAttributes()} {...props}> {children} </RadioGroupPrimitive.Root>
     </RadioGroupContext.Provider>;
-};
+});
+
+RadioGroupRoot.displayName = 'RadioGroupRoot';
 
 export default RadioGroupRoot;

--- a/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
+++ b/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
@@ -89,6 +89,20 @@ describe('RadioGroup (fragments)', () => {
         expect(group.getAttribute('data-rad-ui-accent-color')).toBe('primary');
     });
 
+    it('forwards refs to underlying elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        render(
+            <RadioGroup.Root ref={rootRef}>
+                <RadioGroup.Item ref={itemRef} value="a">
+                    <RadioGroup.Indicator />
+                </RadioGroup.Item>
+            </RadioGroup.Root>
+        );
+        expect(rootRef.current?.tagName).toBe('DIV');
+        expect(itemRef.current?.tagName).toBe('BUTTON');
+    });
+
     it('warns on direct usage of RadioGroup', () => {
         const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         render(<RadioGroup />);

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
@@ -1,17 +1,26 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
 import RadioGroupPrimitiveItemContext from '../context/RadioGroupPrimitiveItemContext';
 import Primitive from '~/core/primitives/Primitive';
 
-export type RadioGroupPrimitiveIndicatorProps = {
-    children?: React.ReactNode
-    className?: string
-    asChild?: boolean
-}
-const RadioGroupPrimitiveIndicator = ({ children, className, asChild = false, ...props }: RadioGroupPrimitiveIndicatorProps) => {
-    const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
+export type RadioGroupPrimitiveIndicatorElement = ElementRef<typeof Primitive.span>;
 
-    if (!itemSelected) return null;
-    return <Primitive.span className={className} asChild={asChild} {...props}>{children}</Primitive.span>;
+export type RadioGroupPrimitiveIndicatorProps = ComponentPropsWithoutRef<typeof Primitive.span> & {
+    asChild?: boolean;
 };
+
+const RadioGroupPrimitiveIndicator = React.forwardRef<RadioGroupPrimitiveIndicatorElement, RadioGroupPrimitiveIndicatorProps>(
+    ({ children, className, asChild = false, ...props }, forwardedRef) => {
+        const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
+
+        if (!itemSelected) return null;
+        return (
+            <Primitive.span ref={forwardedRef} className={className} asChild={asChild} {...props}>
+                {children}
+            </Primitive.span>
+        );
+    }
+);
+
+RadioGroupPrimitiveIndicator.displayName = 'RadioGroupPrimitiveIndicator';
 
 export default RadioGroupPrimitiveIndicator;

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
@@ -1,50 +1,54 @@
-import React, { PropsWithChildren, useContext } from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef, useContext } from 'react';
 import RadioGroupContext from '../context/RadioGroupContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import RadioGroupPrimitiveItemContext from '../context/RadioGroupPrimitiveItemContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
-export type RadioGroupPrimitiveItemProps = PropsWithChildren<{
+export type RadioGroupPrimitiveItemElement = ElementRef<typeof ButtonPrimitive>;
+
+export type RadioGroupPrimitiveItemProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     value: string;
-    disabled?: boolean
+    disabled?: boolean;
     children?: React.ReactNode;
-    required?: boolean
-    className?: string
-    asChild?: boolean
-}>;
-
-const RadioGroupPrimitiveItem = ({ value, children, disabled, required = false, className = '', asChild = false, ...props }: RadioGroupPrimitiveItemProps) => {
-    const context = useContext(RadioGroupContext);
-    if (!context) {
-        throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
-    }
-    const { groupDisabled, selectedValue, setSelectedValue } = context;
-
-    const itemSelected = value === selectedValue;
-    return (
-
-        <RovingFocusGroup.Item >
-            <ButtonPrimitive
-                role="radio"
-                type="button"
-                disabled={groupDisabled || disabled}
-                onClick={() => setSelectedValue(value)}
-                onFocus={() => setSelectedValue(value)}
-                aria-disabled={groupDisabled || disabled}
-                aria-checked={value === selectedValue}
-                data-checked={value === selectedValue}
-                aria-required={required}
-                asChild={asChild}
-                className={className}
-                {...props}
-            >
-                <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
-                    {children}
-                </RadioGroupPrimitiveItemContext.Provider>
-            </ButtonPrimitive>
-        </RovingFocusGroup.Item>
-
-    );
+    required?: boolean;
+    asChild?: boolean;
 };
+
+const RadioGroupPrimitiveItem = React.forwardRef<RadioGroupPrimitiveItemElement, RadioGroupPrimitiveItemProps>(
+    ({ value, children, disabled, required = false, className = '', asChild = false, ...props }, forwardedRef) => {
+        const context = useContext(RadioGroupContext);
+        if (!context) {
+            throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
+        }
+        const { groupDisabled, selectedValue, setSelectedValue } = context;
+
+        const itemSelected = value === selectedValue;
+        return (
+            <RovingFocusGroup.Item>
+                <ButtonPrimitive
+                    ref={forwardedRef}
+                    role="radio"
+                    type="button"
+                    disabled={groupDisabled || disabled}
+                    onClick={() => setSelectedValue(value)}
+                    onFocus={() => setSelectedValue(value)}
+                    aria-disabled={groupDisabled || disabled}
+                    aria-checked={value === selectedValue}
+                    data-checked={value === selectedValue}
+                    aria-required={required}
+                    asChild={asChild}
+                    className={className}
+                    {...props}
+                >
+                    <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
+                        {children}
+                    </RadioGroupPrimitiveItemContext.Provider>
+                </ButtonPrimitive>
+            </RovingFocusGroup.Item>
+        );
+    }
+);
+
+RadioGroupPrimitiveItem.displayName = 'RadioGroupPrimitiveItem';
 
 export default RadioGroupPrimitiveItem;

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
@@ -1,11 +1,12 @@
-import React, { PropsWithChildren } from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
 import Primitive from '../../Primitive';
 import RadioGroupContext from '../context/RadioGroupContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import useControllableState from '~/core/hooks/useControllableState';
 
-export type RadioGroupPrimitiveRootProps = PropsWithChildren<{
-    className?: string;
+export type RadioGroupPrimitiveRootElement = ElementRef<typeof Primitive.div>;
+
+export type RadioGroupPrimitiveRootProps = ComponentPropsWithoutRef<typeof Primitive.div> & {
     customRootClass?: string;
     value?: string;
     defaultValue?: string;
@@ -16,9 +17,21 @@ export type RadioGroupPrimitiveRootProps = PropsWithChildren<{
     orientation?: 'horizontal' | 'vertical' | 'both';
     loop?: boolean,
     dir?: 'ltr' | 'rtl';
-}>;
+};
 
-const RadioGroupPrimitiveRoot = ({ value, defaultValue = '', onValueChange, children, disabled: groupDisabled = false, required = false, name = '', orientation = 'horizontal', loop = false, dir = 'ltr', ...props }: RadioGroupPrimitiveRootProps) => {
+const RadioGroupPrimitiveRoot = React.forwardRef<RadioGroupPrimitiveRootElement, RadioGroupPrimitiveRootProps>(({
+    value,
+    defaultValue = '',
+    onValueChange,
+    children,
+    disabled: groupDisabled = false,
+    required = false,
+    name = '',
+    orientation = 'horizontal',
+    loop = false,
+    dir = 'ltr',
+    ...props
+}, forwardedRef) => {
     const [selectedValue, setSelectedValue] = useControllableState(
         value,
         defaultValue,
@@ -32,7 +45,7 @@ const RadioGroupPrimitiveRoot = ({ value, defaultValue = '', onValueChange, chil
     };
 
     return (
-        <Primitive.div {...props} aria-required={required} role='radiogroup' aria-disabled={groupDisabled}>
+        <Primitive.div ref={forwardedRef} {...props} aria-required={required} role='radiogroup' aria-disabled={groupDisabled}>
             <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
                 <RadioGroupContext.Provider value={sendItems}>
                     <RovingFocusGroup.Group>
@@ -44,8 +57,9 @@ const RadioGroupPrimitiveRoot = ({ value, defaultValue = '', onValueChange, chil
             </RovingFocusGroup.Root>
             <input type='radio' hidden name={name} value={selectedValue} disabled={groupDisabled} required={required}/>
         </Primitive.div>
-    )
-    ;
-};
+    );
+});
+
+RadioGroupPrimitiveRoot.displayName = 'RadioGroupPrimitiveRoot';
 
 export default RadioGroupPrimitiveRoot;

--- a/src/core/primitives/RadioGroup/tests/RadioGroupPrimitive.test.tsx
+++ b/src/core/primitives/RadioGroup/tests/RadioGroupPrimitive.test.tsx
@@ -77,6 +77,20 @@ describe('RadioGroupPrimitive', () => {
         expect(hiddenInput).toHaveAttribute('name', 'my-radio-group');
     });
 
+    it('forwards refs to root and item', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        render(
+            <RadioGroupPrimitive.Root ref={rootRef}>
+                <RadioGroupPrimitive.Item ref={itemRef} value="a">
+                    Option A
+                </RadioGroupPrimitive.Item>
+            </RadioGroupPrimitive.Root>
+        );
+        expect(rootRef.current?.tagName).toBe('DIV');
+        expect(itemRef.current?.tagName).toBe('BUTTON');
+    });
+
     it('throws error if RadioGroupPrimitive.Item is used outside RadioGroupPrimitive.Root', () => {
         // Suppress error output for this test
         const spy = jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- use `React.forwardRef` across RadioGroup primitives and UI fragments
- type components with `ElementRef` and `ComponentPropsWithoutRef`
- add tests checking ref forwarding
- fix misnamed RadioGroupPrimitive test file

## Testing
- `npm test`
- `rg "<<<<<<<" -n`

------
https://chatgpt.com/codex/tasks/task_e_68b9ba7e83b883318fe886055a459c09