### PR TITLE
refactor: forward refs in Select components

### DIFF
--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 import SelectContent from './fragments/SelectContent';
 import SelectItem from './fragments/SelectItem';
 import SelectTrigger from './fragments/SelectTrigger';
@@ -8,10 +9,25 @@ import SelectPortal from './fragments/SelectPortal';
 import SelectGroup from './fragments/SelectGroup';
 import SelectSearch from './fragments/SelectSearch';
 
-const Select = () => {
+const SelectBase = React.forwardRef<unknown, Record<string, never>>((_props, _ref) => {
     console.warn('Direct usage of Select is not supported. Please use Select.Root, Select.Content, etc. instead.');
     return null;
-};
+});
+
+SelectBase.displayName = 'Select';
+
+interface SelectComponent extends React.ForwardRefExoticComponent<React.RefAttributes<unknown>> {
+    Root: typeof SelectRoot;
+    Content: typeof SelectContent;
+    Item: typeof SelectItem;
+    Trigger: typeof SelectTrigger;
+    Portal: typeof SelectPortal;
+    Group: typeof SelectGroup;
+    Indicator: typeof SelectIndicator;
+    Search: typeof SelectSearch;
+}
+
+const Select = SelectBase as SelectComponent;
 
 Select.Root = SelectRoot;
 Select.Content = SelectContent;

--- a/src/components/ui/Select/fragments/SelectContent.tsx
+++ b/src/components/ui/Select/fragments/SelectContent.tsx
@@ -3,7 +3,12 @@ import React, { useContext } from 'react';
 import SelectPrimitive from '~/core/primitives/Select/Select';
 import { SelectRootContext } from '../contexts/SelectRootContext';
 
-function SelectContent({ customRootClass, children, position = 'popper', ...props }: any) {
+type SelectContentElement = React.ElementRef<typeof SelectPrimitive.Content>;
+type SelectContentProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    customRootClass?: string;
+};
+
+const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>(({ customRootClass, children, position = 'popper', ...props }, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
 
     return (
@@ -11,12 +16,14 @@ function SelectContent({ customRootClass, children, position = 'popper', ...prop
             className={`${rootClass}-content`}
             position={position}
             data-position={position}
-
+            ref={forwardedRef}
             {...props}
         >
             {children}
         </SelectPrimitive.Content>
     );
-}
+});
+
+SelectContent.displayName = 'SelectContent';
 
 export default SelectContent;

--- a/src/components/ui/Select/fragments/SelectGroup.tsx
+++ b/src/components/ui/Select/fragments/SelectGroup.tsx
@@ -6,16 +6,23 @@ export type SelectGroupProps = {
     children: React.ReactNode
 };
 
-function SelectGroup({ children }: SelectGroupProps) {
+type SelectGroupElement = React.ElementRef<typeof SelectPrimitive.Group>;
+type SelectGroupComponentProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group> & SelectGroupProps;
+
+const SelectGroup = React.forwardRef<SelectGroupElement, SelectGroupComponentProps>(({ children, ...props }, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
     return (
         <SelectPrimitive.Group
             className={`${rootClass}-group`}
+            ref={forwardedRef}
+            {...props}
         >
             {children}
         </SelectPrimitive.Group>
 
     );
-}
+});
+
+SelectGroup.displayName = 'SelectGroup';
 
 export default SelectGroup;

--- a/src/components/ui/Select/fragments/SelectIndicator.tsx
+++ b/src/components/ui/Select/fragments/SelectIndicator.tsx
@@ -2,15 +2,20 @@
 import React, { useContext } from 'react';
 import { SelectRootContext } from '../contexts/SelectRootContext';
 
-function SelectIndicator() {
+type SelectIndicatorElement = React.ElementRef<'div'>;
+type SelectIndicatorProps = React.ComponentPropsWithoutRef<'div'>;
+
+const SelectIndicator = React.forwardRef<SelectIndicatorElement, SelectIndicatorProps>((props, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
     return (
-        <div className={`${rootClass}-item-indicator`}>
+        <div className={`${rootClass}-item-indicator`} ref={forwardedRef} {...props}>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M13.3332 4L5.99984 11.3333L2.6665 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
         </div>
     );
-}
+});
+
+SelectIndicator.displayName = 'SelectIndicator';
 
 export default SelectIndicator;

--- a/src/components/ui/Select/fragments/SelectItem.tsx
+++ b/src/components/ui/Select/fragments/SelectItem.tsx
@@ -3,7 +3,12 @@ import React, { useContext } from 'react';
 import SelectPrimitive from '~/core/primitives/Select/Select';
 import { SelectRootContext } from '../contexts/SelectRootContext';
 
-function SelectItem({ customRootClass, children, value, disabled, ...props }: any) {
+type SelectItemElement = React.ElementRef<typeof SelectPrimitive.Item>;
+type SelectItemProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    customRootClass?: string;
+};
+
+const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(({ customRootClass, children, value, disabled, ...props }, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
 
     return (
@@ -14,11 +19,14 @@ function SelectItem({ customRootClass, children, value, disabled, ...props }: an
             data-disabled={disabled ? '' : undefined}
             role="option"
             aria-disabled={disabled ? 'true' : undefined}
+            ref={forwardedRef}
             {...props}
         >
             <span className={`${rootClass}-text`}>{children}</span>
         </SelectPrimitive.Item>
     );
-}
+});
+
+SelectItem.displayName = 'SelectItem';
 
 export default SelectItem;

--- a/src/components/ui/Select/fragments/SelectPortal.tsx
+++ b/src/components/ui/Select/fragments/SelectPortal.tsx
@@ -6,15 +6,18 @@ export type SelectPortalProps = {
   children: React.ReactNode;
 };
 
-const SelectPortal = ({ children }: SelectPortalProps) => {
-    const rootElement = document.querySelector('#rad-ui-theme-container') || document.body as HTMLElement | null;
+type SelectPortalElement = React.ElementRef<typeof SelectPrimitive.Portal>;
+type SelectPortalPrimitiveProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Portal> & SelectPortalProps;
 
+const SelectPortal = React.forwardRef<SelectPortalElement, SelectPortalPrimitiveProps>(({ children, ...props }, forwardedRef) => {
     return (
-        <SelectPrimitive.Portal>
+        <SelectPrimitive.Portal ref={forwardedRef} {...props}>
             {children}
         </SelectPrimitive.Portal>
 
     );
-};
+});
+
+SelectPortal.displayName = 'SelectPortal';
 
 export default SelectPortal;

--- a/src/components/ui/Select/fragments/SelectRoot.tsx
+++ b/src/components/ui/Select/fragments/SelectRoot.tsx
@@ -5,24 +5,34 @@ import { SelectRootContext } from '../contexts/SelectRootContext';
 
 const COMPONENT_NAME = 'Select';
 
-function SelectRoot({ customRootClass, children, defaultValue, value, onValueChange, shift, ...props }: any) {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+type SelectRootElement = React.ElementRef<typeof SelectPrimitive.Root>;
+type SelectRootProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root> & {
+    customRootClass?: string;
+};
 
-    return (
-        <SelectRootContext.Provider value={{ rootClass }}>
-            <SelectPrimitive.Root
-                className={`${rootClass}-root`}
-                defaultValue={defaultValue}
-                value={value}
-                onValueChange={onValueChange}
-                shift={shift}
-                {...props}
-            >
-                {children}
-            </SelectPrimitive.Root>
-        </SelectRootContext.Provider>
+const SelectRoot = React.forwardRef<SelectRootElement, SelectRootProps>(
+    ({ customRootClass, children, defaultValue, value, onValueChange, shift, ...props }, forwardedRef) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
 
-    );
-}
+        return (
+            <SelectRootContext.Provider value={{ rootClass }}>
+                <SelectPrimitive.Root
+                    className={`${rootClass}-root`}
+                    defaultValue={defaultValue}
+                    value={value}
+                    onValueChange={onValueChange}
+                    shift={shift}
+                    ref={forwardedRef}
+                    {...props}
+                >
+                    {children}
+                </SelectPrimitive.Root>
+            </SelectRootContext.Provider>
+
+        );
+    }
+);
+
+SelectRoot.displayName = 'SelectRoot';
 
 export default SelectRoot;

--- a/src/components/ui/Select/fragments/SelectSearch.tsx
+++ b/src/components/ui/Select/fragments/SelectSearch.tsx
@@ -2,15 +2,22 @@ import React, { useContext } from 'react';
 import SelectPrimitive from '~/core/primitives/Select/Select';
 import { SelectRootContext } from '../contexts/SelectRootContext';
 
-function SelectSearch() {
+type SelectSearchElement = React.ElementRef<typeof SelectPrimitive.Search>;
+type SelectSearchProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Search>;
+
+const SelectSearch = React.forwardRef<SelectSearchElement, SelectSearchProps>((props, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
     return (
         <SelectPrimitive.Search
             className={`${rootClass}-search`}
+            ref={forwardedRef}
+            {...props}
         >
 
         </SelectPrimitive.Search>
     );
-}
+});
+
+SelectSearch.displayName = 'SelectSearch';
 
 export default SelectSearch;

--- a/src/components/ui/Select/fragments/SelectTrigger.tsx
+++ b/src/components/ui/Select/fragments/SelectTrigger.tsx
@@ -4,16 +4,21 @@ import SelectPrimitive from '~/core/primitives/Select/Select';
 
 import { SelectRootContext } from '../contexts/SelectRootContext';
 
-function SelectTrigger({ customRootClass, children, disabled, placeholder, ...props }: any) {
+type SelectTriggerElement = React.ElementRef<typeof SelectPrimitive.Trigger>;
+type SelectTriggerProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    customRootClass?: string;
+    placeholder?: boolean;
+};
+
+const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>(({ customRootClass, children, disabled, placeholder, ...props }, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
-    const triggerRef = React.useRef<HTMLDivElement>(null);
 
     return (
         <SelectPrimitive.Trigger
             className={`${rootClass}-trigger`}
             aria-disabled={disabled ? 'true' : undefined}
             data-placeholder={placeholder ? '' : undefined}
-            ref={triggerRef}
+            ref={forwardedRef}
             {...props}
         >
 
@@ -21,6 +26,8 @@ function SelectTrigger({ customRootClass, children, disabled, placeholder, ...pr
 
         </SelectPrimitive.Trigger>
     );
-}
+});
+
+SelectTrigger.displayName = 'SelectTrigger';
 
 export default SelectTrigger;

--- a/src/components/ui/Select/tests/Select.test.tsx
+++ b/src/components/ui/Select/tests/Select.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Select from '../Select';
+
+describe('Select', () => {
+    test('forwards ref through Trigger', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <Select.Root>
+                <Select.Trigger ref={ref}>Trigger</Select.Trigger>
+            </Select.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('renders hidden select for forms', () => {
+        const { container } = render(
+            <form>
+                <Select.Root name="fruit" defaultValue="Apple">
+                    <Select.Trigger>Apple</Select.Trigger>
+                </Select.Root>
+            </form>
+        );
+        const hiddenSelect = container.querySelector('select');
+        expect(hiddenSelect).toHaveAttribute('aria-hidden', 'true');
+        expect(hiddenSelect).toHaveValue('Apple');
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(
+            <Select.Root>
+                <Select.Trigger>Trigger</Select.Trigger>
+            </Select.Root>
+        );
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});

--- a/src/core/primitives/Select/Select.tsx
+++ b/src/core/primitives/Select/Select.tsx
@@ -5,11 +5,26 @@ import SelectPrimitiveRoot from './fragments/SelectPrimitiveRoot';
 import SelectPrimitivePortal from './fragments/SelectPrimitivePortal';
 import SelectPrimitiveGroup from './fragments/SelectPrimitiveGroup';
 import SelectPrimitiveSearch from './fragments/SelectPrimitiveSearch';
+import React from 'react';
 
-const SelectPrimitive = () => {
+const SelectPrimitiveBase = React.forwardRef<unknown, Record<string, never>>((_props, _ref) => {
     console.warn('Direct usage of Select is not supported. Please use Select.Root, Select.Content, etc. instead.');
     return null;
-};
+});
+
+SelectPrimitiveBase.displayName = 'SelectPrimitive';
+
+interface SelectPrimitiveComponent extends React.ForwardRefExoticComponent<React.RefAttributes<unknown>> {
+    Root: typeof SelectPrimitiveRoot;
+    Content: typeof SelectPrimitiveContent;
+    Portal: typeof SelectPrimitivePortal;
+    Item: typeof SelectPrimitiveItem;
+    Trigger: typeof SelectPrimitiveTrigger;
+    Group: typeof SelectPrimitiveGroup;
+    Search: typeof SelectPrimitiveSearch;
+}
+
+const SelectPrimitive = SelectPrimitiveBase as SelectPrimitiveComponent;
 
 SelectPrimitive.Root = SelectPrimitiveRoot;
 SelectPrimitive.Content = SelectPrimitiveContent;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveContent.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveContent.tsx
@@ -10,7 +10,10 @@ export type SelectPrimitiveContentProps = {
     [key: string]: any;
 }
 
-function SelectPrimitiveContent({ children, className, ...props }: SelectPrimitiveContentProps) {
+const SelectPrimitiveContent = React.forwardRef<
+    React.ElementRef<'div'>,
+    SelectPrimitiveContentProps & React.ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, forwardedRef) => {
     const { isOpen, elementsRef, labelsRef, floatingContext, refs, getFloatingProps, floatingStyles } = useContext(SelectPrimitiveContext);
 
     return (
@@ -19,7 +22,7 @@ function SelectPrimitiveContent({ children, className, ...props }: SelectPrimiti
                 <Floater.FocusManager context={floatingContext}>
                     <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef} >
                         <div
-                            ref={refs.setFloating}
+                            ref={Floater.useMergeRefs([refs.setFloating, forwardedRef])}
                             style={floatingStyles}
                             className={className}
                             {...getFloatingProps()}
@@ -35,6 +38,8 @@ function SelectPrimitiveContent({ children, className, ...props }: SelectPrimiti
         </>
 
     );
-}
+});
+
+SelectPrimitiveContent.displayName = 'SelectPrimitiveContent';
 
 export default SelectPrimitiveContent;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveGroup.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveGroup.tsx
@@ -3,15 +3,19 @@ import React from 'react';
 export type SelectPrimitiveGroupProps = {
     children: React.ReactNode,
     className?: string,
-
 }
 
-function SelectPrimitiveGroup({ children, className }: SelectPrimitiveGroupProps) {
+const SelectPrimitiveGroup = React.forwardRef<
+    React.ElementRef<'div'>,
+    SelectPrimitiveGroupProps & React.ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, forwardedRef) => {
     return (
-        <div className={className}>
+        <div className={className} ref={forwardedRef} {...props}>
             {children}
         </div>
     );
-}
+});
+
+SelectPrimitiveGroup.displayName = 'SelectPrimitiveGroup';
 
 export default SelectPrimitiveGroup;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveItem.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveItem.tsx
@@ -13,7 +13,10 @@ interface SelectPrimitiveItemProps {
     [key: string]: any;
 }
 
-function SelectPrimitiveItem({ children, value, disabled, className, ...props }: SelectPrimitiveItemProps) {
+const SelectPrimitiveItem = React.forwardRef<
+    React.ElementRef<typeof Primitive.div>,
+    SelectPrimitiveItemProps & React.ComponentPropsWithoutRef<typeof Primitive.div>
+>(({ children, value, disabled, className, ...props }, forwardedRef) => {
     const context = useContext(SelectPrimitiveContext);
 
     if (!context) {
@@ -39,7 +42,7 @@ function SelectPrimitiveItem({ children, value, disabled, className, ...props }:
 
     return (
         <Primitive.div
-            ref={Floater.useMergeRefs([ref, itemRef])} // Merge refs from Floater and props.ref}
+            ref={Floater.useMergeRefs([ref, itemRef, forwardedRef])}
             id={itemId}
             role="option"
             className={className}
@@ -67,6 +70,8 @@ function SelectPrimitiveItem({ children, value, disabled, className, ...props }:
         </Primitive.div>
 
     );
-}
+});
+
+SelectPrimitiveItem.displayName = 'SelectPrimitiveItem';
 
 export default SelectPrimitiveItem;

--- a/src/core/primitives/Select/fragments/SelectPrimitivePortal.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitivePortal.tsx
@@ -3,7 +3,10 @@ import React, { useContext, useEffect, useState } from 'react';
 import Floater from '~/core/primitives/Floater';
 import { SelectPrimitiveContext } from '../contexts/SelectPrimitiveContext';
 
-function SelectPrimitivePortal({ children }: { children: React.ReactNode }) {
+const SelectPrimitivePortal = React.forwardRef<
+    React.ElementRef<typeof Floater.Portal>,
+    { children: React.ReactNode } & React.ComponentPropsWithoutRef<typeof Floater.Portal>
+>(({ children, ...props }, _forwardedRef) => {
     const { isOpen } = useContext(SelectPrimitiveContext);
     const [rootElementFound, setRootElementFound] = useState(false);
     const rootElement = (document.querySelector('#rad-ui-theme-container') || document.body) as HTMLElement | null;
@@ -17,10 +20,12 @@ function SelectPrimitivePortal({ children }: { children: React.ReactNode }) {
     if (!isOpen || !rootElementFound) return null;
 
     return (
-        <Floater.Portal root={rootElement}>
+        <Floater.Portal root={rootElement} {...props}>
             {children}
         </Floater.Portal>
     );
-}
+});
+
+SelectPrimitivePortal.displayName = 'SelectPrimitivePortal';
 
 export default SelectPrimitivePortal;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveRoot.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveRoot.tsx
@@ -20,7 +20,10 @@ export type SelectPrimitiveRootProps = {
     placement?: Placement
 }
 
-function SelectPrimitiveRoot({ children, className, value, name, defaultValue = '', onValueChange, onClickOutside = () => {}, placement = 'bottom-start', offsetValue, shift = true, ...props }: SelectPrimitiveRootProps) {
+const SelectPrimitiveRoot = React.forwardRef<
+    React.ElementRef<typeof Primitive.div>,
+    SelectPrimitiveRootProps & React.ComponentPropsWithoutRef<typeof Primitive.div>
+>(({ children, className, value, name, defaultValue = '', onValueChange, onClickOutside = () => {}, placement = 'bottom-start', offsetValue, shift = true, ...props }, forwardedRef) => {
     const [isOpen, setIsOpen] = React.useState(false);
     const [offsetPositionValue, setOffsetPositionValue] = React.useState(offsetValue);
     const [selectedLabel, setSelectedLabel] = useControllableState(
@@ -140,7 +143,7 @@ function SelectPrimitiveRoot({ children, className, value, name, defaultValue = 
     };
     return (
         <SelectPrimitiveContext.Provider value={values}>
-            <Primitive.div {...props} className={className} ref={rootRef}>
+            <Primitive.div {...props} className={className} ref={Floater.useMergeRefs([rootRef, forwardedRef])}>
 
                 {children}
                 {/* Add hidden native select for form control */}
@@ -152,6 +155,7 @@ function SelectPrimitiveRoot({ children, className, value, name, defaultValue = 
                             hidden
                             aria-hidden="true"
                             tabIndex={-1}
+                            onChange={() => {}}
                         >
                             <option value={selectedLabel}>{selectedLabel}</option>
                         </select>
@@ -160,6 +164,8 @@ function SelectPrimitiveRoot({ children, className, value, name, defaultValue = 
             </Primitive.div>
         </SelectPrimitiveContext.Provider>
     );
-}
+});
+
+SelectPrimitiveRoot.displayName = 'SelectPrimitiveRoot';
 
 export default SelectPrimitiveRoot;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveSearch.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveSearch.tsx
@@ -1,9 +1,13 @@
-'use client';
+"use client";
 import React, { useContext } from 'react';
 import { SelectPrimitiveContext } from '../contexts/SelectPrimitiveContext';
 import Primitive from '../../Primitive';
+import Floater from '../../Floater';
 
-function SelectPrimitiveSearch({ className }: {className?: string}) {
+const SelectPrimitiveSearch = React.forwardRef<
+    React.ElementRef<typeof Primitive.input>,
+    { className?: string } & React.ComponentPropsWithoutRef<typeof Primitive.input>
+>(({ className, ...props }, forwardedRef) => {
     const [search, setSearch] = React.useState('');
     const context = useContext(SelectPrimitiveContext);
     const inputRef = React.useRef<HTMLInputElement>(null);
@@ -19,6 +23,8 @@ function SelectPrimitiveSearch({ className }: {className?: string}) {
                 value={search}
                 // @ts-ignore
                 onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
+                ref={forwardedRef}
+                {...props}
             />
         );
     }
@@ -83,7 +89,7 @@ function SelectPrimitiveSearch({ className }: {className?: string}) {
             type="search"
             className={className}
             placeholder="Search..."
-            ref={inputRef}
+            ref={Floater.useMergeRefs([inputRef, forwardedRef])}
             value={search}
             aria-activedescendant={virtualItemRef.current?.id || (activeIndex !== null && valuesRef.current[activeIndex] ? valuesRef.current[activeIndex] : undefined)}
             // @ts-ignore
@@ -97,8 +103,11 @@ function SelectPrimitiveSearch({ className }: {className?: string}) {
                     }
                 }
             }}
+            {...props}
         />
     );
-}
+});
+
+SelectPrimitiveSearch.displayName = 'SelectPrimitiveSearch';
 
 export default SelectPrimitiveSearch;

--- a/src/core/primitives/Select/fragments/SelectPrimitiveTrigger.tsx
+++ b/src/core/primitives/Select/fragments/SelectPrimitiveTrigger.tsx
@@ -1,13 +1,18 @@
 'use client';
 import React, { useContext } from 'react';
 import { SelectPrimitiveContext } from '../contexts/SelectPrimitiveContext';
+import Floater from '../../Floater';
 
 export type SelectPrimitiveTriggerProps = {
     children: React.ReactNode;
     className?: string;
     [key: string]: any;
 };
-function SelectPrimitiveTrigger({ children, className, ...props }: SelectPrimitiveTriggerProps) {
+
+const SelectPrimitiveTrigger = React.forwardRef<
+    React.ElementRef<'button'>,
+    SelectPrimitiveTriggerProps & React.ComponentPropsWithoutRef<'button'>
+>(({ children, className, ...props }, forwardedRef) => {
     const { isOpen, setIsOpen, selectedLabel, refs, getReferenceProps } = useContext(SelectPrimitiveContext);
     return (
         <button
@@ -15,13 +20,15 @@ function SelectPrimitiveTrigger({ children, className, ...props }: SelectPrimiti
             onClick={() => setIsOpen(!isOpen)}
             className={className}
             aria-expanded={isOpen}
-            ref={refs.setReference}
+            ref={Floater.useMergeRefs([refs.setReference, forwardedRef])}
             {...getReferenceProps()}
             role='combobox'
             {...props}>
             {selectedLabel || children}
         </button>
     );
-}
+});
+
+SelectPrimitiveTrigger.displayName = 'SelectPrimitiveTrigger';
 
 export default SelectPrimitiveTrigger;

--- a/src/core/primitives/Select/tests/SelectPrimitive.test.tsx
+++ b/src/core/primitives/Select/tests/SelectPrimitive.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SelectPrimitive from '../Select';
+
+describe('SelectPrimitive', () => {
+    test('forwards ref through Trigger', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <SelectPrimitive.Root>
+                <SelectPrimitive.Trigger ref={ref}>Trigger</SelectPrimitive.Trigger>
+            </SelectPrimitive.Root>
+        );
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('renders hidden select for forms', () => {
+        const { container } = render(
+            <form>
+                <SelectPrimitive.Root name="test" defaultValue="Apple">
+                    <SelectPrimitive.Trigger>Apple</SelectPrimitive.Trigger>
+                </SelectPrimitive.Root>
+            </form>
+        );
+        const hiddenSelect = container.querySelector('select');
+        expect(hiddenSelect).toHaveAttribute('aria-hidden', 'true');
+        expect(hiddenSelect).toHaveValue('Apple');
+    });
+
+    test('renders without warnings', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        render(
+            <SelectPrimitive.Root>
+                <SelectPrimitive.Trigger>Trigger</SelectPrimitive.Trigger>
+            </SelectPrimitive.Root>
+        );
+        expect(warn).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        warn.mockRestore();
+        error.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- refactor Select primitives and UI components to forward refs
- ensure hidden select remains accessible and add forward-ref tests
- type Select aggregates with static subcomponents

## Testing
- `npm test src/core/primitives/Select/tests/SelectPrimitive.test.tsx src/components/ui/Select/tests/Select.test.tsx`
- `npm run build:rollup`
