### PR TITLE
refactor: forward refs in Button

### DIFF
--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,5 +1,9 @@
 'use client';
-import React, { ButtonHTMLAttributes, DetailedHTMLProps, PropsWithChildren } from 'react';
+import React, {
+    forwardRef,
+    ComponentPropsWithoutRef,
+    ElementRef
+} from 'react';
 import { customClassSwitcher } from '~/core';
 import { clsx } from 'clsx';
 import ButtonPrimitive from '~/core/primitives/Button';
@@ -11,11 +15,12 @@ const COMPONENT_NAME = 'Button';
 export type ButtonProps = {
     customRootClass?: string;
     variant?: string;
-    size?:string;
-    color?:string;
-} & DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & PropsWithChildren
+    size?: string;
+    color?: string;
+} & ComponentPropsWithoutRef<typeof ButtonPrimitive>;
 
-const Button = ({ children, type = 'button', customRootClass = '', className = '', variant = '', size = '', color = '', ...props }: ButtonProps) => {
+const Button = forwardRef<ElementRef<typeof ButtonPrimitive>, ButtonProps>(
+({ children, type = 'button', customRootClass = '', className = '', variant = '', size = '', color = '', ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     // apply data attribute for accent color
     // apply attribute only if color is present
@@ -25,6 +30,7 @@ const Button = ({ children, type = 'button', customRootClass = '', className = '
 
     return (
         <ButtonPrimitive
+            ref={ref}
             type={type}
             className={clsx(rootClass, className)}
             {...composedAttributes()}
@@ -33,7 +39,7 @@ const Button = ({ children, type = 'button', customRootClass = '', className = '
             {children}
         </ButtonPrimitive>
     );
-};
+});
 
 Button.displayName = COMPONENT_NAME;
 

--- a/src/components/ui/Button/tests/Button.test.tsx
+++ b/src/components/ui/Button/tests/Button.test.tsx
@@ -42,4 +42,27 @@ describe('Button', () => {
         await userEvent.click(button);
         expect(onClick).toHaveBeenCalledTimes(1);
     });
+
+    test('forwards ref to the underlying button element', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(<Button ref={ref}>button</Button>);
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('passes accessibility attributes to the button', () => {
+        render(<Button label='Label' description='Description'>button</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveAttribute('aria-label', 'Label');
+        expect(button).toHaveAttribute('aria-description', 'Description');
+    });
+
+    test('renders without warnings', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        render(<Button>button</Button>);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
 });

--- a/src/core/primitives/Button/index.tsx
+++ b/src/core/primitives/Button/index.tsx
@@ -1,4 +1,8 @@
-import React, { forwardRef } from 'react';
+import React, {
+    forwardRef,
+    ComponentPropsWithoutRef,
+    ElementRef
+} from 'react';
 import Primitive from '~/core/primitives/Primitive';
 
 /**
@@ -17,7 +21,18 @@ import Primitive from '~/core/primitives/Primitive';
 
  */
 
-const ButtonPrimitive = forwardRef(({ role = 'button', type = 'button', label = '', description = '', disabled = false, children, ...props }:any, ref) => {
+export type ButtonPrimitiveProps = {
+    label?: string;
+    description?: string;
+    asChild?: boolean;
+    required?: boolean;
+    onChange?: any;
+} & ComponentPropsWithoutRef<'button'>;
+
+const ButtonPrimitive = forwardRef<
+    ElementRef<'button'>,
+    ButtonPrimitiveProps
+>(({ role = 'button', type = 'button', label = '', description = '', disabled = false, children, ...props }, ref) => {
     if (label) {
         // If we have a label, we should set the aria-label attribute
         // This is usually generated automatically by the screen reader

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
@@ -42,7 +42,7 @@ const CheckboxPrimitiveRoot = forwardRef<CheckboxPrimitiveRootElement, CheckboxP
                 opacity: 0,
                 margin: 0,
                 transform: 'translateX(-100%)'
-            }} name={name} value={value} checked={isChecked} disabled={disabled} required={required} readOnly {...props}/>
+            }} name={name} value={value} checked={isChecked} disabled={disabled} required={required} readOnly />
     </CheckboxPrimitiveContext.Provider>;
 });
 


### PR DESCRIPTION
## Summary
- refactor Button to forward refs and add types
- type-safe ButtonPrimitive forwarding and Checkbox trigger fix
- test ref forwarding and accessibility

## Testing
- `npm test`
- `npm run build:rollup`
