### PR TITLE
refactor: forward refs in navigation menu

### DIFF
--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
@@ -4,35 +4,43 @@ import NavigationMenuItemContext from '../contexts/NavigationMenyItemContext';
 import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import clsx from 'clsx';
 
-export interface NavigationMenuContentProps {
+export type NavigationMenuContentElement = React.ElementRef<'div'>;
+
+export interface NavigationMenuContentProps extends React.ComponentPropsWithoutRef<'div'> {
     children: React.ReactNode;
-    className?: string;
 }
 
-const NavigationMenuContent = ({ children, className }: NavigationMenuContentProps) => {
-    const { itemOpen } = React.useContext(NavigationMenuItemContext);
-    const { rootClass } = React.useContext(NavigationMenuRootContext);
-    const contentRef = React.useRef<HTMLDivElement>(null);
+const NavigationMenuContent = React.forwardRef<NavigationMenuContentElement, NavigationMenuContentProps>(
+    ({ children, className, ...props }, ref) => {
+        const { itemOpen } = React.useContext(NavigationMenuItemContext);
+        const { rootClass } = React.useContext(NavigationMenuRootContext);
+        const contentRef = React.useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        const firstFocusable = contentRef.current?.querySelector<HTMLElement>('*');
-        firstFocusable?.focus();
-    }, [itemOpen]);
+        React.useImperativeHandle(ref, () => contentRef.current as HTMLDivElement);
 
-    if (!itemOpen) return null;
+        useEffect(() => {
+            const firstFocusable = contentRef.current?.querySelector<HTMLElement>('*');
+            firstFocusable?.focus();
+        }, [itemOpen]);
 
-    return (
-        <div
-            ref={contentRef}
-            className={clsx(`${rootClass}-content`, className)}
-            data-state={itemOpen ? 'open' : 'closed'}
-        >
-            <RovingFocusGroup.Root>
-                <RovingFocusGroup.Group>{children}</RovingFocusGroup.Group>
-            </RovingFocusGroup.Root>
-        </div>
-    );
-};
+        if (!itemOpen) return null;
+
+        return (
+            <div
+                ref={contentRef}
+                className={clsx(`${rootClass}-content`, className)}
+                data-state={itemOpen ? 'open' : 'closed'}
+                {...props}
+            >
+                <RovingFocusGroup.Root>
+                    <RovingFocusGroup.Group>{children}</RovingFocusGroup.Group>
+                </RovingFocusGroup.Root>
+            </div>
+        );
+    }
+);
+
+NavigationMenuContent.displayName = 'NavigationMenuContent';
 
 export default NavigationMenuContent;
 

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuItem.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuItem.tsx
@@ -4,11 +4,13 @@ import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import clsx from 'clsx';
 import composeEventHandlers from '~/core/hooks/composeEventHandlers';
 
+export type NavigationMenuItemElement = React.ElementRef<'div'>;
+
 export interface NavigationMenuItemProps extends React.ComponentPropsWithoutRef<'div'> {
     value: string;
 }
 
-const NavigationMenuItem = React.forwardRef<HTMLDivElement, NavigationMenuItemProps>(
+const NavigationMenuItem = React.forwardRef<NavigationMenuItemElement, NavigationMenuItemProps>(
     ({ value, children, className, onMouseEnter, onMouseLeave, onKeyDown, ...props }, ref) => {
         const { isOpen, setIsOpen, rootClass } = React.useContext(NavigationMenuRootContext);
 

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuLink.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuLink.tsx
@@ -3,16 +3,23 @@ import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import clsx from 'clsx';
 
+export type NavigationMenuLinkElement = React.ElementRef<'a'>;
+
 export interface NavigationMenuLinkProps extends React.ComponentPropsWithoutRef<'a'> {
     href: string;
 }
 
-const NavigationMenuLink = React.forwardRef<HTMLButtonElement, NavigationMenuLinkProps>(
+const NavigationMenuLink = React.forwardRef<NavigationMenuLinkElement, NavigationMenuLinkProps>(
     ({ children, href, className, ...props }, ref) => {
         const { rootClass } = React.useContext(NavigationMenuRootContext);
         return (
-            <RovingFocusGroup.Item ref={ref}>
-                <a href={href} className={clsx(`${rootClass}-link`, className)} {...props}>
+            <RovingFocusGroup.Item>
+                <a
+                    ref={ref}
+                    href={href}
+                    className={clsx(`${rootClass}-link`, className)}
+                    {...props}
+                >
                     {children}
                 </a>
             </RovingFocusGroup.Item>

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
@@ -5,41 +5,49 @@ import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
 
-const COMPONENT_NAME = 'NavigationMenu';
+const COMPONENT_NAME = 'NavigationMenuRoot';
 
-export interface NavigationMenuRootProps extends React.HTMLAttributes<HTMLDivElement> {
+export type NavigationMenuRootElement = React.ElementRef<'div'>;
+
+export interface NavigationMenuRootProps extends React.ComponentPropsWithoutRef<'div'> {
     children: React.ReactNode;
     value?: string;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     customRootClass?: string;
-    className?: string;
 }
 
-const NavigationMenuRoot = ({
-    children,
-    value,
-    defaultValue = '',
-    onValueChange,
-    customRootClass,
-    className,
-    ...props
-}: NavigationMenuRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const [isOpen, setIsOpen] = useControllableState(value, defaultValue, onValueChange);
+const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, NavigationMenuRootProps>(
+    (
+        {
+            children,
+            value,
+            defaultValue = '',
+            onValueChange,
+            customRootClass,
+            className,
+            ...props
+        },
+        ref
+    ) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const [isOpen, setIsOpen] = useControllableState(value, defaultValue, onValueChange);
 
-    return (
-        <div {...props}>
-            <NavigationMenuRootContext.Provider value={{ isOpen, setIsOpen, rootClass }}>
-                <RovingFocusGroup.Root>
-                    <RovingFocusGroup.Group className={clsx(`${rootClass}-root`, className)}>
-                        {children}
-                    </RovingFocusGroup.Group>
-                </RovingFocusGroup.Root>
-            </NavigationMenuRootContext.Provider>
-        </div>
-    );
-};
+        return (
+            <div ref={ref} {...props}>
+                <NavigationMenuRootContext.Provider value={{ isOpen, setIsOpen, rootClass }}>
+                    <RovingFocusGroup.Root>
+                        <RovingFocusGroup.Group className={clsx(`${rootClass}-root`, className)}>
+                            {children}
+                        </RovingFocusGroup.Group>
+                    </RovingFocusGroup.Root>
+                </NavigationMenuRootContext.Provider>
+            </div>
+        );
+    }
+);
+
+NavigationMenuRoot.displayName = COMPONENT_NAME;
 
 export default NavigationMenuRoot;
 

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuTrigger.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuTrigger.tsx
@@ -3,24 +3,33 @@ import RovingFocusGroup from '~/core/utils/RovingFocusGroup';
 import NavigationMenuItemContext from '../contexts/NavigationMenyItemContext';
 import NavigationMenuRootContext from '../contexts/NavigationMenuRootContext';
 import clsx from 'clsx';
+import composeEventHandlers from '~/core/hooks/composeEventHandlers';
 
-export interface NavigationMenuTriggerProps {
-    children: React.ReactNode;
-    className?: string;
-}
+export type NavigationMenuTriggerElement = React.ElementRef<'button'>;
 
-const NavigationMenuTrigger = ({ children, className }: NavigationMenuTriggerProps) => {
-    const { handleTrigger } = React.useContext(NavigationMenuItemContext);
-    const { rootClass } = React.useContext(NavigationMenuRootContext);
+export interface NavigationMenuTriggerProps extends React.ComponentPropsWithoutRef<'button'> {}
 
-    return (
-        <RovingFocusGroup.Item>
-            <button onClick={handleTrigger} className={clsx(`${rootClass}-trigger`, className)}>
-                {children}
-            </button>
-        </RovingFocusGroup.Item>
-    );
-};
+const NavigationMenuTrigger = React.forwardRef<NavigationMenuTriggerElement, NavigationMenuTriggerProps>(
+    ({ children, className, onClick, ...props }, ref) => {
+        const { handleTrigger } = React.useContext(NavigationMenuItemContext);
+        const { rootClass } = React.useContext(NavigationMenuRootContext);
+
+        return (
+            <RovingFocusGroup.Item>
+                <button
+                    ref={ref}
+                    onClick={composeEventHandlers(onClick, handleTrigger)}
+                    className={clsx(`${rootClass}-trigger`, className)}
+                    {...props}
+                >
+                    {children}
+                </button>
+            </RovingFocusGroup.Item>
+        );
+    }
+);
+
+NavigationMenuTrigger.displayName = 'NavigationMenuTrigger';
 
 export default NavigationMenuTrigger;
 

--- a/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
+++ b/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
@@ -52,6 +52,36 @@ describe('NavigationMenu component', () => {
         expect(link).toHaveAttribute('href', '/about');
     });
 
+    test('sets data-state to open on content when triggered', () => {
+        const { getByText } = render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content>
+                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        fireEvent.click(getByText('Open'));
+        const content = getByText('Item 1 Content').closest('[data-state]');
+        expect(content).toHaveAttribute('data-state', 'open');
+    });
+
+    test('forwards ref to root', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <NavigationMenu.Root ref={ref}>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
     test('forwards ref to item', () => {
         const ref = React.createRef<HTMLDivElement>();
         render(
@@ -65,8 +95,36 @@ describe('NavigationMenu component', () => {
         expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
 
-    test('forwards ref to link', async () => {
+    test('forwards ref to trigger', () => {
         const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger ref={ref}>Open</NavigationMenu.Trigger>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    test('forwards ref to content', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <NavigationMenu.Root defaultValue="item1">
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Content ref={ref}>
+                        <NavigationMenu.Link href="#">Link</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('forwards ref to link', async () => {
+        const ref = React.createRef<HTMLAnchorElement>();
         render(
             <NavigationMenu.Root defaultValue="item1">
                 <NavigationMenu.Item value="item1">
@@ -78,8 +136,27 @@ describe('NavigationMenu component', () => {
         );
 
         await waitFor(() => {
-            expect(ref.current).toBeInstanceOf(HTMLElement);
+            expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
         });
+    });
+
+    test('renders without console errors', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
     });
 });
 


### PR DESCRIPTION
## Summary
- forward refs through NavigationMenu components (Root, Item, Trigger, Content, Link)
- add accessibility and ref forwarding tests for NavigationMenu

## Testing
- `npm test src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx`
- `npm run build:rollup`

