### PR TITLE
test: cover Primitive asChild and forwarding

### DIFF
--- a/src/core/primitives/Primitive/index.tsx
+++ b/src/core/primitives/Primitive/index.tsx
@@ -15,6 +15,13 @@ const createPrimitiveComponent = (elementType: SupportedElement) => {
         const { asChild = false, children, ...elementProps } = props;
 
         if (asChild) {
+            if (React.isValidElement(children) && children.type === React.Fragment) {
+                console.warn(
+                    `Primitive.${elementType}: asChild prop does not support React.Fragment. Please provide a single element.`
+                );
+                return React.createElement(elementType, { ...elementProps, ref }, children);
+            }
+
             // Check if there's exactly one child and it's a valid element
             const childrenArray = React.Children.toArray(children);
             if (childrenArray.length !== 1 || !React.isValidElement(childrenArray[0])) {
@@ -25,13 +32,6 @@ const createPrimitiveComponent = (elementType: SupportedElement) => {
             }
 
             const child = childrenArray[0] as React.ReactElement;
-
-            if (child.type === React.Fragment) {
-                console.warn(
-                    `Primitive.${elementType}: asChild prop does not support React.Fragment. Please provide a single element.`
-                );
-                return React.createElement(elementType, { ...elementProps, ref }, children);
-            }
 
             // Merge refs if child already has one
             // TODO: This can be made into a utility function

--- a/src/core/primitives/Primitive/tests/Primitive.asChild.test.tsx
+++ b/src/core/primitives/Primitive/tests/Primitive.asChild.test.tsx
@@ -81,6 +81,20 @@ describe('Primitive asChild', () => {
         warnSpy.mockRestore();
     });
 
+    test('warns and renders host element when child is a top-level React.Fragment', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { container } = render(
+            <Primitive.div asChild>
+                <React.Fragment>
+                    <span />
+                </React.Fragment>
+            </Primitive.div>
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(container.firstElementChild?.tagName).toBe('DIV');
+        warnSpy.mockRestore();
+    });
+
     test('forwards controlled and uncontrolled value attributes', async () => {
         const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- guard against using React.Fragment with Primitive's `asChild`
- add exhaustive tests for `Primitive` prop/attribute forwarding, ref behavior, and invalid cases

## Testing
- `npm test src/core/primitives/Primitive/tests/Primitive.asChild.test.tsx`
- `npm test src/core/primitives/Primitive/tests/Primitive.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asChild behavior: warns when used with a Fragment and renders the wrapper element instead, avoiding invalid ref handling.
  * Added safeguards for null or multiple children: emits a warning and renders the wrapper element.
  * Ensures reliable forwarding of props, className, data attributes, and refs to a single child element.

* **Tests**
  * Added comprehensive tests covering asChild prop forwarding, fallback cases, controlled/uncontrolled inputs, and accessibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->