### PR TITLE
refactor(toggle-group): forward refs

### DIFF
--- a/src/components/ui/ToggleGroup/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup/ToggleGroup.tsx
@@ -1,10 +1,23 @@
+import React from 'react';
 import ToggleGroupRoot from './fragments/ToggleGroupRoot';
 import ToggleItem from './fragments/ToggleItem';
 
-const ToggleGroup = () => {
-    console.warn('Direct usage of ToggleGroup is not supported. Please use ToggleGroup.Root, ToggleGroup.Item, etc. instead.');
-    return null;
+type ToggleGroupElement = React.ElementRef<'div'>;
+type ToggleGroupProps = React.ComponentPropsWithoutRef<'div'>;
+
+type ToggleGroupComponent = React.ForwardRefExoticComponent<
+    ToggleGroupProps & React.RefAttributes<ToggleGroupElement>
+> & {
+    Root: typeof ToggleGroupRoot;
+    Item: typeof ToggleItem;
 };
+
+const ToggleGroup = React.forwardRef<ToggleGroupElement, ToggleGroupProps>((_props, _ref) => {
+    console.warn(
+        'Direct usage of ToggleGroup is not supported. Please use ToggleGroup.Root, ToggleGroup.Item, etc. instead.'
+    );
+    return null;
+}) as ToggleGroupComponent;
 
 ToggleGroup.Root = ToggleGroupRoot;
 ToggleGroup.Item = ToggleItem;

--- a/src/components/ui/ToggleGroup/fragments/ToggleGroupRoot.tsx
+++ b/src/components/ui/ToggleGroup/fragments/ToggleGroupRoot.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import { clsx } from 'clsx';
 import { customClassSwitcher } from '~/core';
 import useControllableState from '~/core/hooks/useControllableState';
@@ -41,7 +41,7 @@ type ToggleGroupRootProps = React.ComponentPropsWithoutRef<'div'> & {
 
 const COMPONENT_NAME = 'ToggleGroup';
 
-const ToggleGroupRoot = forwardRef<ToggleGroupRootElement, ToggleGroupRootProps>(({
+const ToggleGroupRoot = React.forwardRef<ToggleGroupRootElement, ToggleGroupRootProps>(({ 
     type = 'single',
     className = '',
     loop = true,

--- a/src/components/ui/ToggleGroup/fragments/ToggleItem.tsx
+++ b/src/components/ui/ToggleGroup/fragments/ToggleItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react';
+import React, { useContext } from 'react';
 
 import { ToggleContext } from '../contexts/toggleContext';
 import TogglePrimitive from '~/core/primitives/Toggle';
@@ -28,7 +28,7 @@ export interface ToggleItemProps extends React.ComponentPropsWithoutRef<typeof T
  * @param {ToggleItemProps} props - Component props
  * @returns {JSX.Element} The ToggleItem component
  */
-const ToggleItem = forwardRef<ToggleItemElement, ToggleItemProps>(({
+const ToggleItem = React.forwardRef<ToggleItemElement, ToggleItemProps>(({ 
     children,
     className = '',
     value = null,

--- a/src/components/ui/ToggleGroup/tests/ToggleGroup.test.tsx
+++ b/src/components/ui/ToggleGroup/tests/ToggleGroup.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import ToggleGroup from '../ToggleGroup';
 
 describe('ToggleGroup ref forwarding', () => {
@@ -35,5 +35,17 @@ describe('ToggleGroup ref forwarding', () => {
         expect(warnSpy).not.toHaveBeenCalled();
         errorSpy.mockRestore();
         warnSpy.mockRestore();
+    });
+
+    test('maintains aria-pressed attribute for accessibility', () => {
+        render(
+            <ToggleGroup.Root>
+                <ToggleGroup.Item value="item1">Item 1</ToggleGroup.Item>
+            </ToggleGroup.Root>
+        );
+        const button = screen.getByRole('button');
+        expect(button).toHaveAttribute('aria-pressed', 'false');
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-pressed', 'true');
     });
 });


### PR DESCRIPTION
## Summary
- use React.forwardRef for ToggleGroup and subcomponents to ensure refs reach DOM elements
- verify accessibility by testing aria-pressed state

## Testing
- `npm test src/components/ui/ToggleGroup/tests/ToggleGroup.test.tsx`
- `npm run build:rollup`


------
https://chatgpt.com/codex/tasks/task_e_68baaf73232083318abe7509c046807f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ToggleGroup is now publicly available as a default export with Root and Item as static members, and supports refs.

- Refactor
  - Standardized internal implementation to consistently use React’s forwardRef across ToggleGroup components.

- Tests
  - Added accessibility test ensuring aria-pressed updates correctly on ToggleGroup.Item interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->