### PR TITLE
Run Storybook build and smoke tests in CI

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Build Storybook
         run: npm run build-storybook
       - name: Storybook smoke tests
-        run: npx storybook test --index-json ./storybook-static/index.json
+        run: npm run test-storybook

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,24 @@
+name: Storybook Build and Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+      - name: Build Storybook
+        run: npm run build-storybook
+      - name: Storybook smoke tests
+        run: npx storybook test --index-json ./storybook-static/index.json

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   storybook:
     runs-on: ubuntu-latest

--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -1,0 +1,11 @@
+import { within, userEvent } from '@storybook/testing-library';
+
+// Basic smoke test for each story. If a button exists, click it to ensure interactions
+// don't trigger runtime errors.
+export const run = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const button = canvas.queryByRole('button');
+  if (button) {
+    await userEvent.click(button);
+  }
+};

--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -4,7 +4,7 @@ import { within, userEvent } from '@storybook/testing-library';
 // don't trigger runtime errors.
 export const run = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  const button = canvas.queryByRole('button');
+  const [button] = canvas.queryAllByRole('button');
   if (button) {
     await userEvent.click(button);
   }

--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -1,9 +1,30 @@
+/**
+ * Basic smoke tests for Storybook stories.
+ *
+ * This configuration runs in CI via the Storybook test runner. It renders each
+ * story and performs a minimal interaction to surface runtime errors that unit
+ * tests might miss.
+ *
+ * What it covers:
+ *   - Verifies that stories render without throwing.
+ *   - Clicks the first button (if present) to catch simple interaction bugs.
+ *
+ * What it doesn't cover:
+ *   - Visual regressions or accessibility checks.
+ *   - Complex workflows that require multiple interactions.
+ *   - Stories that depend on network requests or auth; those may require mocks
+ *     or can be excluded from CI if flaky.
+ *
+ * This smoke test is a lightweight safety net and does not replace dedicated
+ * unit, integration, or visual testing.
+ */
 import { within, userEvent } from '@storybook/testing-library';
 
-// Basic smoke test for each story. If a button exists, click it to ensure interactions
-// don't trigger runtime errors.
+// If a button exists, click the first one to ensure the interaction doesn't trigger
+// runtime errors.
 export const run = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
+  // Use queryAllByRole so the test runner doesn't throw when multiple buttons are present.
   const [button] = canvas.queryAllByRole('button');
   if (button) {
     await userEvent.click(button);

--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -18,13 +18,17 @@
  * This smoke test is a lightweight safety net and does not replace dedicated
  * unit, integration, or visual testing.
  */
-import { within, userEvent } from '@storybook/testing-library';
-
 // If a button exists, click the first one to ensure the interaction doesn't trigger
 // runtime errors.
 export const run = async ({ canvasElement }) => {
+  // Import testing utilities inside the runner so that Storybook's jsdom
+  // environment is available. Importing at the module level throws because the
+  // package expects `location` to exist on the global object.
+  const { within, userEvent } = await import('@storybook/testing-library');
+
   const canvas = within(canvasElement);
-  // Use queryAllByRole so the test runner doesn't throw when multiple buttons are present.
+  // Use queryAllByRole so the test runner doesn't throw when multiple buttons
+  // are present.
   const [button] = canvas.queryAllByRole('button');
   if (button) {
     await userEvent.click(button);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sb": "storybook dev -p 6006",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test-storybook": "storybook test --index-json ./storybook-static/index.json",
+    "test-storybook": "npx @storybook/test-runner --index-json ./storybook-static/index.json",
     "build-css": "rollup -c rollup-css.config.js",
     "generate-tokens": "tsx ./src/tokenGen/index.js",
     "bundle-tokens": "rollup --config rollup-tokens.config.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "sb": "storybook dev -p 6006",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "test-storybook": "storybook test --index-json ./storybook-static/index.json",
     "build-css": "rollup -c rollup-css.config.js",
     "generate-tokens": "tsx ./src/tokenGen/index.js",
     "bundle-tokens": "rollup --config rollup-tokens.config.js",


### PR DESCRIPTION
## Summary
- add npm script and basic smoke test runner for Storybook stories
- run Storybook build and smoke tests in CI using Playwright

## Testing
- `npm test`
- `npm run build-storybook`
- `npm run test-storybook` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/@storybook%2fcli)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to build Storybook and run smoke tests on pull requests and the main branch.
  * Faster, more reliable runs via Node setup and browser dependency installation with caching.

* **Tests**
  * Added a lightweight Storybook smoke test that renders stories and exercises a basic UI interaction to catch runtime errors.
  * Added a script to run Storybook smoke tests locally against the built static output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->