### PR TITLE
refactor: forward refs for menubar components

### DIFF
--- a/src/components/ui/Menubar/fragments/MenubarContent.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarContent.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 import clsx from 'clsx';
 
+export type MenubarContentElement = ElementRef<typeof MenuPrimitive.Content>;
 export type MenubarContentProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Content;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
 
-const MenubarContent = ({ children, className, ...props }:MenubarContentProps) => {
+const MenubarContent = forwardRef<MenubarContentElement, MenubarContentProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     if (!context) {
         console.log('MenubarContent should be used in the MenubarRoot');
@@ -16,10 +17,12 @@ const MenubarContent = ({ children, className, ...props }:MenubarContentProps) =
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Content className={clsx(`${rootClass}-content`, className)} {...props}>
+        <MenuPrimitive.Content ref={ref} className={clsx(`${rootClass}-content`, className)} {...props}>
             {children}
         </MenuPrimitive.Content>
     );
-};
+});
+
+MenubarContent.displayName = 'MenubarContent';
 
 export default MenubarContent;

--- a/src/components/ui/Menubar/fragments/MenubarItem.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarItem.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 import clsx from 'clsx';
 
+export type MenubarItemElement = ElementRef<typeof MenuPrimitive.Item>;
 export type MenubarItemProps = {
   children: React.ReactNode;
   className?: string;
   label?: string;
-} & MenuPrimitiveProps.Item;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Item>;
 
-const MenubarItem = ({ children, className, label, ...props }:MenubarItemProps) => {
+const MenubarItem = forwardRef<MenubarItemElement, MenubarItemProps>(({ children, className, label, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     if (!context) {
         console.log('MenubarItem should be used in the MenubarRoot');
@@ -17,10 +18,12 @@ const MenubarItem = ({ children, className, label, ...props }:MenubarItemProps) 
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Item className={clsx(`${rootClass}-item`, className)} label={label} {...props}>
+        <MenuPrimitive.Item ref={ref} className={clsx(`${rootClass}-item`, className)} label={label} {...props}>
             {children}
         </MenuPrimitive.Item>
     );
-};
+});
+
+MenubarItem.displayName = 'MenubarItem';
 
 export default MenubarItem;

--- a/src/components/ui/Menubar/fragments/MenubarMenu.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarMenu.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import clsx from 'clsx';
 import MenubarContext, { MenubarItem } from '../contexts/MenubarContext';
 import Floater from '~/core/primitives/Floater';
 import MenubarMenuContext from '../contexts/MenubarMenuContext';
 
+export type MenubarMenuElement = ElementRef<typeof MenuPrimitive.Root>;
 export type MenubarMenuProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Root;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 
-const MenubarMenu = ({ children, className, ...props }:MenubarMenuProps) => {
+const MenubarMenu = forwardRef<MenubarMenuElement, MenubarMenuProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     const id = Floater.useId();
 
@@ -29,13 +30,23 @@ const MenubarMenu = ({ children, className, ...props }:MenubarMenuProps) => {
     const isOpen = items.find((item: MenubarItem) => item.id === id)?.state === 'open';
     return (
 
-        <MenuPrimitive.Root className={clsx(`${rootClass}-menu`, className)} data-id={id} data-active={isOpen} open={isOpen} onOpenChange={(open) => id && updateItemState(id, open ? 'open' : 'closed')} {...props}>
+        <MenuPrimitive.Root
+            ref={ref}
+            className={clsx(`${rootClass}-menu`, className)}
+            data-id={id}
+            data-active={isOpen}
+            open={isOpen}
+            onOpenChange={(open) => id && updateItemState(id, open ? 'open' : 'closed')}
+            {...props}
+        >
             <MenubarMenuContext.Provider value={{ isOpen }}>
                 {children}
             </MenubarMenuContext.Provider>
         </MenuPrimitive.Root>
 
     );
-};
+});
+
+MenubarMenu.displayName = 'MenubarMenu';
 
 export default MenubarMenu;

--- a/src/components/ui/Menubar/fragments/MenubarPortal.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarPortal.tsx
@@ -1,23 +1,25 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 
+export type MenubarPortalElement = ElementRef<typeof MenuPrimitive.Portal>;
 export type MenubarPortalProps = {
   children: React.ReactNode;
-}
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Portal>;
 
-const MenubarPortal = ({ children }:MenubarPortalProps) => {
+const MenubarPortal = forwardRef<MenubarPortalElement, MenubarPortalProps>(({ children, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     if (!context) {
         console.log('MenubarPortal should be used in the MenubarRoot');
         return null;
     }
-    const { rootClass } = context;
     return (
-        <MenuPrimitive.Portal>
+        <MenuPrimitive.Portal ref={ref} {...props}>
             {children}
         </MenuPrimitive.Portal>
     );
-};
+});
+
+MenubarPortal.displayName = 'MenubarPortal';
 
 export default MenubarPortal;

--- a/src/components/ui/Menubar/fragments/MenubarRoot.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarRoot.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
 import Floater from '~/core/primitives/Floater';
 import MenubarContext, { MenubarItem } from '../contexts/MenubarContext';
 
+export type MenubarRootElement = ElementRef<typeof Floater.Composite>;
 export type MenubarRootProps = {
   children: React.ReactNode;
   customRootClass?: string;
   className?: string;
-  dir?: 'ltr' | 'rtl';
-  loop?: boolean;
-};
+} & ComponentPropsWithoutRef<typeof Floater.Composite>;
 
 const COMPONENT_NAME = 'Menubar';
 
-const MenubarRoot = ({ children, customRootClass, className, dir, loop, ...props }:MenubarRootProps) => {
+const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children, customRootClass, className, dir, loop, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     const [items, setItems] = React.useState<MenubarItem[]>([]);
     const [activeIndex, setActiveIndex] = React.useState(0);
@@ -60,6 +59,7 @@ const MenubarRoot = ({ children, customRootClass, className, dir, loop, ...props
     return (
         <MenubarContext.Provider value={{ rootClass, registerItem, items, updateItemState }} >
             <Floater.Composite
+                ref={ref}
                 className={clsx(`${rootClass}-root`, className)} dir={dir} loop={loop} {...props} activeIndex={activeIndex}
                 onNavigate={handleOnNavigate}
             >
@@ -67,6 +67,8 @@ const MenubarRoot = ({ children, customRootClass, className, dir, loop, ...props
             </Floater.Composite>
         </MenubarContext.Provider>
     );
-};
+});
+
+MenubarRoot.displayName = 'MenubarRoot';
 
 export default MenubarRoot;

--- a/src/components/ui/Menubar/fragments/MenubarSub.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarSub.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 import clsx from 'clsx';
 
+export type MenubarSubElement = ElementRef<typeof MenuPrimitive.Sub>;
 export type MenubarSubProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Sub;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Sub>;
 
-const MenubarSub = ({ children, className, ...props }:MenubarSubProps) => {
+const MenubarSub = forwardRef<MenubarSubElement, MenubarSubProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     if (!context) {
         console.log('MenubarSub should be used in the MenubarRoot');
@@ -16,10 +17,12 @@ const MenubarSub = ({ children, className, ...props }:MenubarSubProps) => {
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Sub className={clsx(`${rootClass}-sub`, className)} {...props}>
+        <MenuPrimitive.Sub ref={ref} className={clsx(`${rootClass}-sub`, className)} {...props}>
             {children}
         </MenuPrimitive.Sub>
     );
-};
+});
+
+MenubarSub.displayName = 'MenubarSub';
 
 export default MenubarSub;

--- a/src/components/ui/Menubar/fragments/MenubarSubTrigger.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarSubTrigger.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 import clsx from 'clsx';
 
+export type MenubarSubTriggerElement = ElementRef<typeof MenuPrimitive.Trigger>;
 export type MenubarSubTriggerProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Trigger;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Trigger>;
 
-const MenubarSubTrigger = ({ children, className, ...props }:MenubarSubTriggerProps) => {
+const MenubarSubTrigger = forwardRef<MenubarSubTriggerElement, MenubarSubTriggerProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     if (!context) {
         console.log('MenubarSubTrigger should be used in the MenubarRoot');
@@ -16,10 +17,12 @@ const MenubarSubTrigger = ({ children, className, ...props }:MenubarSubTriggerPr
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Trigger className={clsx(`${rootClass}-sub-trigger`, className)} {...props}>
+        <MenuPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-sub-trigger`, className)} {...props}>
             {children}
         </MenuPrimitive.Trigger>
     );
-};
+});
+
+MenubarSubTrigger.displayName = 'MenubarSubTrigger';
 
 export default MenubarSubTrigger;

--- a/src/components/ui/Menubar/fragments/MenubarTrigger.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarTrigger.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import MenubarContext from '../contexts/MenubarContext';
 import clsx from 'clsx';
 import Floater from '~/core/primitives/Floater';
 import MenubarMenuContext from '../contexts/MenubarMenuContext';
 
+export type MenubarTriggerElement = ElementRef<typeof MenuPrimitive.Trigger>;
 export type MenubarTriggerProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Trigger;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Trigger>;
 
-const MenubarTrigger = ({ children, className, ...props }:MenubarTriggerProps) => {
+const MenubarTrigger = forwardRef<MenubarTriggerElement, MenubarTriggerProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
     const menuContext = React.useContext(MenubarMenuContext);
 
@@ -28,15 +29,21 @@ const MenubarTrigger = ({ children, className, ...props }:MenubarTriggerProps) =
 
     return (
         <Floater.CompositeItem
-            render={
-                () => (
-                    <MenuPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)} data-active={isOpen} {...props}>
-                        {children}
-                    </MenuPrimitive.Trigger>
-                )
-            }/>
+            render={() => (
+                <MenuPrimitive.Trigger
+                    ref={ref}
+                    className={clsx(`${rootClass}-trigger`, className)}
+                    data-active={isOpen}
+                    {...props}
+                >
+                    {children}
+                </MenuPrimitive.Trigger>
+            )}
+        />
 
     );
-};
+});
+
+MenubarTrigger.displayName = 'MenubarTrigger';
 
 export default MenubarTrigger;

--- a/src/components/ui/Menubar/tests/Menubar.test.tsx
+++ b/src/components/ui/Menubar/tests/Menubar.test.tsx
@@ -1,0 +1,72 @@
+import React, { createRef } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Menubar from '../Menubar';
+
+describe('Menubar', () => {
+    test('forwards refs to subcomponents', () => {
+        const rootRef = createRef<HTMLDivElement>();
+        const menuRef = createRef<HTMLDivElement>();
+        const triggerRef = createRef<HTMLButtonElement>();
+        const contentRef = createRef<HTMLDivElement>();
+        const itemRef = createRef<HTMLButtonElement>();
+
+        const { getByText } = render(
+            <Menubar.Root ref={rootRef}>
+                <Menubar.Menu ref={menuRef}>
+                    <Menubar.Trigger ref={triggerRef}>File</Menubar.Trigger>
+                    <Menubar.Content ref={contentRef}>
+                        <Menubar.Item ref={itemRef}>New</Menubar.Item>
+                    </Menubar.Content>
+                </Menubar.Menu>
+            </Menubar.Root>
+        );
+
+        fireEvent.click(getByText('File'));
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(menuRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('hides content when closed and shows when open', () => {
+        const { queryByText, getByText } = render(
+            <Menubar.Root>
+                <Menubar.Menu>
+                    <Menubar.Trigger>File</Menubar.Trigger>
+                    <Menubar.Content>
+                        <Menubar.Item>New</Menubar.Item>
+                    </Menubar.Content>
+                </Menubar.Menu>
+            </Menubar.Root>
+        );
+
+        expect(queryByText('New')).toBeNull();
+        fireEvent.click(getByText('File'));
+        expect(queryByText('New')).toBeInTheDocument();
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { getByText } = render(
+            <Menubar.Root>
+                <Menubar.Menu>
+                    <Menubar.Trigger>File</Menubar.Trigger>
+                    <Menubar.Content>
+                        <Menubar.Item>New</Menubar.Item>
+                    </Menubar.Content>
+                </Menubar.Menu>
+            </Menubar.Root>
+        );
+
+        fireEvent.click(getByText('File'));
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- refactor Menubar components to forward refs and use typed props
- add Menubar tests for ref forwarding, accessibility, and warnings

## Testing
- `npm test`
- `npm run build:rollup`
