### PR TITLE
test: add a11y tests for Accordion

### DIFF
--- a/src/components/ui/Accordion/tests/Accordion.a11y.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.a11y.test.tsx
@@ -132,15 +132,19 @@ describe('Accordion accessibility', () => {
         const markup = renderToString(<TestAccordion defaultValue={[0]} />);
         const container = document.createElement('div');
         container.innerHTML = markup;
+        document.body.appendChild(container);
 
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        act(() => {
-            const root = hydrateRoot(container, <TestAccordion defaultValue={[0]} />);
-            root.unmount();
+        let root: ReturnType<typeof hydrateRoot>;
+        await act(async () => {
+            root = hydrateRoot(container, <TestAccordion defaultValue={[0]} />);
         });
+        act(() => root.unmount());
 
+        expect(errorSpy).not.toHaveBeenCalled();
         errorSpy.mockRestore();
+        document.body.removeChild(container);
     });
 
     test('supports multiple open panels and disabled triggers', async () => {


### PR DESCRIPTION
## Summary
- add comprehensive accessibility tests for Accordion covering keyboard control, ARIA state, controlled usage, and SSR

## Testing
- `npm test src/components/ui/Accordion/tests/Accordion.a11y.test.tsx`
- `npm run coverage -- src/components/ui/Accordion/tests/Accordion.a11y.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive accessibility test coverage for the Accordion component, validating keyboard interactions (Enter/Space, arrow keys), controlled and default open states, multiple open panels, disabled items, RTL support, SSR hydration, and semantic child usage. This strengthens accessibility compliance and reliability, helping prevent regressions without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->