### PR TITLE
refactor: use forwardRef in DropdownMenu

### DIFF
--- a/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -1,3 +1,4 @@
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import DropdownMenuRoot from './fragments/DropdownMenuRoot';
 import DropdownMenuTrigger from './fragments/DropdownMenuTrigger';
 import DropdownMenuContent from './fragments/DropdownMenuContent';
@@ -6,10 +7,25 @@ import DropdownMenuItem from './fragments/DropdownMenuItem';
 import DropdownMenuSub from './fragments/DropdownMenuSub';
 import DropdownMenuSubTrigger from './fragments/DropdownMenuSubTrigger';
 
-const DropdownMenu = () => {
+export type DropdownMenuElement = ElementRef<'div'>;
+export type DropdownMenuProps = ComponentPropsWithoutRef<'div'>;
+
+type DropdownMenuComponent = React.ForwardRefExoticComponent<DropdownMenuProps & React.RefAttributes<DropdownMenuElement>> & {
+    Root: typeof DropdownMenuRoot;
+    Trigger: typeof DropdownMenuTrigger;
+    Content: typeof DropdownMenuContent;
+    Portal: typeof DropdownMenuPortal;
+    Item: typeof DropdownMenuItem;
+    Sub: typeof DropdownMenuSub;
+    SubTrigger: typeof DropdownMenuSubTrigger;
+};
+
+const DropdownMenu = forwardRef<DropdownMenuElement, DropdownMenuProps>((_props, _ref) => {
     console.warn('Direct usage of DropdownMenu is not supported. Please use DropdownMenu.Root, DropdownMenu.Item instead.');
     return null;
-};
+}) as DropdownMenuComponent;
+
+DropdownMenu.displayName = 'DropdownMenu';
 
 DropdownMenu.Root = DropdownMenuRoot;
 DropdownMenu.Trigger = DropdownMenuTrigger;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuContent.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuContent.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 import clsx from 'clsx';
 
+export type DropdownMenuContentElement = ElementRef<typeof MenuPrimitive.Content>;
 export type DropdownMenuContentProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Content;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
 
-const DropdownMenuContent = ({ children, className }:DropdownMenuContentProps) => {
+const DropdownMenuContent = forwardRef<DropdownMenuContentElement, DropdownMenuContentProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuContent should be used in the DropdownMenuRoot');
@@ -16,10 +17,12 @@ const DropdownMenuContent = ({ children, className }:DropdownMenuContentProps) =
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Content className={clsx(`${rootClass}-content`, className)}>
+        <MenuPrimitive.Content ref={ref} className={clsx(`${rootClass}-content`, className)} {...props}>
             {children}
         </MenuPrimitive.Content>
     );
-};
+});
+
+DropdownMenuContent.displayName = 'DropdownMenuContent';
 
 export default DropdownMenuContent;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuItem.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuItem.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 import clsx from 'clsx';
 
+export type DropdownMenuItemElement = ElementRef<typeof MenuPrimitive.Item>;
 export type DropdownMenuItemProps = {
   children: React.ReactNode;
   className?: string;
   label?: string;
-} & MenuPrimitiveProps.Item;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Item>;
 
-const DropdownMenuItem = ({ children, className, label }:DropdownMenuItemProps) => {
+const DropdownMenuItem = forwardRef<DropdownMenuItemElement, DropdownMenuItemProps>(({ children, className, label, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuItem should be used in the DropdownMenuRoot');
@@ -17,10 +18,12 @@ const DropdownMenuItem = ({ children, className, label }:DropdownMenuItemProps) 
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Item className={clsx(`${rootClass}-item`, className)} label={label}>
+        <MenuPrimitive.Item ref={ref} className={clsx(`${rootClass}-item`, className)} label={label} {...props}>
             {children}
         </MenuPrimitive.Item>
     );
-};
+});
+
+DropdownMenuItem.displayName = 'DropdownMenuItem';
 
 export default DropdownMenuItem;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuPortal.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuPortal.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 
+export type DropdownMenuPortalElement = ElementRef<typeof MenuPrimitive.Portal>;
 export type DropdownMenuPortalProps = {
   children: React.ReactNode;
-}
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Portal>;
 
-const DropdownMenuPortal = ({ children }:DropdownMenuPortalProps) => {
+const DropdownMenuPortal = forwardRef<DropdownMenuPortalElement, DropdownMenuPortalProps>(({ children, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuPortal should be used in the DropdownMenuRoot');
@@ -14,10 +15,12 @@ const DropdownMenuPortal = ({ children }:DropdownMenuPortalProps) => {
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Portal>
+        <MenuPrimitive.Portal ref={ref} {...props}>
             {children}
         </MenuPrimitive.Portal>
     );
-};
+});
+
+DropdownMenuPortal.displayName = 'DropdownMenuPortal';
 
 export default DropdownMenuPortal;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuRoot.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuRoot.tsx
@@ -1,26 +1,29 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import { customClassSwitcher } from '~/core';
 import clsx from 'clsx';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 
+export type DropdownMenuRootElement = ElementRef<typeof MenuPrimitive.Root>;
 export type DropdownMenuRootProps = {
   children: React.ReactNode;
   customRootClass?: string;
   className?: string;
-} & MenuPrimitiveProps.Root;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 
 const COMPONENT_NAME = 'DropdownMenu';
 
-const DropdownMenuRoot = ({ children, customRootClass, className }:DropdownMenuRootProps) => {
+const DropdownMenuRoot = forwardRef<DropdownMenuRootElement, DropdownMenuRootProps>(({ children, customRootClass, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
     return (
         <DropdownMenuContext.Provider value={{ rootClass }} >
-            <MenuPrimitive.Root className={clsx(`${rootClass}-root`, className)}>
+            <MenuPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, className)} {...props}>
                 {children}
             </MenuPrimitive.Root>
         </DropdownMenuContext.Provider>
     );
-};
+});
+
+DropdownMenuRoot.displayName = COMPONENT_NAME;
 
 export default DropdownMenuRoot;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuSub.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuSub.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 import clsx from 'clsx';
 
+export type DropdownMenuSubElement = ElementRef<typeof MenuPrimitive.Sub>;
 export type DropdownMenuSubProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Sub;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Sub>;
 
-const DropdownMenuSub = ({ children, className }:DropdownMenuSubProps) => {
+const DropdownMenuSub = forwardRef<DropdownMenuSubElement, DropdownMenuSubProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuSub should be used in the DropdownMenuRoot');
@@ -16,10 +17,12 @@ const DropdownMenuSub = ({ children, className }:DropdownMenuSubProps) => {
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Sub className={clsx(`${rootClass}-sub`, className)}>
+        <MenuPrimitive.Sub ref={ref} className={clsx(`${rootClass}-sub`, className)} {...props}>
             {children}
         </MenuPrimitive.Sub>
     );
-};
+});
+
+DropdownMenuSub.displayName = 'DropdownMenuSub';
 
 export default DropdownMenuSub;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuSubTrigger.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuSubTrigger.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 import clsx from 'clsx';
 
+export type DropdownMenuSubTriggerElement = ElementRef<typeof MenuPrimitive.Trigger>;
 export type DropdownMenuSubTriggerProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Trigger;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Trigger>;
 
-const DropdownMenuSubTrigger = ({ children, className }:DropdownMenuSubTriggerProps) => {
+const DropdownMenuSubTrigger = forwardRef<DropdownMenuSubTriggerElement, DropdownMenuSubTriggerProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuSubTrigger should be used in the DropdownMenuRoot');
@@ -16,10 +17,12 @@ const DropdownMenuSubTrigger = ({ children, className }:DropdownMenuSubTriggerPr
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Trigger className={clsx(`${rootClass}-sub-trigger`, className)}>
+        <MenuPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-sub-trigger`, className)} {...props}>
             {children}
         </MenuPrimitive.Trigger>
     );
-};
+});
+
+DropdownMenuSubTrigger.displayName = 'DropdownMenuSubTrigger';
 
 export default DropdownMenuSubTrigger;

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuTrigger.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuTrigger.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import MenuPrimitive, { MenuPrimitiveProps } from '~/core/primitives/Menu/MenuPrimitive';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
 import DropdownMenuContext from '../contexts/DropdownMenuContext';
 import clsx from 'clsx';
 
+export type DropdownMenuTriggerElement = ElementRef<typeof MenuPrimitive.Trigger>;
 export type DropdownMenuTriggerProps = {
   children: React.ReactNode;
   className?: string;
-} & MenuPrimitiveProps.Trigger;
+} & ComponentPropsWithoutRef<typeof MenuPrimitive.Trigger>;
 
-const DropdownMenuTrigger = ({ children, className }:DropdownMenuTriggerProps) => {
+const DropdownMenuTrigger = forwardRef<DropdownMenuTriggerElement, DropdownMenuTriggerProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(DropdownMenuContext);
     if (!context) {
         console.log('DropdownMenuTrigger should be used in the DropdownMenuRoot');
@@ -16,10 +17,12 @@ const DropdownMenuTrigger = ({ children, className }:DropdownMenuTriggerProps) =
     }
     const { rootClass } = context;
     return (
-        <MenuPrimitive.Trigger className={clsx(`${rootClass}-trigger`, className)}>
+        <MenuPrimitive.Trigger ref={ref} className={clsx(`${rootClass}-trigger`, className)} {...props}>
             {children}
         </MenuPrimitive.Trigger>
     );
-};
+});
+
+DropdownMenuTrigger.displayName = 'DropdownMenuTrigger';
 
 export default DropdownMenuTrigger;

--- a/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
+++ b/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DropdownMenu from '../DropdownMenu';
+
+const originalWarn = console.warn;
+const mockWarn = jest.fn();
+
+describe('DropdownMenu', () => {
+    beforeEach(() => {
+        console.warn = mockWarn;
+        mockWarn.mockClear();
+    });
+
+    afterEach(() => {
+        console.warn = originalWarn;
+    });
+
+    it('should warn when used directly and return null', () => {
+        const { container } = render(<DropdownMenu />);
+        expect(mockWarn).toHaveBeenCalledWith(
+            'Direct usage of DropdownMenu is not supported. Please use DropdownMenu.Root, DropdownMenu.Item instead.'
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('should forward refs correctly', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const triggerRef = React.createRef<HTMLButtonElement>();
+        const itemRef = React.createRef<HTMLButtonElement>();
+
+        render(
+            <DropdownMenu.Root ref={rootRef} defaultOpen>
+                <DropdownMenu.Trigger ref={triggerRef}>Open</DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                    <DropdownMenu.Content>
+                        <DropdownMenu.Item ref={itemRef} label="Profile">
+                            Profile
+                        </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(triggerRef.current).toBeInstanceOf(HTMLButtonElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    it('should render accessible menu items', () => {
+        render(
+            <DropdownMenu.Root defaultOpen>
+                <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                    <DropdownMenu.Content>
+                        <DropdownMenu.Item label="Profile">Profile</DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+        );
+
+        expect(screen.getByText('Profile')).toBeInTheDocument();
+        expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('should return null when Trigger used outside Root', () => {
+        const { container } = render(<DropdownMenu.Trigger>Open</DropdownMenu.Trigger>);
+        expect(container.firstChild).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- refactor DropdownMenu and subcomponents to use React.forwardRef with proper typing
- add unit tests for DropdownMenu ref forwarding and accessibility

## Testing
- `npm test`
- `npm run build:rollup`

