### PR TITLE
refactor: forward refs for RadioGroup

### DIFF
--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -4,26 +4,28 @@ import React, { useContext } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 
-type AccordionContentProps = {
-  children: React.ReactNode;
+type AccordionContentProps = React.ComponentPropsWithoutRef<'div'> & {
   index: number,
-  className? :string
 };
 
-const AccordionContent: React.FC<AccordionContentProps> = ({ children, index, className = '' }: AccordionContentProps) => {
+const AccordionContent = React.forwardRef<React.ElementRef<'div'>, AccordionContentProps>(({ children, index, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AccordionContext);
 
     return (
         <CollapsiblePrimitive.Content
+            ref={ref}
             asChild
             className={clsx(`${rootClass}-content`, className)}
             id={`content-${index}`}
             role="region"
             aria-labelledby={`section-${index}`}
+            {...props}
         >
             {children}
         </CollapsiblePrimitive.Content>
     );
-};
+});
+
+AccordionContent.displayName = 'AccordionContent';
 
 export default AccordionContent;

--- a/src/components/ui/Accordion/fragments/AccordionHeader.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionHeader.tsx
@@ -3,18 +3,18 @@ import React, { useContext } from 'react';
 import { clsx } from 'clsx';
 import { AccordionContext } from '../contexts/AccordionContext';
 
-export type AccordionHeaderProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+export type AccordionHeaderProps = React.ComponentPropsWithoutRef<'div'>;
 
-const AccordionHeader: React.FC<AccordionHeaderProps> = ({ children, className = '' }) => {
+const AccordionHeader = React.forwardRef<React.ElementRef<'div'>, AccordionHeaderProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AccordionContext);
     return (
-        <div className={clsx(`${rootClass}-header`, className)}>
+        <div ref={ref} className={clsx(`${rootClass}-header`, className)} {...props}>
             {children}
         </div>
     );
-};
+});
+
+AccordionHeader.displayName = 'AccordionHeader';
 
 export default AccordionHeader;
+

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -7,16 +7,14 @@ import { AccordionItemContext } from '../contexts/AccordionItemContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 import Primitive from '~/core/primitives/Primitive';
 
-export type AccordionItemProps = {
-    children: React.ReactNode;
-    className?: string;
+export type AccordionItemProps = React.ComponentPropsWithoutRef<'div'> & {
     value?: number | string;
     disabled?: boolean;
     asChild?: boolean;
-}
+};
 
-const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, className = '', disabled = false, asChild = false, ...props }) => {
-    const accordionItemRef = useRef<HTMLDivElement>(null);
+const AccordionItem = React.forwardRef<React.ElementRef<'div'>, AccordionItemProps>(({ children, value, className = '', disabled = false, asChild = false, ...props }, forwardedRef) => {
+    const accordionItemRef = useRef<HTMLDivElement | null>(null);
     const [itemValue, setItemValue] = useState<number | string>(value ?? 0);
     const { rootClass, activeItems, transitionDuration, transitionTimingFunction } = useContext(AccordionContext);
 
@@ -45,7 +43,12 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, classNam
                 asChild
             >
                 <Primitive.div
-                    ref={accordionItemRef}
+                    ref={(node) => {
+                        const element = node as HTMLDivElement | null;
+                        accordionItemRef.current = element;
+                        if (typeof forwardedRef === 'function') forwardedRef(element);
+                        else if (forwardedRef) (forwardedRef as React.MutableRefObject<HTMLDivElement | null>).current = element;
+                    }}
                     className={clsx(`${rootClass}-item`, className)} {...props}
                     id={`accordion-data-item-${id}`}
                     role="region"
@@ -57,6 +60,8 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ children, value, classNam
 
         </AccordionItemContext.Provider>
     );
-};
+});
+
+AccordionItem.displayName = 'AccordionItem';
 
 export default AccordionItem;

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -9,8 +9,7 @@ import Primitive from '~/core/primitives/Primitive';
 
 const COMPONENT_NAME = 'Accordion';
 
-export type AccordionRootProps = {
-    children: React.ReactNode;
+export type AccordionRootProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'defaultValue'> & {
     customRootClass?: string;
     transitionDuration?: number;
     transitionTimingFunction?: string;
@@ -22,9 +21,23 @@ export type AccordionRootProps = {
     value?: (number | string)[];
     defaultValue?: (number | string)[];
     onValueChange?: (value: (number | string)[]) => void;
-}
+};
 
-const AccordionRoot = ({ children, orientation = 'vertical', disableTabIndexing = true, asChild, transitionDuration = 0, transitionTimingFunction = 'linear', customRootClass, loop = true, openMultiple = false, value, defaultValue = [], onValueChange }: AccordionRootProps) => {
+const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootProps>(({
+    children,
+    orientation = 'vertical',
+    disableTabIndexing = true,
+    asChild,
+    transitionDuration = 0,
+    transitionTimingFunction = 'linear',
+    customRootClass,
+    loop = true,
+    openMultiple = false,
+    value,
+    defaultValue = [],
+    onValueChange,
+    ...props
+}, forwardedRef) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const processedValue = value !== undefined
@@ -54,13 +67,25 @@ const AccordionRoot = ({ children, orientation = 'vertical', disableTabIndexing 
             }}>
             <RovingFocusGroup.Root orientation={orientation} loop={loop} disableTabIndexing={disableTabIndexing} >
                 <RovingFocusGroup.Group >
-                    <Primitive.div className={clsx(`${rootClass}-root`)} ref={accordionRef} asChild={asChild}>
+                    <Primitive.div
+                        className={clsx(`${rootClass}-root`)}
+                        ref={(node) => {
+                            const element = node as HTMLDivElement | null;
+                            accordionRef.current = element;
+                            if (typeof forwardedRef === 'function') forwardedRef(element);
+                            else if (forwardedRef) (forwardedRef as React.MutableRefObject<HTMLDivElement | null>).current = element;
+                        }}
+                        asChild={asChild}
+                        {...props}
+                    >
                         {children}
                     </Primitive.div>
                 </RovingFocusGroup.Group>
             </RovingFocusGroup.Root>
         </AccordionContext.Provider>
     );
-};
+});
+
+AccordionRoot.displayName = COMPONENT_NAME;
 
 export default AccordionRoot;

--- a/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { clsx } from 'clsx';
-import React, { useContext, useRef } from 'react';
+import React, { useContext } from 'react';
 import { AccordionContext } from '../contexts/AccordionContext';
 import { AccordionItemContext } from '../contexts/AccordionItemContext';
 
@@ -8,15 +8,12 @@ import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import ButtonPrimitive from '~/core/primitives/Button';
 
-type AccordionTriggerProps = {
-  children: React.ReactNode;
-  className?: string,
-  index?: number,
-  handleClick?: (index: number) => void
+type AccordionTriggerProps = React.ComponentPropsWithoutRef<'button'> & {
+    index?: number;
 };
 
-const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, index, className = '' }) => {
-    const triggerRef = useRef<HTMLButtonElement>(null);
+const AccordionTrigger = React.forwardRef<React.ElementRef<'button'>, AccordionTriggerProps>(
+    ({ children, index, className = '', onClick, ...props }, ref) => {
     const { setActiveItems, rootClass, activeItems, openMultiple } = useContext(AccordionContext);
     const { itemValue, disabled } = useContext(AccordionItemContext);
 
@@ -40,22 +37,30 @@ const AccordionTrigger: React.FC<AccordionTriggerProps> = ({ children, index, cl
         }
     };
 
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+        onClickHandler(e);
+        onClick?.(e);
+    };
+
     return (
         <RovingFocusGroup.Item>
             <CollapsiblePrimitive.Trigger disabled={disabled} asChild>
                 <ButtonPrimitive
                     className={clsx(`${rootClass}-trigger`, className)}
-                    ref={triggerRef}
+                    ref={ref}
                     aria-disabled={disabled}
-                    onClick={onClickHandler}
+                    onClick={handleClick}
                     aria-expanded={activeItems.includes(itemValue)}
                     aria-controls={`content-${index}`}
+                    {...props}
                 >
                     {children}
                 </ButtonPrimitive>
             </CollapsiblePrimitive.Trigger>
         </RovingFocusGroup.Item>
     );
-};
+});
+
+AccordionTrigger.displayName = 'AccordionTrigger';
 
 export default AccordionTrigger;

--- a/src/components/ui/Accordion/tests/Accordion.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.test.tsx
@@ -41,10 +41,65 @@ describe('Accordion Component', () => {
         expect(screen.getByText('Item 3')).toBeInTheDocument();
     });
 
+    test('forwards refs to underlying elements without warnings', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLDivElement>();
+        const headerRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const contentRef = React.createRef<HTMLDivElement>();
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        render(
+            <Accordion.Root ref={rootRef} defaultValue={[0]}>
+                <Accordion.Item value={0} ref={itemRef}>
+                    <Accordion.Header ref={headerRef}>
+                        <Accordion.Trigger ref={triggerRef}>Item 1</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content ref={contentRef} index={0}>
+                        Content 1
+                    </Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(headerRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
     test('displays content when item is clicked', () => {
         render(<TestAccordion />);
         const item1Trigger = screen.getByText('Item 1');
         fireEvent.click(item1Trigger);
+        expect(screen.getByText('Content 1')).toBeInTheDocument();
+    });
+
+    test('calls user onClick while preserving toggle behavior', () => {
+        const handleClick = jest.fn();
+        render(
+            <Accordion.Root>
+                <Accordion.Item value={0}>
+                    <Accordion.Header>
+                        <Accordion.Trigger onClick={handleClick}>
+                            Item 1
+                        </Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content index={0}>Content 1</Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>
+        );
+
+        const trigger = screen.getByText('Item 1');
+        fireEvent.click(trigger);
+        expect(handleClick).toHaveBeenCalled();
         expect(screen.getByText('Content 1')).toBeInTheDocument();
     });
 

--- a/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogAction.tsx
@@ -1,22 +1,25 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogActionProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogActionElement = React.ElementRef<typeof DialogPrimitive.Action>;
+type DialogPrimitiveActionProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Action>;
 
-const AlertDialogAction = ({ children, asChild, className = '', ...props } : AlertDialogActionProps) => {
+export type AlertDialogActionProps = DialogPrimitiveActionProps & {
+    className?: string;
+};
+
+const AlertDialogAction = forwardRef<AlertDialogActionElement, AlertDialogActionProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <DialogPrimitive.Action className={`${rootClass}-action ${className}`} {...props}>
+        <DialogPrimitive.Action ref={ref} className={`${rootClass}-action ${className}`} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Action>
 
     );
-};
+});
+
+AlertDialogAction.displayName = 'AlertDialogAction';
 
 export default AlertDialogAction;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogCancel.tsx
@@ -1,22 +1,25 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogCancelProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogCancelElement = React.ElementRef<typeof DialogPrimitive.Cancel>;
+type DialogPrimitiveCancelProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Cancel>;
 
-const AlertDialogCancel = ({ children, asChild, className = '', ...props } : AlertDialogCancelProps) => {
+export type AlertDialogCancelProps = DialogPrimitiveCancelProps & {
+    className?: string;
+};
+
+const AlertDialogCancel = forwardRef<AlertDialogCancelElement, AlertDialogCancelProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <DialogPrimitive.Cancel className={`${rootClass}-cancel ${className}`} {...props}>
+        <DialogPrimitive.Cancel ref={ref} className={`${rootClass}-cancel ${className}`} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Cancel>
     );
-};
+});
+
+AlertDialogCancel.displayName = 'AlertDialogCancel';
 
 export default AlertDialogCancel;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogContent.tsx
@@ -1,23 +1,25 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogContentProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+type AlertDialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
+type DialogPrimitiveContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
 
-const AlertDialogContent = ({ children, className = '' } : AlertDialogContentProps) => {
+export type AlertDialogContentProps = DialogPrimitiveContentProps & {
+    className?: string;
+};
+
+const AlertDialogContent = forwardRef<AlertDialogContentElement, AlertDialogContentProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <>
-            <DialogPrimitive.Content className={clsx(`${rootClass}-content`, className)} >
-                {children}
-            </DialogPrimitive.Content>
-        </>
+        <DialogPrimitive.Content ref={ref} className={clsx(`${rootClass}-content`, className)} {...props}>
+            {children}
+        </DialogPrimitive.Content>
     );
-};
+});
+
+AlertDialogContent.displayName = 'AlertDialogContent';
 
 export default AlertDialogContent;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogDescription.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-const AlertDialogDescription = ({ children, className = '' }: { children: React.ReactNode, className?: string }) => {
+type AlertDialogDescriptionElement = React.ElementRef<typeof Primitive.p>;
+type PrimitivePProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
+
+export type AlertDialogDescriptionProps = PrimitivePProps & { className?: string };
+
+const AlertDialogDescription = forwardRef<AlertDialogDescriptionElement, AlertDialogDescriptionProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.p className={`${rootClass}-description ${className}`}>{children}</Primitive.p>;
-};
+    return <Primitive.p ref={ref} className={`${rootClass}-description ${className}`} {...props}>{children}</Primitive.p>;
+});
+
+AlertDialogDescription.displayName = 'AlertDialogDescription';
 
 export default AlertDialogDescription;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogOverlay.tsx
@@ -1,21 +1,24 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-type AlertDialogOverlayProps = {
-    className?: string;
-}
+type AlertDialogOverlayElement = React.ElementRef<typeof DialogPrimitive.Overlay>;
+type DialogPrimitiveOverlayProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>;
 
-const AlertDialogOverlay = ({ className = '' }: AlertDialogOverlayProps) => {
+type AlertDialogOverlayProps = DialogPrimitiveOverlayProps & {
+    className?: string;
+};
+
+const AlertDialogOverlay = forwardRef<AlertDialogOverlayElement, AlertDialogOverlayProps>(({ className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
     return (
-        <>
-            <DialogPrimitive.Overlay className={clsx(`${rootClass}-overlay`, className)}></DialogPrimitive.Overlay>
-        </>
+        <DialogPrimitive.Overlay ref={ref} className={clsx(`${rootClass}-overlay`, className)} {...props}></DialogPrimitive.Overlay>
     );
-};
+});
+
+AlertDialogOverlay.displayName = 'AlertDialogOverlay';
 
 export default AlertDialogOverlay;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogPortal.tsx
@@ -1,17 +1,20 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogPortalProps = {
-  children: React.ReactNode;
-};
+type AlertDialogPortalElement = React.ElementRef<'div'>;
+type DialogPrimitivePortalProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Portal>;
 
-const AlertDialogPortal = ({ children }: AlertDialogPortalProps) => {
+export type AlertDialogPortalProps = DialogPrimitivePortalProps;
+
+const AlertDialogPortal = forwardRef<AlertDialogPortalElement, AlertDialogPortalProps>(({ children, ...props }, _ref) => {
     return (
-        <DialogPrimitive.Portal>
+        <DialogPrimitive.Portal {...props}>
             {children}
         </DialogPrimitive.Portal>
     );
-};
+});
+
+AlertDialogPortal.displayName = 'AlertDialogPortal';
 
 export default AlertDialogPortal;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
@@ -1,34 +1,35 @@
 'use client';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 import { clsx } from 'clsx';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogRootProps = {
-    open?: boolean;
-    children: React.ReactNode;
+type AlertDialogRootElement = React.ElementRef<typeof DialogPrimitive.Root>;
+type DialogPrimitiveRootProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>;
+
+export type AlertDialogRootProps = DialogPrimitiveRootProps & {
     customRootClass?: string;
     className?: string;
-}
+};
 
 const COMPONENT_NAME = 'AlertDialog';
 
-const AlertDialogRoot = ({ children, className = '', customRootClass = '', open = false, ...props } : AlertDialogRootProps) => {
+const AlertDialogRoot = forwardRef<AlertDialogRootElement, AlertDialogRootProps>(({ children, className = '', customRootClass = '', open = false, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const contextProps = { rootClass };
     return (
-        <DialogPrimitive.Root className={clsx(rootClass, className)} {...props}>
+        <DialogPrimitive.Root open={open} className={clsx(rootClass, className)} {...props}>
             <AlertDialogContext.Provider value={contextProps}>
-                <div className={clsx(rootClass, className)}>
+                <div ref={ref} className={clsx(rootClass, className)}>
                     {children}
                 </div>
             </AlertDialogContext.Provider>
         </DialogPrimitive.Root>
     );
-};
+});
 
 AlertDialogRoot.displayName = COMPONENT_NAME;
 export default AlertDialogRoot;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTitle.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import Primitive from '~/core/primitives/Primitive';
 
-type AlertDialogTitleProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+type AlertDialogTitleElement = React.ElementRef<typeof Primitive.h2>;
+type PrimitiveH2Props = React.ComponentPropsWithoutRef<typeof Primitive.h2>;
 
-const AlertDialogTitle = ({ children, className = '' }: AlertDialogTitleProps) => {
-    const { rootClass } = useContext(AlertDialogContext);
-    return <Primitive.h2 className={`${rootClass}-title ${className}`}>{children}</Primitive.h2>;
+export type AlertDialogTitleProps = PrimitiveH2Props & {
+    className?: string;
 };
+
+const AlertDialogTitle = forwardRef<AlertDialogTitleElement, AlertDialogTitleProps>(({ children, className = '', ...props }, ref) => {
+    const { rootClass } = useContext(AlertDialogContext);
+    return <Primitive.h2 ref={ref} className={`${rootClass}-title ${className}`} {...props}>{children}</Primitive.h2>;
+});
+
+AlertDialogTitle.displayName = 'AlertDialogTitle';
 
 export default AlertDialogTitle;

--- a/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogTrigger.tsx
@@ -1,25 +1,28 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { clsx } from 'clsx';
 import { AlertDialogContext } from '../contexts/AlertDialogContext';
 
 import DialogPrimitive from '~/core/primitives/Dialog';
 
-export type AlertDialogTriggerProps = {
-    children: React.ReactNode;
-    asChild?: boolean;
-    className?: string;
-}
+type AlertDialogTriggerElement = React.ElementRef<typeof DialogPrimitive.Trigger>;
+type DialogPrimitiveTriggerProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>;
 
-const AlertDialogTrigger = ({ children, asChild, className = '', ...props } : AlertDialogTriggerProps) => {
+export type AlertDialogTriggerProps = DialogPrimitiveTriggerProps & {
+    className?: string;
+};
+
+const AlertDialogTrigger = forwardRef<AlertDialogTriggerElement, AlertDialogTriggerProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { rootClass } = useContext(AlertDialogContext);
 
     return (
-        <DialogPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)} asChild={asChild} {...props}>
+        <DialogPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-trigger`, className)} asChild={asChild} {...props}>
             {children}
         </DialogPrimitive.Trigger>
 
     );
-};
+});
+
+AlertDialogTrigger.displayName = 'AlertDialogTrigger';
 
 export default AlertDialogTrigger;

--- a/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
+++ b/src/components/ui/AlertDialog/tests/AlertDialog.test.tsx
@@ -1,0 +1,61 @@
+import React, { createRef } from 'react';
+import { render } from '@testing-library/react';
+import AlertDialog from '../AlertDialog';
+
+describe('AlertDialog', () => {
+    test('forwards refs to subcomponents', () => {
+        const rootRef = createRef<HTMLDivElement>();
+        const triggerRef = createRef<HTMLButtonElement>();
+        const overlayRef = createRef<HTMLDivElement>();
+        const contentRef = createRef<HTMLDivElement>();
+        const titleRef = createRef<HTMLHeadingElement>();
+        const descriptionRef = createRef<HTMLParagraphElement>();
+        const cancelRef = createRef<HTMLButtonElement>();
+        const actionRef = createRef<HTMLButtonElement>();
+
+        render(
+            <AlertDialog.Root ref={rootRef} open>
+                <AlertDialog.Trigger ref={triggerRef}>Open</AlertDialog.Trigger>
+                <AlertDialog.Overlay ref={overlayRef} />
+                <AlertDialog.Content ref={contentRef}>
+                    <AlertDialog.Title ref={titleRef}>Title</AlertDialog.Title>
+                    <AlertDialog.Description ref={descriptionRef}>Description</AlertDialog.Description>
+                    <AlertDialog.Cancel ref={cancelRef}>Cancel</AlertDialog.Cancel>
+                    <AlertDialog.Action ref={actionRef}>Action</AlertDialog.Action>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(overlayRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(titleRef.current?.tagName).toBe('H2');
+        expect(descriptionRef.current?.tagName).toBe('P');
+        expect(cancelRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(actionRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <AlertDialog.Root open>
+                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                <AlertDialog.Overlay />
+                <AlertDialog.Content>
+                    <AlertDialog.Title>Title</AlertDialog.Title>
+                    <AlertDialog.Description>Description</AlertDialog.Description>
+                    <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+                    <AlertDialog.Action>Action</AlertDialog.Action>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});

--- a/src/components/ui/Code/Code.tsx
+++ b/src/components/ui/Code/Code.tsx
@@ -5,15 +5,22 @@ import { customClassSwitcher } from '~/core';
 
 const COMPONENT_NAME = 'Code';
 
-export type CodeProps= {
-    children: React.ReactNode;
+export type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
     customRootClass?: string;
     variant?: string;
     size?: string;
     color?: string;
-}
+};
 
-const Code = ({ children, customRootClass = '', color = '', variant = '', size = '' }: CodeProps) => {
+const Code = React.forwardRef<React.ElementRef<'code'>, CodeProps>(({
+    children,
+    customRootClass = '',
+    color = '',
+    variant = '',
+    size = '',
+    className,
+    ...props
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const data_attributes: Record<string, string> = {};
@@ -30,9 +37,11 @@ const Code = ({ children, customRootClass = '', color = '', variant = '', size =
         data_attributes['data-rad-ui-accent-color'] = color;
     }
 
-    return <code className={clsx(rootClass)} {...data_attributes}>
+    return <code ref={ref} className={clsx(rootClass, className)} {...data_attributes} {...props}>
         {children}
     </code>;
-};
+});
+
+Code.displayName = COMPONENT_NAME;
 
 export default Code;

--- a/src/components/ui/Code/tests/Code.test.tsx
+++ b/src/components/ui/Code/tests/Code.test.tsx
@@ -1,14 +1,22 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Code from '../Code';
 
 describe('Code Component', () => {
-    it('renders without crashing', () => {
-        const { container } = render(<Code>console.log('Hello world!');</Code>);
+    it('renders content accessible to screen readers', () => {
+        render(<Code>console.log('Hello world!');</Code>);
 
-        const codeElement = container.querySelector('code');
+        const codeElement = screen.getByText("console.log('Hello world!');");
         expect(codeElement).toBeInTheDocument();
-        expect(codeElement).toHaveTextContent('console.log(\'Hello world!\');');
+        expect(codeElement.tagName).toBe('CODE');
+        expect(codeElement).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('forwards ref to the code element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Code ref={ref}>ref test</Code>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName).toBe('CODE');
     });
 
     it('renders Code component with correct color', () => {
@@ -17,5 +25,17 @@ describe('Code Component', () => {
         const codeElement = container.querySelector('code');
         expect(codeElement).toBeInTheDocument();
         expect(codeElement).toHaveAttribute('data-rad-ui-accent-color', 'blue');
+    });
+
+    it('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Code>console.log('Hello world!');</Code>);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
     });
 });

--- a/src/components/ui/DataList/fragments/DataListItem.tsx
+++ b/src/components/ui/DataList/fragments/DataListItem.tsx
@@ -1,10 +1,15 @@
-import React, { useContext } from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, useContext } from 'react';
 import DataListContext from '../contexts/DataListContex';
 import { clsx } from 'clsx';
 
-const DataListItem = ({ children, className = '', ...props }: { children: React.ReactNode, className?: string }) => {
+type DataListItemElement = ElementRef<'div'>;
+export type DataListItemProps = ComponentPropsWithoutRef<'div'>;
+
+const DataListItem = forwardRef<DataListItemElement, DataListItemProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(DataListContext);
-    return <div className={clsx(`${rootClass}-item`, className)} {...props}>{children}</div>;
-};
+    return <div ref={ref} className={clsx(`${rootClass}-item`, className)} {...props}>{children}</div>;
+});
+
+DataListItem.displayName = 'DataListItem';
 
 export default DataListItem;

--- a/src/components/ui/DataList/fragments/DataListLabel.tsx
+++ b/src/components/ui/DataList/fragments/DataListLabel.tsx
@@ -1,10 +1,15 @@
-import React, { useContext } from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, useContext } from 'react';
 import DataListContext from '../contexts/DataListContex';
 import { clsx } from 'clsx';
 
-const DataListLabel = ({ children, className = '', ...props }: { children: React.ReactNode, className?: string }) => {
+type DataListLabelElement = ElementRef<'dt'>;
+export type DataListLabelProps = ComponentPropsWithoutRef<'dt'>;
+
+const DataListLabel = forwardRef<DataListLabelElement, DataListLabelProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(DataListContext);
-    return <dt className={clsx(`${rootClass}-label`, className)} {...props}>{children}</dt>;
-};
+    return <dt ref={ref} className={clsx(`${rootClass}-label`, className)} {...props}>{children}</dt>;
+});
+
+DataListLabel.displayName = 'DataListLabel';
 
 export default DataListLabel;

--- a/src/components/ui/DataList/fragments/DataListRoot.tsx
+++ b/src/components/ui/DataList/fragments/DataListRoot.tsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import DataListContext from '../contexts/DataListContex';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'DataList';
 
-const DataListRoot = ({ children, className = '', customRootClass = '', ...props }: { children: React.ReactNode, className?: string, customRootClass?: string }) => {
+type DataListRootElement = ElementRef<'div'>;
+export interface DataListRootProps extends ComponentPropsWithoutRef<'div'> {
+    customRootClass?: string;
+}
+
+const DataListRoot = forwardRef<DataListRootElement, DataListRootProps>(({ children, className = '', customRootClass = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     return <DataListContext.Provider
         value={{
             rootClass
         }}>
-        <div className={clsx(rootClass, className)} {...props}>{children}</div>
+        <div ref={ref} className={clsx(rootClass, className)} {...props}>{children}</div>
     </DataListContext.Provider>;
-};
+});
+
+DataListRoot.displayName = 'DataListRoot';
 
 export default DataListRoot;

--- a/src/components/ui/DataList/fragments/DataListValue.tsx
+++ b/src/components/ui/DataList/fragments/DataListValue.tsx
@@ -1,10 +1,15 @@
-import React, { useContext } from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, useContext } from 'react';
 import DataListContext from '../contexts/DataListContex';
 import { clsx } from 'clsx';
 
-const DataListValue = ({ children, className = '', ...props }: { children: React.ReactNode, className?: string }) => {
+type DataListValueElement = ElementRef<'dd'>;
+export type DataListValueProps = ComponentPropsWithoutRef<'dd'>;
+
+const DataListValue = forwardRef<DataListValueElement, DataListValueProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(DataListContext);
-    return <dd className={clsx(`${rootClass}-value`, className)} {...props}>{children}</dd>;
-};
+    return <dd ref={ref} className={clsx(`${rootClass}-value`, className)} {...props}>{children}</dd>;
+});
+
+DataListValue.displayName = 'DataListValue';
 
 export default DataListValue;

--- a/src/components/ui/DataList/tests/DataList.test.tsx
+++ b/src/components/ui/DataList/tests/DataList.test.tsx
@@ -89,6 +89,55 @@ describe('DataList Component', () => {
         expect(screen.getByText('123-456-7890')).toBeInTheDocument();
     });
 
+    test('should forward refs to underlying elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLDivElement>();
+        const labelRef = React.createRef<HTMLElement>();
+        const valueRef = React.createRef<HTMLElement>();
+
+        render(
+            <DataList.Root ref={rootRef}>
+                <DataList.Item ref={itemRef}>
+                    <DataList.Label ref={labelRef}>Name</DataList.Label>
+                    <DataList.Value ref={valueRef}>John Doe</DataList.Value>
+                </DataList.Item>
+            </DataList.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(labelRef.current?.tagName).toBe('DT');
+        expect(valueRef.current?.tagName).toBe('DD');
+    });
+
+    test('should render hidden labels for screen readers', () => {
+        render(
+            <DataList.Root>
+                <DataList.Item>
+                    <DataList.Label style={{ position: 'absolute', left: '-10000px' }}>Hidden Label</DataList.Label>
+                    <DataList.Value>Visible Value</DataList.Value>
+                </DataList.Item>
+            </DataList.Root>
+        );
+
+        expect(screen.getByText('Hidden Label')).toBeInTheDocument();
+    });
+
+    test('should render components without warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(
+            <DataList.Root>
+                <DataList.Item>
+                    <DataList.Label>Name</DataList.Label>
+                    <DataList.Value>John Doe</DataList.Value>
+                </DataList.Item>
+            </DataList.Root>
+        );
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
     test('should warn when using DataList directly', () => {
         const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         render(<DataList />);

--- a/src/components/ui/Disclosure/Disclosure.tsx
+++ b/src/components/ui/Disclosure/Disclosure.tsx
@@ -1,18 +1,24 @@
 import React from 'react';
-import DisclosureRoot from './fragments/DisclosureRoot';
+import DisclosureRoot, { DisclosureRootProps } from './fragments/DisclosureRoot';
 import DisclosureItem from './fragments/DisclosureItem';
 import DisclosureTrigger from './fragments/DisclosureTrigger';
 import DisclosureContent from './fragments/DisclosureContent';
 
-export type DisclosureProps = {
-
+export type DisclosureProps = DisclosureRootProps & {
      items:{title:string, content: React.ReactNode}[]
+};
+
+interface DisclosureComponent extends React.ForwardRefExoticComponent<DisclosureProps & React.RefAttributes<React.ElementRef<'div'>>> {
+    Root: typeof DisclosureRoot;
+    Item: typeof DisclosureItem;
+    Trigger: typeof DisclosureTrigger;
+    Content: typeof DisclosureContent;
 }
 
-const Disclosure = ({ items }:DisclosureProps) => {
+const Disclosure = React.forwardRef<React.ElementRef<'div'>, DisclosureProps>(({ items, ...props }, ref) => {
     return (
 
-        <DisclosureRoot>
+        <DisclosureRoot ref={ref} {...props}>
             {items.map((item, index) => (
                 <DisclosureItem key={index} value={index}>
                     <DisclosureTrigger>
@@ -27,11 +33,13 @@ const Disclosure = ({ items }:DisclosureProps) => {
 
         </DisclosureRoot>
     );
-};
+}) as DisclosureComponent;
 
 Disclosure.Root = DisclosureRoot;
 Disclosure.Item = DisclosureItem;
 Disclosure.Trigger = DisclosureTrigger;
 Disclosure.Content = DisclosureContent;
+
+Disclosure.displayName = 'Disclosure';
 
 export default Disclosure;

--- a/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
@@ -4,19 +4,17 @@ import { DisclosureContext } from '../contexts/DisclosureContext';
 import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 
-export type DisclosureContentProps = {
-      children: React.ReactNode;
-      className?: string;
+export type DisclosureContentProps = React.ComponentPropsWithoutRef<'div'>;
 
-}
-
-const DisclosureContent = ({ children, className = '' }:DisclosureContentProps) => {
+const DisclosureContent = React.forwardRef<React.ElementRef<'div'>, DisclosureContentProps>(({ children, className = '', ...props }, forwardedRef) => {
     const { activeItem, rootClass } = useContext(DisclosureContext);
     const { itemValue } = useContext(DisclosureItemContext);
     return (
         itemValue !== activeItem
             ? null
             : <CollapsiblePrimitive.Content
+                {...props}
+                ref={forwardedRef}
                 className={clsx(`${rootClass}-content`, className)}
 
                 role="region"
@@ -25,6 +23,8 @@ const DisclosureContent = ({ children, className = '' }:DisclosureContentProps) 
                 {children}
             </CollapsiblePrimitive.Content>
     );
-};
+});
+
+DisclosureContent.displayName = 'DisclosureContent';
 
 export default DisclosureContent;

--- a/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
@@ -1,17 +1,14 @@
-import React, { useContext, useEffect, useRef, useState, useId } from 'react';
+import React, { useContext, useEffect, useState, useId } from 'react';
 import { DisclosureContext } from '../contexts/DisclosureContext';
 import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import { clsx } from 'clsx';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 
-export type DisclosureItemProps = {
-    children: React.ReactNode;
-    className?: string;
+export type DisclosureItemProps = React.ComponentPropsWithoutRef<'div'> & {
     value: number;
-}
+};
 
-const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps) => {
-    const disclosureItemRef = useRef<HTMLDivElement>(null);
+const DisclosureItem = React.forwardRef<React.ElementRef<'div'>, DisclosureItemProps>(({ children, className = '', value, ...props }, forwardedRef) => {
     const { activeItem, rootClass } = useContext(DisclosureContext);
 
     const [itemValue, setItemValue] = useState<number>(value);
@@ -36,8 +33,9 @@ const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps)
                 asChild
             >
                 <div
+                    {...props}
                     className={clsx(`${rootClass}-item`, className)}
-                    ref={disclosureItemRef}
+                    ref={forwardedRef}
                     data-state={isOpen ? 'open' : 'closed'}
                     id={`disclosure-data-item-${id}`}
                     role="region"
@@ -50,6 +48,8 @@ const DisclosureItem = ({ children, className = '', value }:DisclosureItemProps)
 
         </DisclosureItemContext.Provider>
     );
-};
+});
+
+DisclosureItem.displayName = 'DisclosureItem';
 
 export default DisclosureItem;

--- a/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { DisclosureContext } from '../contexts/DisclosureContext';
@@ -7,19 +7,25 @@ import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 
 const COMPONENT_NAME = 'Disclosure';
 
-export type DisclosureRootProps = {
-     children: React.ReactNode;
+export type DisclosureRootProps = React.ComponentPropsWithoutRef<'div'> & {
      customRootClass?: string;
      defaultOpen?: number | null;
-     'aria-label'?: string;
+};
 
-}
-
-const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:DisclosureRootProps) => {
-    const disclosureRef = useRef(null);
+const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, ...props }, forwardedRef) => {
+    const disclosureRef = useRef<React.ElementRef<'div'> | null>(null);
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [activeItem, setActiveItem] = useState<number | null>(null);
+
+    const setRefs = useCallback((node: React.ElementRef<'div'> | null) => {
+        disclosureRef.current = node;
+        if (typeof forwardedRef === 'function') {
+            forwardedRef(node);
+        } else if (forwardedRef) {
+            (forwardedRef as React.MutableRefObject<React.ElementRef<'div'> | null>).current = node;
+        }
+    }, [forwardedRef]);
 
     return (
 
@@ -34,8 +40,9 @@ const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:D
             <RovingFocusGroup.Root>
                 <RovingFocusGroup.Group className={clsx(`${rootClass}-root`)}>
                     <div
+                        {...props}
                         className={clsx(`${rootClass}-root`)}
-                        ref={disclosureRef}
+                        ref={setRefs}
                         role="region"
                         aria-label={ariaLabel}
                         data-testid='disclosure-root'
@@ -48,6 +55,8 @@ const DisclosureRoot = ({ children, customRootClass, 'aria-label': ariaLabel }:D
 
         </DisclosureContext.Provider>
     );
-};
+});
+
+DisclosureRoot.displayName = 'DisclosureRoot';
 
 export default DisclosureRoot;

--- a/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
@@ -5,12 +5,9 @@ import { DisclosureItemContext } from '../contexts/DisclosureItemContext';
 import CollapsiblePrimitive from '~/core/primitives/Collapsible';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 
-export type DisclosureTriggerProps = {
-    children: React.ReactNode;
-    className?: string;
-}
+export type DisclosureTriggerProps = React.ComponentPropsWithoutRef<'button'>;
 
-const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
+const DisclosureTrigger = React.forwardRef<React.ElementRef<'button'>, DisclosureTriggerProps>(({ children, className, onClick, ...props }, forwardedRef) => {
     const { activeItem, setActiveItem, rootClass } = useContext(DisclosureContext);
     const { itemValue } = useContext(DisclosureItemContext);
 
@@ -20,12 +17,15 @@ const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
         } else if (activeItem !== itemValue) {
             setActiveItem(itemValue);
         }
+        if (onClick) onClick(e);
     };
 
     return (
         <RovingFocusGroup.Item>
             <CollapsiblePrimitive.Trigger asChild>
                 <button
+                    {...props}
+                    ref={forwardedRef}
                     type='button'
                     className={clsx(`${rootClass}-trigger`, className)}
                     onClick={onClickHandler}
@@ -38,6 +38,8 @@ const DisclosureTrigger = ({ children, className }:DisclosureTriggerProps) => {
             </CollapsiblePrimitive.Trigger>
         </RovingFocusGroup.Item>
     );
-};
+});
+
+DisclosureTrigger.displayName = 'DisclosureTrigger';
 
 export default DisclosureTrigger;

--- a/src/components/ui/Disclosure/tests/Disclosure.test.tsx
+++ b/src/components/ui/Disclosure/tests/Disclosure.test.tsx
@@ -9,27 +9,74 @@ const items = [
 
 describe('Disclosure', () => {
     test('renders Disclosure component', () => {
-        render(<Disclosure items={[]} />);
+        render(<Disclosure items={[]} aria-label="test" />);
         expect(screen.getByTestId('disclosure-root')).toBeInTheDocument();
     });
 
+    test('forwards refs', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const contentRef = React.createRef<HTMLDivElement>();
+
+        render(
+            <Disclosure.Root ref={rootRef} aria-label="test">
+                <Disclosure.Item ref={itemRef} value={0}>
+                    <Disclosure.Trigger ref={triggerRef}>Item</Disclosure.Trigger>
+                    <Disclosure.Content ref={contentRef}>Content</Disclosure.Content>
+                </Disclosure.Item>
+            </Disclosure.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(contentRef.current).toBeNull();
+        fireEvent.click(triggerRef.current!);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('forwards ref through main component', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Disclosure ref={ref} items={items} aria-label="test" />);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
     test('renders all item titles', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         items.forEach(item => {
             expect(screen.getByText(item.title)).toBeInTheDocument();
         });
     });
 
     test('shows content when an item is clicked', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         fireEvent.click(screen.getByText('Item 1'));
         expect(screen.getByText('Content 1')).toBeInTheDocument();
     });
 
     test('hides content when the same item is clicked again', () => {
-        render(<Disclosure items={items} />);
+        render(<Disclosure items={items} aria-label="test" />);
         const button = screen.getByText('Item 1');
         fireEvent.click(button);
-        expect(screen.getByText('Content 1')).not.toHaveAttribute('');
+        fireEvent.click(button);
+        expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    });
+
+    test('has proper accessibility attributes', () => {
+        render(<Disclosure items={items} aria-label="accordion" />);
+        const root = screen.getByTestId('disclosure-root');
+        expect(root).toHaveAttribute('aria-label', 'accordion');
+        const trigger = screen.getByText('Item 1');
+        fireEvent.click(trigger);
+        const content = screen.getByText('Content 1');
+        expect(content).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    test('renders without warnings', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Disclosure items={items} aria-label="test" />);
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
     });
 });

--- a/src/components/ui/Em/Em.tsx
+++ b/src/components/ui/Em/Em.tsx
@@ -1,22 +1,22 @@
 'use client';
-import React from 'react';
+import React, { ComponentPropsWithoutRef, ElementRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
+
 const COMPONENT_NAME = 'Em';
 
-export type EmProps = {
-    children: React.ReactNode;
+export type EmProps = ComponentPropsWithoutRef<'em'> & {
     customRootClass?: string;
-    className?: string;
-    props: Record<string, any>[]
-}
-
-const Em = ({ children, customRootClass, className, ...props }: EmProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <em className={clsx(rootClass, className)} {...props}>
-        {children}
-    </em>;
 };
+
+const Em = React.forwardRef<ElementRef<'em'>, EmProps>(({ children, customRootClass, className, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    return (
+        <em ref={ref} className={clsx(rootClass, className)} {...props}>
+            {children}
+        </em>
+    );
+});
 
 Em.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Em/tests/Em.test.tsx
+++ b/src/components/ui/Em/tests/Em.test.tsx
@@ -32,4 +32,20 @@ describe('Em', () => {
         render(<>Welcome to <Em data-testid="em-data">RadUI</Em></>);
         expect(screen.getByText('RadUI')).toHaveAttribute('data-testid', 'em-data');
     });
+
+    test('forwards refs to the underlying element', () => {
+        const ref = React.createRef<HTMLElement>();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Em ref={ref}>RadUI</Em>);
+
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName.toLowerCase()).toBe('em');
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/components/ui/Heading/Heading.tsx
+++ b/src/components/ui/Heading/Heading.tsx
@@ -14,34 +14,27 @@ export type HeadingProps = {
     as?: HeadingTag;
     /** Custom root class for specialized styling */
     customRootClass?: string;
-    /** Additional class names to apply */
-    className?: string;
-    /** Content of the heading */
-    children?: React.ReactNode;
-} & React.HTMLAttributes<HTMLHeadingElement>;
+} & React.ComponentPropsWithoutRef<'h1'>;
 
 /**
  * Renders a heading element with customizable tag and styling
  */
-const Heading = ({
+const Heading = React.forwardRef<React.ElementRef<'h1'>, HeadingProps>(({
     children,
     as = 'h1',
     customRootClass = '',
     className = '',
     ...props
-}: HeadingProps) => {
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, as);
+    const Tag: HeadingTag = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(as) ? as : 'h1';
 
-    // Check if the heading tag is valid
-    if (!['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(as)) {
-        as = 'h1';
-    }
-
-    return React.createElement(as, {
+    return React.createElement(Tag, {
         className: clsx(rootClass, className),
+        ref,
         ...props
     }, children);
-};
+});
 
 Heading.displayName = 'Heading';
 

--- a/src/components/ui/Heading/tests/Heading.test.js
+++ b/src/components/ui/Heading/tests/Heading.test.js
@@ -37,4 +37,26 @@ describe('Heading', () => {
         const element = screen.getByTestId('heading-element');
         expect(element).toBeInTheDocument();
     });
+
+    test('forwards ref to the DOM element', () => {
+        const ref = React.createRef();
+        render(<Heading ref={ref}>Test Content</Heading>);
+        expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+    });
+
+    test('visually hidden headings remain accessible to screen readers', () => {
+        render(<Heading className="sr-only">Hidden Heading</Heading>);
+        const element = screen.getByRole('heading', { name: 'Hidden Heading' });
+        expect(element).toBeInTheDocument();
+    });
+
+    test('renders without console warnings', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<Heading>Test Content</Heading>);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
 });

--- a/src/components/ui/Kbd/Kbd.tsx
+++ b/src/components/ui/Kbd/Kbd.tsx
@@ -1,24 +1,25 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import { useCreateDataAttribute } from '~/core/hooks/createDataAttribute';
+
 const COMPONENT_NAME = 'Kbd';
 
-export type KbdProps = {
-    children: React.ReactNode;
+export type KbdElement = ElementRef<'kbd'>;
+export interface KbdProps extends ComponentPropsWithoutRef<'kbd'> {
     customRootClass?: string;
-    className?: string;
     size?: string;
-    props?: Record<string, any>[];
 }
 
-const Kbd = ({ children, customRootClass, className, size = '', ...props }: KbdProps) => {
+const Kbd = forwardRef<KbdElement, KbdProps>(({ children, customRootClass, className, size = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const dataAttributes = useCreateDataAttribute('kbd', { size });
 
-    return <kbd className={clsx(rootClass, className)} {...dataAttributes()} {...props}>{children}</kbd>;
-};
+    return <kbd ref={ref} className={clsx(rootClass, className)} {...dataAttributes()} {...props}>{children}</kbd>;
+});
+
+Kbd.displayName = COMPONENT_NAME;
 
 export default Kbd;

--- a/src/components/ui/Kbd/tests/Kbd.test.tsx
+++ b/src/components/ui/Kbd/tests/Kbd.test.tsx
@@ -18,5 +18,23 @@ describe('Kbd', () => {
         render(<Kbd data-testid="kbd-element">Ctrl</Kbd>);
         const kbdElement = screen.getByTestId('kbd-element');
         expect(kbdElement).toBeInTheDocument();
+        expect(kbdElement).not.toHaveAttribute('aria-hidden');
+    });
+
+    test('forwards ref to kbd element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Kbd ref={ref}>Ctrl</Kbd>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('KBD');
+    });
+
+    test('renders without console warnings', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<Kbd>Ctrl</Kbd>);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
     });
 });

--- a/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldDecrementProps = {
-    className?: string;
-    children?: React.ReactNode
-}
+export type NumberFieldDecrementElement = ElementRef<'button'>;
+export type NumberFieldDecrementProps = ComponentPropsWithoutRef<'button'>;
 
-const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecrementProps) => {
+const NumberFieldDecrement = forwardRef<NumberFieldDecrementElement, NumberFieldDecrementProps>(({ children, className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldDecrement must be used within a NumberField');
@@ -16,6 +14,7 @@ const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecr
     const { handleStep, rootClass, disabled, readOnly } = context;
     return (
         <button
+            ref={ref}
             onClick={() => handleStep({ direction: 'decrement', type: 'small' })}
             className={clsx(`${rootClass}-decrement`, className)}
             disabled={disabled || readOnly}
@@ -24,6 +23,8 @@ const NumberFieldDecrement = ({ children, className, ...props }: NumberFieldDecr
             {children}
         </button>
     );
-};
+});
+
+NumberFieldDecrement.displayName = 'NumberFieldDecrement';
 
 export default NumberFieldDecrement;

--- a/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldIncrementProps = {
-    className?: string
-    children?: React.ReactNode
-}
+export type NumberFieldIncrementElement = ElementRef<'button'>;
+export type NumberFieldIncrementProps = ComponentPropsWithoutRef<'button'>;
 
-const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncrementProps) => {
+const NumberFieldIncrement = forwardRef<NumberFieldIncrementElement, NumberFieldIncrementProps>(({ children, className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldIncrement must be used within a NumberField');
@@ -17,6 +15,7 @@ const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncr
 
     return (
         <button
+            ref={ref}
             onClick={() => handleStep({ direction: 'increment', type: 'small' })}
             className={clsx(`${rootClass}-increment`, className)}
             disabled={disabled || readOnly}
@@ -25,6 +24,8 @@ const NumberFieldIncrement = ({ children, className, ...props }: NumberFieldIncr
             {children}
         </button>
     );
-};
+});
+
+NumberFieldIncrement.displayName = 'NumberFieldIncrement';
 
 export default NumberFieldIncrement;

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import clsx from 'clsx';
 
-export type NumberFieldInputProps = {
-    className?: string
-}
-const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
+export type NumberFieldInputElement = ElementRef<'input'>;
+export type NumberFieldInputProps = ComponentPropsWithoutRef<'input'>;
+
+const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputProps>(({ className, ...props }, ref) => {
     const context = useContext(NumberFieldContext);
     if (!context) {
         console.error('NumberFieldInput must be used within a NumberField');
@@ -43,6 +43,7 @@ const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
     };
     return (
         <input
+            ref={ref}
             type="number"
             onKeyDown={handleKeyDown}
             value={inputValue === '' ? '' : inputValue}
@@ -55,6 +56,8 @@ const NumberFieldInput = ({ className, ...props }: NumberFieldInputProps) => {
             className={clsx(`${rootClass}-input`, className)}
             {...props}/>
     );
-};
+});
+
+NumberFieldInput.displayName = 'NumberFieldInput';
 
 export default NumberFieldInput;

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { useControllableState } from '~/core/hooks/useControllableState';
 import NumberFieldContext from '../contexts/NumberFieldContext';
 import { customClassSwitcher } from '~/core';
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 const COMPONENT_NAME = 'NumberField';
 
+export type NumberFieldRootElement = ElementRef<'div'>;
 export type NumberFieldRootProps = {
     name?: string
     defaultValue?: number | ''
@@ -18,12 +19,9 @@ export type NumberFieldRootProps = {
     disabled?: boolean
     readOnly?: boolean
     required?: boolean
-    id?: string
-    className?: string
-    children?: React.ReactNode
-};
+} & ComponentPropsWithoutRef<'div'>;
 
-const NumberFieldRoot = ({ children, name, defaultValue = '', value, onValueChange, largeStep, step, min, max, disabled, readOnly, required, id, className, ...props }: NumberFieldRootProps) => {
+const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep, step, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
     const [inputValue, setInputValue] = useControllableState<number | ''>(
         value,
@@ -105,12 +103,14 @@ const NumberFieldRoot = ({ children, name, defaultValue = '', value, onValueChan
     };
 
     return (
-        <div className={clsx(`${rootClass}-root`, className)} {...props}>
+        <div ref={ref} className={clsx(`${rootClass}-root`, className)} {...props}>
             <NumberFieldContext.Provider value={contextValues}>
                 {children}
             </NumberFieldContext.Provider>
         </div>
     );
-};
+});
+
+NumberFieldRoot.displayName = COMPONENT_NAME;
 
 export default NumberFieldRoot;

--- a/src/components/ui/NumberField/tests/NumberField.test.tsx
+++ b/src/components/ui/NumberField/tests/NumberField.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NumberField from '../NumberField';
+
+describe('NumberField', () => {
+    test('forwards refs to underlying elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const inputRef = React.createRef<HTMLInputElement>();
+        const incRef = React.createRef<HTMLButtonElement>();
+        const decRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <NumberField.Root ref={rootRef}>
+                <NumberField.Decrement ref={decRef}>-</NumberField.Decrement>
+                <NumberField.Input ref={inputRef} aria-label="value" />
+                <NumberField.Increment ref={incRef}>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+        expect(incRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(decRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('supports accessibility attributes', () => {
+        render(
+            <NumberField.Root>
+                <NumberField.Decrement>-</NumberField.Decrement>
+                <NumberField.Input aria-label="Quantity" />
+                <NumberField.Increment>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(screen.getByLabelText('Quantity')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '+' })).toBeInTheDocument();
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <NumberField.Root>
+                <NumberField.Decrement>-</NumberField.Decrement>
+                <NumberField.Input aria-label="value" />
+                <NumberField.Increment>+</NumberField.Increment>
+            </NumberField.Root>
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});

--- a/src/components/ui/Progress/Progress.tsx
+++ b/src/components/ui/Progress/Progress.tsx
@@ -1,13 +1,28 @@
-import ProgressRoot from './fragments/ProgressRoot';
-import ProgressIndicator from './fragments/ProgressIndicator';
+import React, { forwardRef } from "react";
+import ProgressRoot, {
+    ProgressRootElement,
+    ProgressRootProps,
+} from "./fragments/ProgressRoot";
+import ProgressIndicator from "./fragments/ProgressIndicator";
 
-export const COMPONENT_NAME = 'Progress';
+export const COMPONENT_NAME = "Progress";
 
-function Progress() {
-    console.warn('Direct usage of Progress is not supported. Please use Progress.Root, Progress.Indicator, etc. instead.');
-    return null;
-}
+export type ProgressProps = ProgressRootProps;
+type ProgressComponent = React.ForwardRefExoticComponent<
+    ProgressProps & React.RefAttributes<ProgressRootElement>
+> & {
+    Root: typeof ProgressRoot;
+    Indicator: typeof ProgressIndicator;
+};
 
+const Progress = forwardRef<ProgressRootElement, ProgressProps>((props, ref) => {
+    console.warn(
+        "Direct usage of Progress is not supported. Please use Progress.Root, Progress.Indicator, etc. instead.",
+    );
+    return <ProgressRoot ref={ref} {...props} />;
+}) as ProgressComponent;
+
+Progress.displayName = COMPONENT_NAME;
 Progress.Root = ProgressRoot;
 Progress.Indicator = ProgressIndicator;
 

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -1,15 +1,24 @@
-'use client';
-import React, { useContext } from 'react';
+"use client";
+import React, {
+    useContext,
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef,
+} from "react";
 
-import { clsx } from 'clsx';
-import { ProgressContext } from '../contexts/ProgressContext';
-import Primitive from '~/core/primitives/Primitive';
+import { clsx } from "clsx";
+import { ProgressContext } from "../contexts/ProgressContext";
+import Primitive from "~/core/primitives/Primitive";
 
-interface IndicatorProps {
-    asChild?: boolean;
-}
+export type ProgressIndicatorElement = ElementRef<typeof Primitive.div>;
+export type ProgressIndicatorProps = ComponentPropsWithoutRef<
+    typeof Primitive.div
+>;
 
-export default function ProgressIndicator({ asChild }: IndicatorProps) {
+const ProgressIndicator = forwardRef<
+    ProgressIndicatorElement,
+    ProgressIndicatorProps
+>(({ className, style, ...props }, ref) => {
     const { value, minValue, maxValue, rootClass, state } = useContext(ProgressContext);
     // Ensure value stays within bounds in production, use 0 if value is null
     const boundedValue = Math.min(Math.max(value ?? 0, minValue), maxValue);
@@ -17,13 +26,13 @@ export default function ProgressIndicator({ asChild }: IndicatorProps) {
     // Calculate the percentage of completion
     const percentage = ((boundedValue - minValue) / (maxValue - minValue)) * 100;
 
-    const data_attributes: Record<string, string> = {};
+    const { asChild, ...rest } = props;
 
     return (
         <Primitive.div
             role="progressbar"
-            className={clsx(`${rootClass}-indicator`)}
-            style={{ transform: `translateX(-${100 - percentage}%)` }}
+            className={clsx(`${rootClass}-indicator`, className)}
+            style={{ transform: `translateX(-${100 - percentage}%)`, ...style }}
             aria-valuenow={boundedValue}
             aria-valuemax={maxValue}
             aria-valuemin={minValue}
@@ -32,9 +41,12 @@ export default function ProgressIndicator({ asChild }: IndicatorProps) {
             data-max={maxValue}
             data-min={minValue}
             asChild={asChild}
-            {...data_attributes}
-        >
-
-        </Primitive.div>
+            ref={ref}
+            {...rest}
+        />
     );
-}
+});
+
+ProgressIndicator.displayName = "ProgressIndicator";
+
+export default ProgressIndicator;

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,66 +1,103 @@
-'use client';
-import React, { useEffect, useState } from 'react';
-import { clsx } from 'clsx';
-import { customClassSwitcher } from '~/core';
-import { ProgressContext } from '../contexts/ProgressContext';
+"use client";
+import React, {
+    useEffect,
+    useState,
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef,
+} from "react";
+import { clsx } from "clsx";
+import { customClassSwitcher } from "~/core";
+import { ProgressContext } from "../contexts/ProgressContext";
 
-import Primitive from '~/core/primitives/Primitive';
+import Primitive from "~/core/primitives/Primitive";
 
-const COMPONENT_NAME = 'Progress';
+const COMPONENT_NAME = "Progress";
 
-type ProgressRootProps = {
-    asChild?: boolean;
+export type ProgressRootElement = ElementRef<typeof Primitive.div>;
+export type ProgressRootProps = {
     value: number | null;
     minValue: number;
     maxValue: number;
     getValueLabel?: (value: number, minValue: number, maxValue: number) => string;
-    children: React.ReactNode;
     customRootClass?: string;
-}
+    children: React.ReactNode;
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
 
 const STATE_ENUMS = {
-    LOADING: 'loading', // a progress is loading when the value is not null and not equal to the maxValue
-    COMPLETE: 'complete', // a progress is complete when the value is equal to the maxValue
-    INDETERMINATE: 'indeterminate' // a progress is indeterminate when the value is null, by default it's 0
+    LOADING: "loading", // a progress is loading when the value is not null and not equal to the maxValue
+    COMPLETE: "complete", // a progress is complete when the value is equal to the maxValue
+    INDETERMINATE: "indeterminate", // a progress is indeterminate when the value is null, by default it's 0
 } as const;
 
-const ProgressRoot = ({ value = 0, minValue = 0, maxValue = 100, children, customRootClass, asChild, getValueLabel }: ProgressRootProps) => {
-    const [state, setState] = useState<typeof STATE_ENUMS[keyof typeof STATE_ENUMS]>(STATE_ENUMS.LOADING);
+const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
+    (
+        {
+            value = 0,
+            minValue = 0,
+            maxValue = 100,
+            children,
+            customRootClass,
+            getValueLabel,
+            className,
+            ...props
+        },
+        ref,
+    ) => {
+        const [state, setState] = useState<
+            (typeof STATE_ENUMS)[keyof typeof STATE_ENUMS]
+        >(STATE_ENUMS.LOADING);
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? '';
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? "";
 
-    useEffect(() => {
-        setState(value === null ? STATE_ENUMS.INDETERMINATE : value === maxValue ? STATE_ENUMS.COMPLETE : STATE_ENUMS.LOADING);
-    }, [value, maxValue]);
+        useEffect(() => {
+            setState(
+                value === null
+                    ? STATE_ENUMS.INDETERMINATE
+                    : value === maxValue
+                        ? STATE_ENUMS.COMPLETE
+                        : STATE_ENUMS.LOADING,
+            );
+        }, [value, maxValue]);
 
-    const sendValues = {
-        value,
-        minValue,
-        maxValue,
-        rootClass,
-        getValueLabel,
-        ariaLabel,
-        state
-    };
-    return (
-        <ProgressContext.Provider value={sendValues}>
-            <Primitive.div
-                role="progressbar"
-                aria-label={ariaLabel}
-                aria-valuetext={ariaLabel}
-                aria-valuenow={value ?? 0}
-                aria-valuemin={minValue}
-                aria-valuemax={maxValue}
-                data-state={state}
-                data-value={value ?? 0}
-                data-max={maxValue}
-                data-min={minValue}
-                className={clsx(rootClass)}
-                asChild={asChild}
-            >{children}</Primitive.div>
-        </ProgressContext.Provider>
-    );
-};
+        const sendValues = {
+            value,
+            minValue,
+            maxValue,
+            rootClass,
+            getValueLabel,
+            ariaLabel,
+            state,
+        };
+
+        const { asChild, ...rest } = props;
+
+        return (
+            <ProgressContext.Provider value={sendValues}>
+                <Primitive.div
+                    role="progressbar"
+                    aria-label={ariaLabel}
+                    aria-valuetext={ariaLabel}
+                    aria-valuenow={value ?? 0}
+                    aria-valuemin={minValue}
+                    aria-valuemax={maxValue}
+                    data-state={state}
+                    data-value={value ?? 0}
+                    data-max={maxValue}
+                    data-min={minValue}
+                    className={clsx(rootClass, className)}
+                    asChild={asChild}
+                    ref={ref}
+                    {...rest}
+                >
+                    {children}
+                </Primitive.div>
+            </ProgressContext.Provider>
+        );
+    },
+);
+
+ProgressRoot.displayName = COMPONENT_NAME;
 
 export default ProgressRoot;

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -18,6 +18,26 @@ describe('Progress', () => {
         expect(progressBars[0]).toBeInTheDocument();
     });
 
+    test('forwards ref to root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Progress.Root ref={ref} value={50} maxValue={100} minValue={0}>
+                <Progress.Indicator />
+            </Progress.Root>,
+        );
+        expect(ref.current).not.toBeNull();
+    });
+
+    test('forwards ref to indicator element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Progress.Root value={50} maxValue={100} minValue={0}>
+                <Progress.Indicator ref={ref} />
+            </Progress.Root>,
+        );
+        expect(ref.current).not.toBeNull();
+    });
+
     test('renders progress bar with clamped value', () => {
         const { rerender } = render(<ProgressComp value={110} maxValue={100} minValue={0} />);
         const progressBars = screen.getAllByRole('progressbar');

--- a/src/components/ui/Quote/Quote.tsx
+++ b/src/components/ui/Quote/Quote.tsx
@@ -2,19 +2,23 @@
 import React from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
+
 const COMPONENT_NAME = 'Quote';
 
-export type QuoteProps = {
-    children: React.ReactNode;
+export type QuoteProps = React.ComponentPropsWithoutRef<'q'> & {
     customRootClass?: string;
-    className?: string;
-    props?: Record<string, any>[]
-}
-
-const Quote = ({ children, customRootClass, className, ...props }: QuoteProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <q className={clsx(rootClass, className)} {...props}>{children}</q>;
 };
+
+const Quote = React.forwardRef<React.ElementRef<'q'>, QuoteProps>(
+    ({ children, customRootClass, className, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        return (
+            <q ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </q>
+        );
+    }
+);
 
 Quote.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Quote/tests/Quote.test.tsx
+++ b/src/components/ui/Quote/tests/Quote.test.tsx
@@ -1,36 +1,52 @@
 import React from 'react';
-import { render, RenderResult } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+
 import Quote from '../Quote';
 
-describe('Quote Component', () => {
-    it('renders without crashing', () => {
-        const { container } = render(
+describe('Quote', () => {
+    test('renders quote text', () => {
+        render(
             <Quote>
-                You must be the change you wish to see in the world. - Mahatma
-                Gandhi
+                You must be the change you wish to see in the world. - Mahatma Gandhi
             </Quote>
         );
-        const quoteElements = container.querySelectorAll('q');
 
-        expect(quoteElements.length).toEqual(1);
-        expect(quoteElements[0]).toBeTruthy();
-        expect(quoteElements[0].textContent).toEqual(
-            'You must be the change you wish to see in the world. - Mahatma Gandhi'
-        );
+        expect(
+            screen.getByText(
+                'You must be the change you wish to see in the world. - Mahatma Gandhi'
+            )
+        ).toBeInTheDocument();
     });
 
-    it('renders with custom root class and custom class name', () => {
-        const { container } = render(
-            <Quote
-                customRootClass="acme-corp"
-                className="custom-class-name">
-                You must be the change you wish to see in the world. - Mahatma
-                Gandhi
+    test('supports custom classes', () => {
+        render(
+            <Quote customRootClass='acme-corp' className='custom-class-name'>
+                You must be the change you wish to see in the world. - Mahatma Gandhi
             </Quote>
         );
 
-        const quoteElement = container.querySelector('q');
+        const quoteElement = screen.getByText(
+            'You must be the change you wish to see in the world. - Mahatma Gandhi'
+        );
         expect(quoteElement).toHaveClass('acme-corp-quote');
         expect(quoteElement).toHaveClass('custom-class-name');
     });
+
+    test('forwards refs to the underlying element', () => {
+        const ref = React.createRef<HTMLQuoteElement>();
+        render(<Quote ref={ref}>Quote</Quote>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current?.tagName).toBe('Q');
+    });
+
+    test('renders without console errors', () => {
+        const consoleError = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        render(<Quote>Quote</Quote>);
+        expect(consoleError).not.toHaveBeenCalled();
+        consoleError.mockRestore();
+    });
 });
+

--- a/src/components/ui/Radio/Radio.tsx
+++ b/src/components/ui/Radio/Radio.tsx
@@ -9,7 +9,9 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 
 const COMPONENT_NAME = 'Radio';
 
-export type RadioProps = RadioPrimitiveProps & {
+export type RadioElement = React.ElementRef<typeof RadioPrimitive>;
+
+export type RadioProps = Omit<RadioPrimitiveProps, 'size'> & {
     customRootClass?: string;
     className?: string;
     size?: string;
@@ -17,7 +19,10 @@ export type RadioProps = RadioPrimitiveProps & {
     variant?: string;
 };
 
-function Radio({ name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props }: RadioProps) {
+const Radio = React.forwardRef<RadioElement, RadioProps>(function Radio(
+    { name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props },
+    ref
+) {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const [isChecked, setIsChecked] = React.useState(checked);
 
@@ -33,6 +38,7 @@ function Radio({ name, value, id, checked = false, required, onChange, disabled,
     };
     return (
         <RadioPrimitive
+            ref={ref}
             name={name}
             id={id}
             value={value}
@@ -48,6 +54,8 @@ function Radio({ name, value, id, checked = false, required, onChange, disabled,
         />
 
     );
-}
+});
+
+Radio.displayName = COMPONENT_NAME;
 
 export default Radio;

--- a/src/components/ui/Radio/tests/Radio.test.tsx
+++ b/src/components/ui/Radio/tests/Radio.test.tsx
@@ -66,4 +66,10 @@ describe('Radio', () => {
         expect(radio).toHaveAttribute('data-button-size', 'lg');
         expect(radio).toHaveAttribute('data-rad-ui-accent-color', 'red');
     });
+
+    it('forwards refs', () => {
+        const ref = React.createRef<HTMLInputElement>();
+        render(<Radio {...baseProps} ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
 });

--- a/src/components/ui/RadioCards/fragments/RadioCardsItem.tsx
+++ b/src/components/ui/RadioCards/fragments/RadioCardsItem.tsx
@@ -4,15 +4,21 @@ import { RadioCardsContext } from '../context/RadioCardsContext';
 
 import clsx from 'clsx';
 
-export type RadioCardsItemProps = {
-    children?: React.ReactNode
-    className?: string
-    value: string
-} & RadioGroupPrimitiveProps.Item
+export type RadioCardsItemElement = React.ElementRef<typeof RadioGroupPrimitive.Item>;
 
-const RadioCardsItem = ({ children, className = '', value, ...props }: RadioCardsItemProps) => {
-    const { rootClass } = useContext(RadioCardsContext);
-    return <RadioGroupPrimitive.Item className={clsx(`${rootClass}-item`, className)} {...props} value={value}>{children}</RadioGroupPrimitive.Item>;
-};
+export type RadioCardsItemProps = {
+    children?: React.ReactNode;
+    className?: string;
+    value: string;
+} & RadioGroupPrimitiveProps.Item;
+
+const RadioCardsItem = React.forwardRef<RadioCardsItemElement, RadioCardsItemProps>(
+    ({ children, className = '', value, ...props }, ref) => {
+        const { rootClass } = useContext(RadioCardsContext);
+        return <RadioGroupPrimitive.Item ref={ref} className={clsx(`${rootClass}-item`, className)} {...props} value={value}>{children}</RadioGroupPrimitive.Item>;
+    }
+);
+
+RadioCardsItem.displayName = 'RadioCardsItem';
 
 export default RadioCardsItem;

--- a/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
+++ b/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
@@ -8,6 +8,8 @@ import { RadioCardsContext } from '../context/RadioCardsContext';
 
 const COMPONENT_NAME = 'RadioCards';
 
+export type RadioCardsRootElement = React.ElementRef<typeof RadioGroupPrimitive.Root>;
+
 type RadioCardsRootProps = {
     children: React.ReactNode;
     className?: string;
@@ -17,16 +19,20 @@ type RadioCardsRootProps = {
     color?: string;
 } & RadioGroupPrimitiveProps.Root;
 
-const RadioCardsRoot = ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }: RadioCardsRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const RadioCardsRoot = React.forwardRef<RadioCardsRootElement, RadioCardsRootProps>(
+    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    const dataAttributes = useCreateDataAttribute('radio-cards', { variant, size });
-    const accentAttributes = useCreateDataAccentColorAttribute(color);
-    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+        const dataAttributes = useCreateDataAttribute('radio-cards', { variant, size });
+        const accentAttributes = useCreateDataAccentColorAttribute(color);
+        const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
-    return <RadioCardsContext.Provider value={{ rootClass }}>
-        <RadioGroupPrimitive.Root className={clsx(rootClass, className)} {...composedAttributes} {...props}>{children}</RadioGroupPrimitive.Root>
-    </RadioCardsContext.Provider>;
-};
+        return <RadioCardsContext.Provider value={{ rootClass }}>
+            <RadioGroupPrimitive.Root ref={ref} className={clsx(rootClass, className)} {...composedAttributes()} {...props}>{children}</RadioGroupPrimitive.Root>
+        </RadioCardsContext.Provider>;
+    }
+);
+
+RadioCardsRoot.displayName = 'RadioCardsRoot';
 
 export default RadioCardsRoot;

--- a/src/components/ui/RadioCards/tests/RadioCards.test.tsx
+++ b/src/components/ui/RadioCards/tests/RadioCards.test.tsx
@@ -78,4 +78,20 @@ describe('RadioCards', () => {
         const { container } = renderRadioCards({ className: 'custom-root' });
         expect(container.firstChild).toHaveClass('custom-root');
     });
+
+    it('forwards refs to root and item', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <RadioCards.Root ref={rootRef} name="group" defaultValue={options[0].value}>
+                <RadioCards.Item ref={itemRef} value={options[0].value}>
+                    {options[0].label}
+                </RadioCards.Item>
+            </RadioCards.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
 });

--- a/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
@@ -9,15 +9,22 @@ export type RadioGroupIndicatorProps = ComponentPropsWithoutRef<typeof RadioGrou
     className?: string;
 };
 
-const RadioGroupIndicator = React.forwardRef<RadioGroupIndicatorElement, RadioGroupIndicatorProps>(({ className = '', children, ...props }, forwardedRef) => {
-    const { rootClass } = React.useContext(RadioGroupContext);
-    return (
-        <RadioGroupPrimitive.Indicator ref={forwardedRef} className={clsx(`${rootClass}-indicator`, className)} {...props} >
-            {children}
-        </RadioGroupPrimitive.Indicator>
-    );
-});
+const RadioGroupIndicator = React.forwardRef<RadioGroupIndicatorElement, RadioGroupIndicatorProps>(
+    ({ className = '', children, ...props }, forwardedRef) => {
+        const { rootClass } = React.useContext(RadioGroupContext);
+        return (
+            <RadioGroupPrimitive.Indicator
+                ref={forwardedRef}
+                className={clsx(`${rootClass}-indicator`, className)}
+                {...props}
+            >
+                {children}
+            </RadioGroupPrimitive.Indicator>
+        );
+    }
+);
 
 RadioGroupIndicator.displayName = 'RadioGroupIndicator';
 
 export default RadioGroupIndicator;
+

--- a/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
@@ -10,11 +10,23 @@ export type RadioGroupItemProps = ComponentPropsWithoutRef<typeof RadioGroupPrim
     value: string;
 };
 
-const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(({ children, className = '', value, ...props }, forwardedRef) => {
-    const { rootClass } = useContext(RadioGroupContext);
-    return <RadioGroupPrimitive.Item ref={forwardedRef} className={clsx(`${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
-});
+const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
+    ({ children, className = '', value, ...props }, forwardedRef) => {
+        const { rootClass } = useContext(RadioGroupContext);
+        return (
+            <RadioGroupPrimitive.Item
+                ref={forwardedRef}
+                className={clsx(`${rootClass}-item`, className)}
+                value={value}
+                {...props}
+            >
+                {children}
+            </RadioGroupPrimitive.Item>
+        );
+    }
+);
 
 RadioGroupItem.displayName = 'RadioGroupItem';
 
 export default RadioGroupItem;
+

--- a/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
@@ -5,16 +5,25 @@ import { RadioGroupContext } from '../context/RadioGroupContext';
 
 export type RadioGroupLabelElement = ElementRef<typeof Primitive.label>;
 
-export type RadioGroupLabelProps = ComponentPropsWithoutRef<typeof Primitive.label> & {
-    className?: string;
-    asChild?: boolean;
-};
+export type RadioGroupLabelProps = ComponentPropsWithoutRef<typeof Primitive.label>;
 
-const RadioGroupLabel = React.forwardRef<RadioGroupLabelElement, RadioGroupLabelProps>(({ className = '', asChild = false, children, ...props }, forwardedRef) => {
-    const { rootClass } = React.useContext(RadioGroupContext);
-    return <Primitive.label ref={forwardedRef} {...props} className={clsx(`${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
-});
+const RadioGroupLabel = React.forwardRef<RadioGroupLabelElement, RadioGroupLabelProps>(
+    ({ className = '', asChild = false, children, ...props }, forwardedRef) => {
+        const { rootClass } = React.useContext(RadioGroupContext);
+        return (
+            <Primitive.label
+                ref={forwardedRef}
+                {...props}
+                className={clsx(`${rootClass}-label`, className)}
+                asChild={asChild}
+            >
+                {children}
+            </Primitive.label>
+        );
+    }
+);
 
 RadioGroupLabel.displayName = 'RadioGroupLabel';
 
 export default RadioGroupLabel;
+

--- a/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
@@ -6,7 +6,11 @@ import { customClassSwitcher } from '~/core';
 
 import { RadioGroupContext } from '../context/RadioGroupContext';
 
-import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
+import {
+    useCreateDataAttribute,
+    useComposeAttributes,
+    useCreateDataAccentColorAttribute,
+} from '~/core/hooks/createDataAttribute';
 
 const COMPONENT_NAME = 'RadioGroup';
 
@@ -20,18 +24,30 @@ export type RadioGroupRootProps = ComponentPropsWithoutRef<typeof RadioGroupPrim
     color?: string;
 };
 
-const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootProps>(({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, forwardedRef) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
+const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootProps>(
+    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, forwardedRef) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
 
-    const accentAttributes = useCreateDataAccentColorAttribute(color);
-    const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
+        const accentAttributes = useCreateDataAccentColorAttribute(color);
+        const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());
 
-    return <RadioGroupContext.Provider value={{ rootClass }}>
-        <RadioGroupPrimitive.Root ref={forwardedRef} className={clsx(`${rootClass}-root`, className)} {...composedAttributes()} {...props}> {children} </RadioGroupPrimitive.Root>
-    </RadioGroupContext.Provider>;
-});
+        return (
+            <RadioGroupContext.Provider value={{ rootClass }}>
+                <RadioGroupPrimitive.Root
+                    ref={forwardedRef}
+                    className={clsx(`${rootClass}-root`, className)}
+                    {...composedAttributes()}
+                    {...props}
+                >
+                    {children}
+                </RadioGroupPrimitive.Root>
+            </RadioGroupContext.Provider>
+        );
+    }
+);
 
 RadioGroupRoot.displayName = 'RadioGroupRoot';
 
 export default RadioGroupRoot;
+

--- a/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
+++ b/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
@@ -111,4 +111,22 @@ describe('RadioGroup (fragments)', () => {
         );
         spy.mockRestore();
     });
+
+    it('forwards refs to root, item, and indicator', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        const indicatorRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <RadioGroup.Root ref={rootRef} defaultValue="html">
+                <RadioGroup.Item ref={itemRef} value="html">
+                    <RadioGroup.Indicator ref={indicatorRef} />
+                </RadioGroup.Item>
+            </RadioGroup.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(indicatorRef.current).toBeInstanceOf(HTMLSpanElement);
+    });
 });

--- a/src/components/ui/Separator/Separator.tsx
+++ b/src/components/ui/Separator/Separator.tsx
@@ -2,54 +2,59 @@ import React from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import Primitive from '~/core/primitives/Primitive';
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 
 const COMPONENT_NAME = 'Separator';
 
+type SeparatorElement = ElementRef<typeof Primitive.div>;
+type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+
 export type SeparatorProps = {
     orientation?: 'horizontal' | 'vertical';
-    className?: string;
     customRootClass?: string;
     color?: string;
-    asChild?: boolean;
     decorative?: boolean;
-    props?: any;
-} & React.ComponentProps<'div'>;
+} & PrimitiveDivProps;
 
-const Separator = ({
-    orientation = 'horizontal',
-    className,
-    customRootClass,
-    color = '',
-    asChild = false,
-    decorative = false,
-    ...props
-}: SeparatorProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const orientationClass = orientation === 'vertical' ? `${rootClass}-vertical` : `${rootClass}-horizontal`;
-    const data_attributes: Record<string, string> = {};
+const Separator = React.forwardRef<SeparatorElement, SeparatorProps>(
+    (
+        {
+            orientation = 'horizontal',
+            className,
+            customRootClass,
+            color = '',
+            decorative = false,
+            ...props
+        },
+        ref
+    ) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const orientationClass = orientation === 'vertical' ? `${rootClass}-vertical` : `${rootClass}-horizontal`;
+        const data_attributes: Record<string, string> = {};
 
-    // Add data-orientation attribute
-    data_attributes['data-orientation'] = orientation;
+        // Add data-orientation attribute
+        data_attributes['data-orientation'] = orientation;
 
-    if (color) {
-        data_attributes['data-rad-ui-accent-color'] = color;
+        if (color) {
+            data_attributes['data-rad-ui-accent-color'] = color;
+        }
+
+        // Add decorative role if specified
+        if (decorative) {
+            data_attributes.role = 'separator';
+            data_attributes['aria-hidden'] = 'true';
+        }
+
+        return (
+            <Primitive.div
+                ref={ref}
+                className={clsx(rootClass, orientationClass, className)}
+                {...data_attributes}
+                {...props}
+            />
+        );
     }
-
-    // Add decorative role if specified
-    if (decorative) {
-        data_attributes.role = 'separator';
-        data_attributes['aria-hidden'] = 'true';
-    }
-
-    return (
-        <Primitive.div
-            className={clsx(rootClass, orientationClass, className)}
-            asChild={asChild}
-            {...data_attributes}
-            {...props}
-        />
-    );
-};
+);
 
 Separator.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Separator/tests/Separator.test.tsx
+++ b/src/components/ui/Separator/tests/Separator.test.tsx
@@ -28,6 +28,29 @@ describe('Separator Component', () => {
         expect(screen.getByTestId('separator')).toHaveAttribute('data-rad-ui-accent-color', 'blue');
     });
 
+    test('forwards ref to underlying DOM element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Separator ref={ref} data-testid="separator" />);
+        expect(ref.current).toBe(screen.getByTestId('separator'));
+    });
+
+    test('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Separator data-testid="separator" />);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test('non-decorative separator is accessible to screen readers', () => {
+        render(<Separator data-testid="separator" />);
+        const separator = screen.getByTestId('separator');
+        expect(separator).not.toHaveAttribute('aria-hidden');
+        expect(separator).not.toHaveAttribute('role');
+    });
+
     // New tests for the GitHub issue #1269 features
     describe('New Props and Features', () => {
         test('asChild prop works correctly', () => {

--- a/src/components/ui/Slider/Slider.tsx
+++ b/src/components/ui/Slider/Slider.tsx
@@ -1,14 +1,27 @@
 'use client';
 
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, ForwardRefExoticComponent, RefAttributes } from 'react';
 import SliderRoot from './fragments/SliderRoot';
 import SliderTrack from './fragments/SliderTrack';
 import SliderThumb from './fragments/SliderThumb';
 import SliderRange from './fragments/SliderRange';
 
-const Slider = () => {
+export type SliderElement = ElementRef<'div'>;
+export type SliderProps = ComponentPropsWithoutRef<'div'>;
+
+type SliderComponent = ForwardRefExoticComponent<SliderProps & RefAttributes<SliderElement>> & {
+    Root: typeof SliderRoot;
+    Track: typeof SliderTrack;
+    Range: typeof SliderRange;
+    Thumb: typeof SliderThumb;
+};
+
+const Slider = forwardRef<SliderElement, SliderProps>((_props, _ref) => {
     console.warn('Direct usage of Slider is not supported. Please use Slider.Root, Slider.Track, etc. instead.');
     return null;
-};
+}) as SliderComponent;
+
+Slider.displayName = 'Slider';
 
 Slider.Root = SliderRoot;
 Slider.Track = SliderTrack;

--- a/src/components/ui/Slider/fragments/SliderRange.tsx
+++ b/src/components/ui/Slider/fragments/SliderRange.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderRange = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderRange';
+
+export type SliderRangeElement = ElementRef<'div'>;
+export type SliderRangeProps = { children: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderRange = forwardRef<SliderRangeElement, SliderRangeProps>(({ children, ...props }, ref) => {
     const { rootClass, value } = React.useContext(SliderContext);
 
-    return <div className={`${rootClass}-range`} style={{ left: `calc(${value}% - 16px)`, width: `calc(${value}%)` }}>{children}</div>;
-};
+    return <div ref={ref} className={`${rootClass}-range`} style={{ left: `calc(${value}% - 16px)`, width: `calc(${value}%)` }} {...props}>{children}</div>;
+});
+
+SliderRange.displayName = COMPONENT_NAME;
 
 export default SliderRange;

--- a/src/components/ui/Slider/fragments/SliderRoot.tsx
+++ b/src/components/ui/Slider/fragments/SliderRoot.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import clsx from 'clsx';
 
 import { customClassSwitcher } from '~/core/customClassSwitcher';
@@ -7,7 +7,8 @@ import { SliderContext } from '../context/SliderContext';
 
 const COMPONENT_NAME = 'Slider';
 
-type SliderRootProps = {
+export type SliderRootElement = ElementRef<'div'>;
+export type SliderRootProps = {
     children: React.ReactNode;
     className?: string;
     customRootClass?: string;
@@ -19,9 +20,22 @@ type SliderRootProps = {
     readOnly?: boolean;
     orientation?: 'horizontal' | 'vertical';
     valueLabelDisplay?: 'auto' | 'on' | 'off';
-};
+} & ComponentPropsWithoutRef<'div'>;
 
-const SliderRoot = ({ children, className = '', customRootClass = '', defaultValue = 0, min = 0, max = 100, step = 1, disabled = false, readOnly = false, orientation = 'horizontal', valueLabelDisplay = 'auto' }: SliderRootProps) => {
+const SliderRoot = forwardRef<SliderRootElement, SliderRootProps>(({
+    children,
+    className = '',
+    customRootClass = '',
+    defaultValue = 0,
+    min = 0,
+    max = 100,
+    step = 1,
+    disabled = false,
+    readOnly = false,
+    orientation = 'horizontal',
+    valueLabelDisplay = 'auto',
+    ...props
+}, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
     const [value, setValue] = React.useState(defaultValue);
@@ -89,8 +103,10 @@ const SliderRoot = ({ children, className = '', customRootClass = '', defaultVal
     };
 
     return <SliderContext.Provider value={contextValues}>
-        <div className={clsx(rootClass, className)} onClick={handleClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove}>{children}</div>
+        <div ref={ref} className={clsx(rootClass, className)} onClick={handleClick} onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} {...props}>{children}</div>
     </SliderContext.Provider>;
-};
+});
+
+SliderRoot.displayName = COMPONENT_NAME;
 
 export default SliderRoot;

--- a/src/components/ui/Slider/fragments/SliderThumb.tsx
+++ b/src/components/ui/Slider/fragments/SliderThumb.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderThumb = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderThumb';
+
+export type SliderThumbElement = ElementRef<'div'>;
+export type SliderThumbProps = { children?: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderThumb = forwardRef<SliderThumbElement, SliderThumbProps>(({ children: _children, ...props }, ref) => {
     const { rootClass, value } = React.useContext(SliderContext);
     const sliderInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -16,10 +21,12 @@ const SliderThumb = ({ children }: { children: React.ReactNode }) => {
         console.log(e.target.value);
     };
 
-    return <div className={`${rootClass}-thumb`} onClick={handleClick} style={{ left: `calc(${value}% - 16px)` }}>
+    return <div ref={ref} className={`${rootClass}-thumb`} onClick={handleClick} style={{ left: `calc(${value}% - 16px)` }} {...props}>
         <span className={`${rootClass}-thumb-value`}></span>
         <input onChange={handleChange} value={value} style={{ display: 'none' }} ref={sliderInputRef} />
     </div>;
-};
+});
+
+SliderThumb.displayName = COMPONENT_NAME;
 
 export default SliderThumb;

--- a/src/components/ui/Slider/fragments/SliderTrack.tsx
+++ b/src/components/ui/Slider/fragments/SliderTrack.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { SliderContext } from '../context/SliderContext';
 
-const SliderTrack = ({ children }: { children: React.ReactNode }) => {
+const COMPONENT_NAME = 'SliderTrack';
+
+export type SliderTrackElement = ElementRef<'div'>;
+export type SliderTrackProps = { children: React.ReactNode } & ComponentPropsWithoutRef<'div'>;
+
+const SliderTrack = forwardRef<SliderTrackElement, SliderTrackProps>(({ children, ...props }, ref) => {
     const { rootClass } = React.useContext(SliderContext);
 
-    return <div className={`${rootClass}-track`}>{children}</div>;
-};
+    return <div ref={ref} className={`${rootClass}-track`} {...props}>{children}</div>;
+});
+
+SliderTrack.displayName = COMPONENT_NAME;
 
 export default SliderTrack;

--- a/src/components/ui/Slider/tests/Slider.test.tsx
+++ b/src/components/ui/Slider/tests/Slider.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Slider from '../Slider';
+
+describe('Slider Component', () => {
+    test('Slider.Root forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root ref={ref}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Track forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track ref={ref}>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Range forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range ref={ref}>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('Slider.Thumb forwards ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb ref={ref} />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('hidden input is present for accessibility', () => {
+        render(
+            <Slider.Root defaultValue={50}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        const hiddenInput = screen.getByRole('textbox', { hidden: true });
+        expect(hiddenInput).toHaveValue('50');
+    });
+
+    test('renders without warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(
+            <Slider.Root>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    test('matches snapshot', () => {
+        const { asFragment } = render(
+            <Slider.Root defaultValue={25}>
+                <Slider.Track>
+                    <Slider.Range>
+                        <Slider.Thumb />
+                    </Slider.Range>
+                </Slider.Track>
+            </Slider.Root>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/src/components/ui/Slider/tests/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/ui/Slider/tests/__snapshots__/Slider.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider Component matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="rad-ui-slider"
+  >
+    <div
+      class="rad-ui-slider-track"
+    >
+      <div
+        class="rad-ui-slider-range"
+        style="left: calc(25% - 16px); width: calc(25%);"
+      >
+        <div
+          class="rad-ui-slider-thumb"
+          style="left: calc(25% - 16px);"
+        >
+          <span
+            class="rad-ui-slider-thumb-value"
+          />
+          <input
+            style="display: none;"
+            value="25"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/ui/Strong/Strong.tsx
+++ b/src/components/ui/Strong/Strong.tsx
@@ -1,20 +1,25 @@
+"use client";
 import React from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
+
 const COMPONENT_NAME = 'Strong';
 
-export type StrongProps = {
-    children: React.ReactNode,
-    className?: string,
-    customRootClass?: string
-} & React.ComponentProps<'strong'>
-
-const Strong = ({ children, className, customRootClass, ...props }: StrongProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return (
-        <strong className={clsx(rootClass, className)} {...props} >{children}</strong>
-    );
+export type StrongProps = React.ComponentPropsWithoutRef<'strong'> & {
+    customRootClass?: string;
+    className?: string;
 };
+
+const Strong = React.forwardRef<React.ElementRef<'strong'>, StrongProps>(
+    ({ children, className, customRootClass, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        return (
+            <strong ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </strong>
+        );
+    }
+);
 
 Strong.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Strong/tests/Strong.test.tsx
+++ b/src/components/ui/Strong/tests/Strong.test.tsx
@@ -3,35 +3,57 @@ import { render, screen } from '@testing-library/react';
 import Strong from '../Strong';
 
 describe('Strong Component', () => {
-    const Component = () => <Strong className='font-bold'>I am Strong!</Strong>;
+    it('renders content accessible to screen readers', () => {
+        render(<Strong>I am Strong!</Strong>);
 
-    test('renders Strong component', () => {
-        render(<Component />);
-        expect(screen.getByText('I am Strong!')).toBeInTheDocument();
+        const strongElement = screen.getByText('I am Strong!');
+        expect(strongElement).toBeInTheDocument();
+        expect(strongElement.tagName).toBe('STRONG');
+        expect(strongElement).not.toHaveAttribute('aria-hidden');
     });
 
-    test('renders Strong component with className', () => {
-        render(<Component />);
+    it('forwards ref to the strong element', () => {
+        const ref = React.createRef<HTMLElement>();
+        render(<Strong ref={ref}>ref test</Strong>);
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(ref.current?.tagName).toBe('STRONG');
+    });
+
+    it('renders Strong component with className', () => {
+        render(<Strong className='font-bold'>I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveClass('font-bold');
     });
 
-    test('renders Strong component with custom className', () => {
+    it('renders Strong component with custom className', () => {
         render(<Strong className="text-gray-1000">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveClass('text-gray-1000');
     });
 
-    test('renders Strong component with custom style', () => {
+    it('renders Strong component with custom style', () => {
         render(<Strong style={{ color: 'red' }}>I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveStyle('color: red');
     });
 
-    test('renders Strong component with custom id', () => {
+    it('renders Strong component with custom id', () => {
         render(<Strong id="strong-id">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveAttribute('id', 'strong-id');
     });
 
-    test('renders Strong component with custom data attribute', () => {
+    it('renders Strong component with custom data attribute', () => {
         render(<Strong data-testid="strong-data">I am Strong!</Strong>);
         expect(screen.getByText('I am Strong!')).toHaveAttribute('data-testid', 'strong-data');
+    });
+
+    it('renders without console warnings', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(<Strong>I am Strong!</Strong>);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
     });
 });

--- a/src/components/ui/Switch/fragments/SwitchRoot.tsx
+++ b/src/components/ui/Switch/fragments/SwitchRoot.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import { customClassSwitcher } from '~/core';
 import { SwitchContext } from '../context/SwitchContext';
-import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
+import {
+    useCreateDataAttribute,
+    useComposeAttributes,
+    useCreateDataAccentColorAttribute
+} from '~/core/hooks/createDataAttribute';
 import useControllableState from '~/core/hooks/useControllableState';
 
 const COMPONENT_NAME = 'Switch';
 
-export type SwitchRootProps = {
+export type SwitchRootElement = ElementRef<typeof ButtonPrimitive>;
+export type SwitchRootProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     children: React.ReactNode;
     customRootClass?: string;
     color?: string;
@@ -25,7 +30,7 @@ export type SwitchRootProps = {
     asChild?: boolean;
 };
 
-const SwitchRoot = ({
+const SwitchRoot = forwardRef<SwitchRootElement, SwitchRootProps>(({
     children,
     customRootClass,
     color = '',
@@ -40,7 +45,7 @@ const SwitchRoot = ({
     value,
     asChild = false,
     ...props
-}: SwitchRootProps) => {
+}, ref) => {
     const [isChecked, setIsChecked] = useControllableState(
         checked,
         defaultChecked,
@@ -83,6 +88,7 @@ const SwitchRoot = ({
     return (
         <SwitchContext.Provider value={contextValues}>
             <ButtonPrimitive
+                ref={ref}
                 onClick={handleCheckedChange}
                 className={rootClass}
                 asChild={asChild}
@@ -92,6 +98,8 @@ const SwitchRoot = ({
             </ButtonPrimitive>
         </SwitchContext.Provider>
     );
-};
+});
+
+SwitchRoot.displayName = COMPONENT_NAME;
 
 export default SwitchRoot;

--- a/src/components/ui/Switch/fragments/SwitchThumb.tsx
+++ b/src/components/ui/Switch/fragments/SwitchThumb.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import React, { useContext } from 'react';
+import React, { useContext, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 import { SwitchContext } from '../context/SwitchContext';
 
-export type SwitchThumbProps = {
+export type SwitchThumbElement = ElementRef<typeof Primitive.span>;
+export type SwitchThumbProps = ComponentPropsWithoutRef<typeof Primitive.span> & {
     asChild?: boolean;
     className?: string;
     children?: React.ReactNode;
 };
 
-const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchThumbProps) => {
+const SwitchThumb = forwardRef<SwitchThumbElement, SwitchThumbProps>(({ asChild = false, className, children, ...props }, ref) => {
     const { checked, rootClass, disabled } = useContext(SwitchContext);
 
     const dataAttributes: Record<string, string> = {};
@@ -21,6 +22,7 @@ const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchT
 
     return (
         <Primitive.span
+            ref={ref}
             role='switch'
             className={`${rootClass}-indicator ${className || ''}`}
             asChild={asChild}
@@ -30,6 +32,8 @@ const SwitchThumb = ({ asChild = false, className, children, ...props }: SwitchT
             {children}
         </Primitive.span>
     );
-};
+});
+
+SwitchThumb.displayName = 'SwitchThumb';
 
 export default SwitchThumb;

--- a/src/components/ui/Switch/tests/Switch.test.tsx
+++ b/src/components/ui/Switch/tests/Switch.test.tsx
@@ -4,6 +4,7 @@ import Switch from '../Switch';
 
 describe('Switch Component', () => {
     test('renders correctly with composable API', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const { container } = render(
             <Switch.Root>
                 <Switch.Thumb />
@@ -12,6 +13,8 @@ describe('Switch Component', () => {
         expect(container.firstChild).toBeInTheDocument();
         const switchElement = container.querySelector('[role="switch"]');
         expect(switchElement).toBeInTheDocument();
+        expect(consoleSpy).not.toHaveBeenCalled();
+        consoleSpy.mockRestore();
     });
 
     test('warns when using Switch directly', () => {
@@ -23,6 +26,26 @@ describe('Switch Component', () => {
         );
 
         consoleSpy.mockRestore();
+    });
+
+    test('forwards ref to Switch.Root', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <Switch.Root ref={ref}>
+                <Switch.Thumb />
+            </Switch.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('forwards ref to Switch.Thumb', () => {
+        const ref = React.createRef<HTMLSpanElement>();
+        render(
+            <Switch.Root>
+                <Switch.Thumb ref={ref} />
+            </Switch.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLSpanElement);
     });
 
     test('toggles state correctly', () => {
@@ -39,6 +62,18 @@ describe('Switch Component', () => {
 
         fireEvent.click(switchButton!);
         expect(switchButton).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    test('aria-checked updates with state', () => {
+        const { container } = render(
+            <Switch.Root>
+                <Switch.Thumb />
+            </Switch.Root>
+        );
+        const switchButton = container.querySelector('button')!;
+        expect(switchButton).toHaveAttribute('aria-checked', 'false');
+        fireEvent.click(switchButton);
+        expect(switchButton).toHaveAttribute('aria-checked', 'true');
     });
 
     test('thumb indicator reflects switch state', () => {

--- a/src/components/ui/Text/Text.tsx
+++ b/src/components/ui/Text/Text.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 
@@ -16,21 +16,28 @@ export type TextProps = {
     customRootClass?: string;
     className?: string;
     as?: string;
-} & React.ComponentProps<'p'>;
+} & ComponentPropsWithoutRef<'p'>;
 
-const Text = ({ children, customRootClass = '', className = '', as = 'p', ...props }: TextProps) => {
-    const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME);
+type TextElement = ElementRef<'p'>;
 
-    if (!TAGS.includes(as)) {
-        as = 'p';
+const Text = forwardRef<TextElement, TextProps>(
+    (
+        { children, customRootClass = '', className = '', as = 'p', ...props },
+        ref
+    ) => {
+        const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME);
+
+        if (!TAGS.includes(as)) {
+            as = 'p';
+        }
+
+        return React.createElement(
+            as,
+            { ref, className: clsx(rootClassName, className), ...props },
+            children
+        );
     }
-
-    return React.createElement(
-        as,
-        { className: clsx(rootClassName, className), ...props },
-        children
-    );
-};
+);
 
 Text.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Text/tests/Text.test.js
+++ b/src/components/ui/Text/tests/Text.test.js
@@ -87,4 +87,26 @@ describe('Text Component', () => {
         render(<Text as={true} >I am Text!</Text>);
         expect(screen.getByText('I am Text!')).toHaveProperty('tagName', 'P');
     });
+
+    test('forwards ref to the underlying element', () => {
+        const ref = React.createRef();
+        render(<Text ref={ref}>I am Text!</Text>);
+        expect(ref.current).not.toBeNull();
+        expect(ref.current.tagName).toBe('P');
+    });
+
+    test('passes through accessibility attributes', () => {
+        render(<Text aria-label='hidden text'>Hidden content</Text>);
+        expect(screen.getByLabelText('hidden text')).toBeInTheDocument();
+    });
+
+    test('renders without console warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Text>I am Text!</Text>);
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
 });

--- a/src/components/ui/TextArea/TextArea.test.tsx
+++ b/src/components/ui/TextArea/TextArea.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TextArea from './TextArea';
+
+describe('TextArea', () => {
+    it('forwards ref to the root element', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<TextArea ref={ref}>content</TextArea>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('forwards ref to the input element', () => {
+        const ref = React.createRef<HTMLTextAreaElement>();
+        render(<TextArea.Input ref={ref} placeholder="test" />);
+        expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+    });
+
+    it('forwards ref to the root subcomponent', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(<TextArea.Root ref={ref}>child</TextArea.Root>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('is accessible via placeholder', () => {
+        render(<TextArea>hidden</TextArea>);
+        expect(screen.getByPlaceholderText('enter text')).toBeInTheDocument();
+    });
+
+    it('renders without console warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<TextArea>content</TextArea>);
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+
+    it('matches snapshot', () => {
+        const { container } = render(<TextArea>content</TextArea>);
+        expect(container.firstChild).toMatchSnapshot();
+    });
+});

--- a/src/components/ui/TextArea/TextArea.tsx
+++ b/src/components/ui/TextArea/TextArea.tsx
@@ -4,21 +4,27 @@ import { clsx } from 'clsx';
 import TextAreaRoot from './fragments/TextAreaRoot';
 import TextAreaInput from './fragments/TextAreaInput';
 
-export type TextAreaProps = {
-    children: React.ReactNode;
+export type TextAreaProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
-    className?: string;
-}
-
-const TextArea = ({ customRootClass = '', className = '', children, ...props }: TextAreaProps) => {
-    return <TextAreaRoot customRootClass={customRootClass} className={clsx(className)}>
-        <TextAreaInput placeholder="enter text">
-            {children}
-        </TextAreaInput>
-        {children}
-    </TextAreaRoot>;
 };
 
+type TextAreaComponent = React.ForwardRefExoticComponent<TextAreaProps & React.RefAttributes<React.ElementRef<'div'>>> & {
+    Input: typeof TextAreaInput;
+    Root: typeof TextAreaRoot;
+};
+
+const TextArea = React.forwardRef<React.ElementRef<'div'>, TextAreaProps>(({ customRootClass = '', className = '', children, ...props }, ref) => {
+    return (
+        <TextAreaRoot ref={ref} customRootClass={customRootClass} className={clsx(className)} {...props}>
+            <TextAreaInput placeholder="enter text">
+                {children}
+            </TextAreaInput>
+            {children}
+        </TextAreaRoot>
+    );
+}) as TextAreaComponent;
+
+TextArea.displayName = 'TextArea';
 TextArea.Input = TextAreaInput;
 TextArea.Root = TextAreaRoot;
 

--- a/src/components/ui/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/ui/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea matches snapshot 1`] = `
+<div
+  class="rad-ui-text-area"
+>
+  <textarea
+    placeholder="enter text"
+  >
+    content
+  </textarea>
+  content
+</div>
+`;

--- a/src/components/ui/TextArea/fragments/TextAreaInput.tsx
+++ b/src/components/ui/TextArea/fragments/TextAreaInput.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 
-type TextAreaInputProps = {
-    children: React.ReactNode;
-    placeholder?: string;
-}
+export type TextAreaInputProps = React.ComponentPropsWithoutRef<'textarea'>;
 
-const TextAreaInput = ({ children, placeholder = '' }:TextAreaInputProps) => {
-    return <textarea placeholder={placeholder}>
-        {children}
-    </textarea>;
-};
+const TextAreaInput = React.forwardRef<React.ElementRef<'textarea'>, TextAreaInputProps>(
+    ({ children, placeholder = '', ...props }, ref) => (
+        <textarea
+            ref={ref}
+            placeholder={placeholder}
+            defaultValue={typeof children === 'string' ? children : undefined}
+            {...props}
+        />
+    )
+);
+
+TextAreaInput.displayName = 'TextAreaInput';
 
 export default TextAreaInput;

--- a/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
+++ b/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
@@ -4,17 +4,22 @@ import { clsx } from 'clsx';
 
 const COMPONENT_NAME = 'TextArea';
 
-export type TextAreaProps = {
-    children: React.ReactNode;
+export type TextAreaRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
-    className?: string;
-}
-
-const TextAreaRoot = ({ children, customRootClass = '', className = '' }:TextAreaProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    return <div className={clsx(rootClass, className)}>
-        {children}
-    </div>;
 };
+
+const TextAreaRoot = React.forwardRef<React.ElementRef<'div'>, TextAreaRootProps>(
+    ({ children, customRootClass = '', className = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+
+        return (
+            <div ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </div>
+        );
+    }
+);
+
+TextAreaRoot.displayName = COMPONENT_NAME;
 
 export default TextAreaRoot;

--- a/src/components/ui/Theme/Theme.tsx
+++ b/src/components/ui/Theme/Theme.tsx
@@ -1,16 +1,23 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { forwardRef, useState, useEffect, ElementRef, ComponentPropsWithoutRef } from 'react';
 
-type ThemeProps = {
+type ThemeElement = ElementRef<'div'>;
+export type ThemeProps = ComponentPropsWithoutRef<'div'> & {
     appearance?: 'light' | 'dark' | 'system';
     accentColor?: string;
     radius?: string;
     scaling?: string;
-    children: React.ReactNode;
-    id?: string;
-}
+};
 
-const Theme = ({ appearance = 'system', id = 'rad-ui-theme-container', accentColor = '', radius = '', scaling = '', children, ...props }: ThemeProps) => {
+const Theme = forwardRef<ThemeElement, ThemeProps>(function Theme({
+    appearance = 'system',
+    id = 'rad-ui-theme-container',
+    accentColor = '',
+    radius = '',
+    scaling = '',
+    children,
+    ...props
+}, ref) {
     const [theme, setTheme] = useState(appearance);
     const [themeAccentColor, setThemeAccentColor] = useState(accentColor);
     const [themeRadius, setThemeRadius] = useState(radius);
@@ -52,16 +59,21 @@ const Theme = ({ appearance = 'system', id = 'rad-ui-theme-container', accentCol
         }
     }, [scaling]);
 
-    return <div
-        id={id}
-        data-rad-ui-theme={theme}
-        data-rad-ui-accent-color={themeAccentColor}
-        data-rad-ui-radius={themeRadius}
-        data-rad-ui-scaling={themeScaling}
-        {...props}
-    >
-        {children}
-    </div>;
-};
+    return (
+        <div
+            ref={ref}
+            id={id}
+            data-rad-ui-theme={theme}
+            data-rad-ui-accent-color={themeAccentColor}
+            data-rad-ui-radius={themeRadius}
+            data-rad-ui-scaling={themeScaling}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+});
+
+Theme.displayName = 'Theme';
 
 export default Theme;

--- a/src/components/ui/Theme/tests/Theme.test.tsx
+++ b/src/components/ui/Theme/tests/Theme.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, screen } from '@testing-library/react';
 
 import Theme from '../Theme';
 
@@ -44,5 +44,30 @@ describe('Theme', () => {
         unmount();
 
         expect(mediaQueryList.removeEventListener).toHaveBeenCalledWith('change', addedListener);
+    });
+
+    test('forwards ref to underlying div', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        const ref = React.createRef<HTMLDivElement>();
+        render(<Theme ref={ref}>content</Theme>);
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        expect(ref.current).toContainElement(screen.getByText('content'));
+    });
+
+    test('renders without console warnings', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(<Theme>content</Theme>);
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test('renders children accessibly', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        render(<Theme>content</Theme>);
+        expect(screen.getByText('content')).toBeVisible();
     });
 });

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
@@ -9,10 +9,11 @@ export type DialogPrimitiveActionProps = {
     asChild?: boolean;
 }
 
-const DialogPrimitiveAction = ({ children, asChild, ...props } : DialogPrimitiveActionProps) => {
+const DialogPrimitiveAction = forwardRef<HTMLButtonElement, DialogPrimitiveActionProps>(({ children, asChild, ...props }, ref) => {
     const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
     return (
         <ButtonPrimitive
+            ref={ref}
             asChild={asChild}
             onClick={() => handleOpenChange(false)}
             {...getItemProps()}
@@ -21,6 +22,8 @@ const DialogPrimitiveAction = ({ children, asChild, ...props } : DialogPrimitive
             {children}
         </ButtonPrimitive>
     );
-};
+});
+
+DialogPrimitiveAction.displayName = 'DialogPrimitiveAction';
 
 export default DialogPrimitiveAction;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import ButtonPrimitive from '~/core/primitives/Button';
 
@@ -9,10 +9,11 @@ export type DialogPrimitiveCancelProps = {
     className?: string;
 }
 
-const DialogPrimitiveCancel = ({ children, asChild, ...props } : DialogPrimitiveCancelProps) => {
+const DialogPrimitiveCancel = forwardRef<HTMLButtonElement, DialogPrimitiveCancelProps>(({ children, asChild, ...props }, ref) => {
     const { handleOpenChange, getItemProps } = useContext(DialogPrimitiveContext);
     return (
         <ButtonPrimitive
+            ref={ref}
             asChild={asChild}
             onClick={() => handleOpenChange(false)}
             {...getItemProps()}
@@ -21,6 +22,8 @@ const DialogPrimitiveCancel = ({ children, asChild, ...props } : DialogPrimitive
             {children}
         </ButtonPrimitive>
     );
-};
+});
+
+DialogPrimitiveCancel.displayName = 'DialogPrimitiveCancel';
 
 export default DialogPrimitiveCancel;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
 
@@ -8,20 +8,24 @@ export type DialogPrimitiveContentProps = {
     className?: string;
 }
 
-const DialogPrimitiveContent = ({ children, ...props } : DialogPrimitiveContentProps) => {
+const DialogPrimitiveContent = forwardRef<HTMLDivElement, DialogPrimitiveContentProps>(({ children, ...props }, ref) => {
     const { isOpen, getFloatingProps, floaterContext, refs } = useContext(DialogPrimitiveContext);
+
+    const mergedRef = Floater.useMergeRefs([refs.setFloating, ref]);
 
     return (
         <>
             {isOpen && (
                 <Floater.FocusManager context={floaterContext} returnFocus={true}>
-                    <div ref={refs.setFloating} {...getFloatingProps()} {...props}>
+                    <div ref={mergedRef} {...getFloatingProps()} {...props}>
                         {children}
                     </div>
                 </Floater.FocusManager>
             )}
         </>
     );
-};
+});
+
+DialogPrimitiveContent.displayName = 'DialogPrimitiveContent';
 
 export default DialogPrimitiveContent;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import Floater from '~/core/primitives/Floater';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 
@@ -9,13 +9,14 @@ type DialogPrimitiveOverlayProps = {
     className?: string;
 }
 
-const DialogPrimitiveOverlay = ({ ...props }: DialogPrimitiveOverlayProps) => {
+const DialogPrimitiveOverlay = forwardRef<HTMLDivElement, DialogPrimitiveOverlayProps>(({ ...props }, ref) => {
     const { isOpen, handleOverlayClick } = useContext(DialogPrimitiveContext);
     return (
         <>
             {isOpen && (
                 <RemoveScroll>
                     <Floater.Overlay
+                        ref={ref}
                         onClick={handleOverlayClick}
                         {...props}
                     >
@@ -24,6 +25,8 @@ const DialogPrimitiveOverlay = ({ ...props }: DialogPrimitiveOverlayProps) => {
             )}
         </>
     );
-};
+});
+
+DialogPrimitiveOverlay.displayName = 'DialogPrimitiveOverlay';
 
 export default DialogPrimitiveOverlay;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
 
@@ -13,7 +13,7 @@ export type DialogPrimitiveRootProps = {
 
 const COMPONENT_NAME = 'DialogPrimitive';
 
-const DialogPrimitiveRoot = ({ children, open = false, onOpenChange = () => {}, onClickOutside = () => {}, className, ...props } : DialogPrimitiveRootProps) => {
+const DialogPrimitiveRoot = forwardRef<HTMLDivElement, DialogPrimitiveRootProps>(({ children, open = false, onOpenChange = () => {}, onClickOutside = () => {}, className, ...props }, ref) => {
     const [isOpen, setIsOpen] = useState(open);
     const handleOpenChange = (open: boolean) => {
         setIsOpen(open);
@@ -39,12 +39,12 @@ const DialogPrimitiveRoot = ({ children, open = false, onOpenChange = () => {}, 
     const contextProps = { isOpen, handleOpenChange, floaterContext, handleOverlayClick, getReferenceProps, getFloatingProps, getItemProps, refs, floatingStyles };
     return (
         <DialogPrimitiveContext.Provider value={contextProps}>
-            <div {...props} className={className}>
+            <div ref={ref} {...props} className={className}>
                 {children}
             </div>
         </DialogPrimitiveContext.Provider>
     );
-};
+});
 
 DialogPrimitiveRoot.displayName = COMPONENT_NAME;
 export default DialogPrimitiveRoot;

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
@@ -1,7 +1,8 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
+import Floater from '~/core/primitives/Floater';
 
 export type DialogPrimitiveTriggerProps = {
     children: React.ReactNode;
@@ -9,12 +10,14 @@ export type DialogPrimitiveTriggerProps = {
     className?: string;
 }
 
-const DialogPrimitiveTrigger = ({ children, asChild, className = '', ...props } : DialogPrimitiveTriggerProps) => {
+const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTriggerProps>(({ children, asChild, className = '', ...props }, ref) => {
     const { handleOpenChange, getReferenceProps, refs } = useContext(DialogPrimitiveContext);
+
+    const mergedRef = Floater.useMergeRefs([refs.setReference, ref]);
 
     return (
         <ButtonPrimitive
-            ref={refs?.setReference || null}
+            ref={mergedRef}
             asChild={asChild}
             className={className}
             onClick={() => handleOpenChange(true)}
@@ -24,6 +27,8 @@ const DialogPrimitiveTrigger = ({ children, asChild, className = '', ...props } 
             {children}
         </ButtonPrimitive>
     );
-};
+});
+
+DialogPrimitiveTrigger.displayName = 'DialogPrimitiveTrigger';
 
 export default DialogPrimitiveTrigger;

--- a/src/core/primitives/Radio/index.tsx
+++ b/src/core/primitives/Radio/index.tsx
@@ -1,37 +1,41 @@
 import React from 'react';
 import Primitive from '../Primitive';
 
-export type RadioPrimitiveProps = {
+export type RadioPrimitiveElement = React.ElementRef<'input'>;
+
+export type RadioPrimitiveProps = Omit<React.ComponentPropsWithoutRef<'input'>, 'onChange'> & {
     name: string;
     value: string;
     id: string;
     onChange?: () => void;
-    checked?: boolean;
-    required?: boolean;
-    disabled?: boolean;
     asChild?: boolean;
     className?: string;
-}
+};
 
-function RadioPrimitive({ name, value, id, checked, required, onChange, disabled, asChild, className, ...props }: RadioPrimitiveProps) {
-    return (
-        <Primitive.input
-            type="radio"
-            checked={checked}
-            name={name}
-            tabIndex={-1}
-            value={value}
-            onChange={onChange}
-            id={id}
-            aria-disabled={disabled}
-            disabled={disabled}
-            required={required}
-            aria-required={required}
-            asChild={asChild}
-            className={className}
-            {...props}
-        />
-    );
-}
+const RadioPrimitive = React.forwardRef<RadioPrimitiveElement, RadioPrimitiveProps>(
+    ({ name, value, id, checked, required, onChange, disabled, asChild, className, ...props }, forwardedRef) => {
+        return (
+            <Primitive.input
+                ref={forwardedRef}
+                type="radio"
+                checked={checked}
+                name={name}
+                tabIndex={-1}
+                value={value}
+                onChange={onChange}
+                id={id}
+                aria-disabled={disabled}
+                disabled={disabled}
+                required={required}
+                aria-required={required}
+                asChild={asChild}
+                className={className}
+                {...props}
+            />
+        );
+    }
+);
+
+RadioPrimitive.displayName = 'RadioPrimitive';
 
 export default RadioPrimitive;

--- a/src/core/primitives/Radio/tests/Radio.test.tsx
+++ b/src/core/primitives/Radio/tests/Radio.test.tsx
@@ -45,4 +45,10 @@ describe('RadioPrimitive', () => {
         const radio = screen.getByRole('radio');
         expect(radio).toBeInTheDocument();
     });
+
+    it('forwards refs', () => {
+        const ref = React.createRef<HTMLInputElement>();
+        render(<RadioPrimitive {...baseProps} ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
 });

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveIndicator.tsx
@@ -8,19 +8,26 @@ export type RadioGroupPrimitiveIndicatorProps = ComponentPropsWithoutRef<typeof 
     asChild?: boolean;
 };
 
-const RadioGroupPrimitiveIndicator = React.forwardRef<RadioGroupPrimitiveIndicatorElement, RadioGroupPrimitiveIndicatorProps>(
-    ({ children, className, asChild = false, ...props }, forwardedRef) => {
-        const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
+const RadioGroupPrimitiveIndicator = React.forwardRef<
+    RadioGroupPrimitiveIndicatorElement,
+    RadioGroupPrimitiveIndicatorProps
+>(({ children, className, asChild = false, ...props }, forwardedRef) => {
+    const { itemSelected } = React.useContext(RadioGroupPrimitiveItemContext);
 
-        if (!itemSelected) return null;
-        return (
-            <Primitive.span ref={forwardedRef} className={className} asChild={asChild} {...props}>
-                {children}
-            </Primitive.span>
-        );
-    }
-);
+    if (!itemSelected) return null;
+    return (
+        <Primitive.span
+            ref={forwardedRef}
+            className={className}
+            asChild={asChild}
+            {...props}
+        >
+            {children}
+        </Primitive.span>
+    );
+});
 
 RadioGroupPrimitiveIndicator.displayName = 'RadioGroupPrimitiveIndicator';
 
 export default RadioGroupPrimitiveIndicator;
+

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveItem.tsx
@@ -8,47 +8,46 @@ export type RadioGroupPrimitiveItemElement = ElementRef<typeof ButtonPrimitive>;
 
 export type RadioGroupPrimitiveItemProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     value: string;
-    disabled?: boolean;
-    children?: React.ReactNode;
     required?: boolean;
-    asChild?: boolean;
 };
 
-const RadioGroupPrimitiveItem = React.forwardRef<RadioGroupPrimitiveItemElement, RadioGroupPrimitiveItemProps>(
-    ({ value, children, disabled, required = false, className = '', asChild = false, ...props }, forwardedRef) => {
-        const context = useContext(RadioGroupContext);
-        if (!context) {
-            throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
-        }
-        const { groupDisabled, selectedValue, setSelectedValue } = context;
-
-        const itemSelected = value === selectedValue;
-        return (
-            <RovingFocusGroup.Item>
-                <ButtonPrimitive
-                    ref={forwardedRef}
-                    role="radio"
-                    type="button"
-                    disabled={groupDisabled || disabled}
-                    onClick={() => setSelectedValue(value)}
-                    onFocus={() => setSelectedValue(value)}
-                    aria-disabled={groupDisabled || disabled}
-                    aria-checked={value === selectedValue}
-                    data-checked={value === selectedValue}
-                    aria-required={required}
-                    asChild={asChild}
-                    className={className}
-                    {...props}
-                >
-                    <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
-                        {children}
-                    </RadioGroupPrimitiveItemContext.Provider>
-                </ButtonPrimitive>
-            </RovingFocusGroup.Item>
-        );
+const RadioGroupPrimitiveItem = React.forwardRef<
+    RadioGroupPrimitiveItemElement,
+    RadioGroupPrimitiveItemProps
+>(({ value, children, disabled, required = false, className = '', asChild = false, ...props }, forwardedRef) => {
+    const context = useContext(RadioGroupContext);
+    if (!context) {
+        throw new Error('RadioGroup.Item must be used within a RadioGroup.Root');
     }
-);
+    const { groupDisabled, selectedValue, setSelectedValue } = context;
+
+    const itemSelected = value === selectedValue;
+    return (
+        <RovingFocusGroup.Item>
+            <ButtonPrimitive
+                ref={forwardedRef}
+                role="radio"
+                type="button"
+                disabled={groupDisabled || disabled}
+                onClick={() => setSelectedValue(value)}
+                onFocus={() => setSelectedValue(value)}
+                aria-disabled={groupDisabled || disabled}
+                aria-checked={value === selectedValue}
+                data-checked={value === selectedValue}
+                aria-required={required}
+                asChild={asChild}
+                className={className}
+                {...props}
+            >
+                <RadioGroupPrimitiveItemContext.Provider value={{ itemSelected }}>
+                    {children}
+                </RadioGroupPrimitiveItemContext.Provider>
+            </ButtonPrimitive>
+        </RovingFocusGroup.Item>
+    );
+});
 
 RadioGroupPrimitiveItem.displayName = 'RadioGroupPrimitiveItem';
 
 export default RadioGroupPrimitiveItem;
+

--- a/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
+++ b/src/core/primitives/RadioGroup/fragments/RadioGroupPrimitiveRoot.tsx
@@ -7,7 +7,6 @@ import useControllableState from '~/core/hooks/useControllableState';
 export type RadioGroupPrimitiveRootElement = ElementRef<typeof Primitive.div>;
 
 export type RadioGroupPrimitiveRootProps = ComponentPropsWithoutRef<typeof Primitive.div> & {
-    customRootClass?: string;
     value?: string;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
@@ -15,51 +14,69 @@ export type RadioGroupPrimitiveRootProps = ComponentPropsWithoutRef<typeof Primi
     required?: boolean;
     name?: string;
     orientation?: 'horizontal' | 'vertical' | 'both';
-    loop?: boolean,
+    loop?: boolean;
     dir?: 'ltr' | 'rtl';
 };
 
-const RadioGroupPrimitiveRoot = React.forwardRef<RadioGroupPrimitiveRootElement, RadioGroupPrimitiveRootProps>(({
-    value,
-    defaultValue = '',
-    onValueChange,
-    children,
-    disabled: groupDisabled = false,
-    required = false,
-    name = '',
-    orientation = 'horizontal',
-    loop = false,
-    dir = 'ltr',
-    ...props
-}, forwardedRef) => {
-    const [selectedValue, setSelectedValue] = useControllableState(
-        value,
-        defaultValue,
-        onValueChange
-    );
+const RadioGroupPrimitiveRoot = React.forwardRef<
+    RadioGroupPrimitiveRootElement,
+    RadioGroupPrimitiveRootProps
+>(
+    (
+        {
+            value,
+            defaultValue = '',
+            onValueChange,
+            children,
+            disabled: groupDisabled = false,
+            required = false,
+            name = '',
+            orientation = 'horizontal',
+            loop = false,
+            dir = 'ltr',
+            ...props
+        },
+        forwardedRef
+    ) => {
+        const [selectedValue, setSelectedValue] = useControllableState(
+            value,
+            defaultValue,
+            onValueChange
+        );
 
-    const sendItems = {
-        selectedValue,
-        setSelectedValue,
-        groupDisabled
-    };
+        const sendItems = {
+            selectedValue,
+            setSelectedValue,
+            groupDisabled,
+        };
 
-    return (
-        <Primitive.div ref={forwardedRef} {...props} aria-required={required} role='radiogroup' aria-disabled={groupDisabled}>
-            <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
-                <RadioGroupContext.Provider value={sendItems}>
-                    <RovingFocusGroup.Group>
-
-                        {children}
-
-                    </RovingFocusGroup.Group>
-                </RadioGroupContext.Provider>
-            </RovingFocusGroup.Root>
-            <input type='radio' hidden name={name} value={selectedValue} disabled={groupDisabled} required={required}/>
-        </Primitive.div>
-    );
-});
+        return (
+            <Primitive.div
+                ref={forwardedRef}
+                {...props}
+                aria-required={required}
+                role="radiogroup"
+                aria-disabled={groupDisabled}
+            >
+                <RovingFocusGroup.Root dir={dir} orientation={orientation} loop={loop}>
+                    <RadioGroupContext.Provider value={sendItems}>
+                        <RovingFocusGroup.Group>{children}</RovingFocusGroup.Group>
+                    </RadioGroupContext.Provider>
+                </RovingFocusGroup.Root>
+                <input
+                    type="radio"
+                    hidden
+                    name={name}
+                    value={selectedValue}
+                    disabled={groupDisabled}
+                    required={required}
+                />
+            </Primitive.div>
+        );
+    }
+);
 
 RadioGroupPrimitiveRoot.displayName = 'RadioGroupPrimitiveRoot';
 
 export default RadioGroupPrimitiveRoot;
+

--- a/src/core/primitives/RadioGroup/tests/RadioGroupPrimitive.test.tsx
+++ b/src/core/primitives/RadioGroup/tests/RadioGroupPrimitive.test.tsx
@@ -99,4 +99,22 @@ describe('RadioGroupPrimitive', () => {
         }).toThrow('RadioGroup.Item must be used within a RadioGroup.Root');
         spy.mockRestore();
     });
+
+    it('forwards refs to root, item, and indicator', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+        const indicatorRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <RadioGroupPrimitive.Root ref={rootRef} value="a" name="group">
+                <RadioGroupPrimitive.Item ref={itemRef} value="a">
+                    <RadioGroupPrimitive.Indicator ref={indicatorRef}>*</RadioGroupPrimitive.Indicator>
+                </RadioGroupPrimitive.Item>
+            </RadioGroupPrimitive.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(indicatorRef.current).toBeInstanceOf(HTMLSpanElement);
+    });
 });


### PR DESCRIPTION
## Summary
- use `React.forwardRef` across RadioGroup primitives and UI fragments
- type components with `ElementRef` and `ComponentPropsWithoutRef`
- add tests checking ref forwarding
- fix misnamed RadioGroupPrimitive test file

## Testing
- `npm test`
- `rg "<<<<<<<" -n`