### PR TITLE
refactor: forward refs in Button component

### DIFF
--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { ButtonHTMLAttributes, DetailedHTMLProps, PropsWithChildren } from 'react';
+import React from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import ButtonPrimitive from '~/core/primitives/Button';
@@ -8,14 +8,15 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 // make the color prop default accent color
 const COMPONENT_NAME = 'Button';
 
-export type ButtonProps = {
+type ButtonElement = React.ElementRef<typeof ButtonPrimitive>;
+type ButtonProps = React.ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     customRootClass?: string;
     variant?: string;
-    size?:string;
-    color?:string;
-} & DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & PropsWithChildren
+    size?: string;
+    color?: string;
+};
 
-const Button = ({ children, type = 'button', customRootClass = '', className = '', variant = '', size = '', color = '', ...props }: ButtonProps) => {
+const Button = React.forwardRef<ButtonElement, ButtonProps>(({ children, type = 'button', customRootClass = '', className = '', variant = '', size = '', color = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     // apply data attribute for accent color
     // apply attribute only if color is present
@@ -25,6 +26,7 @@ const Button = ({ children, type = 'button', customRootClass = '', className = '
 
     return (
         <ButtonPrimitive
+            ref={ref}
             type={type}
             className={clsx(rootClass, className)}
             {...composedAttributes()}
@@ -33,7 +35,7 @@ const Button = ({ children, type = 'button', customRootClass = '', className = '
             {children}
         </ButtonPrimitive>
     );
-};
+});
 
 Button.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -42,4 +42,11 @@ describe('Button', () => {
         await userEvent.click(button);
         expect(onClick).toHaveBeenCalledTimes(1);
     });
+
+    test('forwards ref to the underlying button element', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(<Button ref={ref}>ref button</Button>);
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+        expect(ref.current?.tagName).toBe('BUTTON');
+    });
 });

--- a/src/core/primitives/Button/index.tsx
+++ b/src/core/primitives/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import Primitive from '~/core/primitives/Primitive';
 
 /**
@@ -17,7 +17,16 @@ import Primitive from '~/core/primitives/Primitive';
 
  */
 
-const ButtonPrimitive = forwardRef(({ role = 'button', type = 'button', label = '', description = '', disabled = false, children, ...props }:any, ref) => {
+type ButtonPrimitiveElement = React.ElementRef<typeof Primitive.button>;
+type ButtonPrimitiveProps = Omit<React.ComponentPropsWithoutRef<typeof Primitive.button>, 'type'> & {
+    role?: React.AriaRole;
+    label?: string;
+    description?: string;
+    disabled?: boolean;
+    type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+};
+
+const ButtonPrimitive = React.forwardRef<ButtonPrimitiveElement, ButtonPrimitiveProps>(({ role = 'button', type = 'button', label = '', description = '', disabled = false, children, ...props }, ref) => {
     if (label) {
         // If we have a label, we should set the aria-label attribute
         // This is usually generated automatically by the screen reader


### PR DESCRIPTION
## Summary
- forward refs through Button component and primitive
- verify Button ref forwarding with dedicated test
- drop VisuallyHidden ref-forwarding changes to retain baseline

## Testing
- `npm test`
- `npm run build:rollup`


------
https://chatgpt.com/codex/tasks/task_e_68b989bf0a588331b625374ffec3ff54