### PR TITLE
Add Checkbox state tests and indeterminate support

### DIFF
--- a/src/components/ui/Checkbox/tests/Checkbox.states.test.tsx
+++ b/src/components/ui/Checkbox/tests/Checkbox.states.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as axe from 'axe-core';
+
+import Checkbox from '../Checkbox';
+import { ACCESSIBILITY_TEST_TAGS } from '~/setupTests';
+
+describe('Checkbox states', () => {
+    test('click toggles checked state and data-state attribute', async () => {
+        const user = userEvent.setup();
+        const { container } = render(
+            <Checkbox.Root>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button')!;
+        expect(button).toHaveAttribute('data-state', 'unchecked');
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'checked');
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    test('supports indeterminate state and updates to checked on click', async () => {
+        const user = userEvent.setup();
+        const { container } = render(
+            <Checkbox.Root defaultChecked={'indeterminate' as any}>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button')!;
+        expect(button).toHaveAttribute('data-state', 'indeterminate');
+        expect(button).toHaveAttribute('aria-checked', 'mixed');
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'checked');
+    });
+
+    test('controlled checked prop syncs with onCheckedChange and defaultChecked works', async () => {
+        const user = userEvent.setup();
+        const Controlled = () => {
+            const [checked, setChecked] = React.useState<boolean | 'indeterminate' | null>(false);
+            return (
+                <Checkbox.Root checked={checked} onCheckedChange={setChecked}>
+                    <Checkbox.Indicator />
+                </Checkbox.Root>
+            );
+        };
+        const { container, rerender } = render(<Controlled />);
+        let button = container.querySelector('button')!;
+        expect(button).toHaveAttribute('data-state', 'unchecked');
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'checked');
+
+        rerender(
+            <Checkbox.Root defaultChecked>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        button = container.querySelector('button')!;
+        expect(button).toHaveAttribute('data-state', 'checked');
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    test('form submission reflects value and disabled prevents submit/change events', async () => {
+        const user = userEvent.setup();
+        let submitted: Record<string, FormDataEntryValue> | undefined;
+        const handleSubmit = jest.fn((e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            const formData = new FormData(e.currentTarget);
+            submitted = Object.fromEntries(Array.from((formData as any).entries()));
+        });
+        const handleChange = jest.fn();
+        const { rerender } = render(
+            <form onSubmit={handleSubmit}>
+                <Checkbox.Root name="agree" value="yes" onCheckedChange={handleChange}>
+                    <Checkbox.Indicator />
+                </Checkbox.Root>
+                <button type="submit">Submit</button>
+            </form>
+        );
+        const checkbox = screen.getAllByRole('checkbox')[0];
+        await user.click(checkbox);
+        await user.click(screen.getByText('Submit'));
+        expect(handleChange).toHaveBeenCalledWith(true);
+        expect(submitted).toEqual({ agree: 'yes' });
+
+        handleChange.mockClear();
+        handleSubmit.mockClear();
+        submitted = undefined;
+        rerender(
+            <form onSubmit={handleSubmit}>
+                <Checkbox.Root name="agree" value="yes" disabled onCheckedChange={handleChange}>
+                    <Checkbox.Indicator />
+                </Checkbox.Root>
+                <button type="submit">Submit</button>
+            </form>
+        );
+        const disabledCheckbox = screen.getAllByRole('checkbox')[0];
+        await user.click(disabledCheckbox);
+        await user.click(screen.getByText('Submit'));
+        expect(handleChange).not.toHaveBeenCalled();
+        expect(submitted).toEqual({});
+    });
+
+    test('axe has no violations and checkbox has appropriate aria attributes', async () => {
+        const { container } = render(
+            <Checkbox.Root>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        const results = await axe.run(container, { runOnly: { type: 'tag', values: ACCESSIBILITY_TEST_TAGS } });
+        expect(results.violations.length).toBe(0);
+        const checkbox = screen.getAllByRole('checkbox')[0];
+        expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    test('asChild label preserves semantics and refs', async () => {
+        const user = userEvent.setup();
+        const ref = React.createRef<HTMLLabelElement>();
+        render(
+            <Checkbox.Root asChild ref={ref as any}>
+                <label data-testid="label">
+                    <Checkbox.Indicator />
+                    Label
+                </label>
+            </Checkbox.Root>
+        );
+        const label = screen.getByTestId('label');
+        expect(label).toHaveAttribute('role', 'checkbox');
+        expect(ref.current).toBe(label);
+        await user.click(label);
+        expect(label).toHaveAttribute('data-state', 'checked');
+    });
+
+    test('rtl dir works correctly', async () => {
+        const user = userEvent.setup();
+        const { container } = render(
+            <div dir="rtl">
+                <Checkbox.Root>
+                    <Checkbox.Indicator />
+                </Checkbox.Root>
+            </div>
+        );
+        const button = container.querySelector('button')!;
+        expect(button.closest('[dir="rtl"]')).not.toBeNull();
+        await user.click(button);
+        expect(button).toHaveAttribute('data-state', 'checked');
+    });
+
+    test('null checked prop results in indeterminate state', () => {
+        const { container } = render(
+            <Checkbox.Root checked={null as any}>
+                <Checkbox.Indicator />
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button')!;
+        expect(button).toHaveAttribute('data-state', 'indeterminate');
+        expect(button).toHaveAttribute('aria-checked', 'mixed');
+    });
+});

--- a/src/core/primitives/Checkbox/context/CheckboxPrimitiveContext.tsx
+++ b/src/core/primitives/Checkbox/context/CheckboxPrimitiveContext.tsx
@@ -3,8 +3,8 @@
 import React from 'react';
 
 export interface CheckboxPrimitiveContextProps {
-    isChecked: boolean,
-    setIsChecked: (value:boolean) => void,
+    isChecked: boolean | 'indeterminate' | null,
+    setIsChecked: (value: boolean | 'indeterminate' | null) => void,
     id?: string,
     required?: boolean,
     disabled?: boolean

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
@@ -11,7 +11,7 @@ export type CheckboxPrimitiveIndicatorProps = ComponentPropsWithoutRef<'span'> &
 const CheckboxPrimitiveIndicator = forwardRef<CheckboxPrimitiveIndicatorElement, CheckboxPrimitiveIndicatorProps>(({ children, className = '', ...props }, ref) => {
     const { isChecked } = React.useContext(CheckboxPrimitiveContext);
 
-    if (!isChecked) return null;
+    if (isChecked !== true) return null;
 
     return <span ref={ref} className={className} {...props}>{children}</span>;
 });

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveRoot.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef, useRef, useEffect } from 'react';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 import CheckboxPrimitiveTrigger from './CheckboxPrimitiveTrigger';
 import useControllableState from '~/core/hooks/useControllableState';
@@ -8,43 +8,53 @@ import useControllableState from '~/core/hooks/useControllableState';
 export type CheckboxPrimitiveRootElement = ElementRef<typeof CheckboxPrimitiveTrigger>;
 export type CheckboxPrimitiveRootProps = {
     children: React.ReactNode;
-    checked?: boolean;
-    defaultChecked?: boolean;
-    onCheckedChange?: () => void;
+    checked?: boolean | 'indeterminate' | null;
+    defaultChecked?: boolean | 'indeterminate' | null;
+    onCheckedChange?: (value: boolean | 'indeterminate' | null) => void;
     name?: string;
     value?: string;
     id?: string;
 } & ComponentPropsWithoutRef<typeof CheckboxPrimitiveTrigger>;
 
-const CheckboxPrimitiveRoot = forwardRef<CheckboxPrimitiveRootElement, CheckboxPrimitiveRootProps>(({ children, className = '', checked, defaultChecked = false, onCheckedChange, disabled, required, name, value, id, ...props }, ref) => {
-    const [isChecked, setIsChecked] = useControllableState(
-        checked,
-        defaultChecked,
-        onCheckedChange
-    );
+const CheckboxPrimitiveRoot = forwardRef<CheckboxPrimitiveRootElement, CheckboxPrimitiveRootProps>(
+    ({ children, className = '', checked, defaultChecked = false, onCheckedChange, disabled, required, name, value, id, ...props }, ref) => {
+        const [isChecked, setIsChecked] = useControllableState<boolean | 'indeterminate' | null>(
+            checked,
+            defaultChecked,
+            onCheckedChange
+        );
 
-    const contextValues = {
-        isChecked,
-        setIsChecked,
-        id,
-        required,
-        disabled
-    };
+        const inputRef = useRef<HTMLInputElement>(null);
+        useEffect(() => {
+            if (inputRef.current) {
+                inputRef.current.indeterminate = isChecked === 'indeterminate' || isChecked === null;
+            }
+        }, [isChecked]);
 
-    return <CheckboxPrimitiveContext.Provider value={contextValues}>
-        <CheckboxPrimitiveTrigger ref={ref} className={className} disabled={disabled} required={required} {...props}>
-            {children}
-        </CheckboxPrimitiveTrigger>
-        <input
-            type="checkbox" style={{
-                position: 'absolute',
-                pointerEvents: 'none',
-                opacity: 0,
-                margin: 0,
-                transform: 'translateX(-100%)'
-            }} name={name} value={value} checked={isChecked} disabled={disabled} required={required} readOnly />
-    </CheckboxPrimitiveContext.Provider>;
-});
+        const contextValues = {
+            isChecked,
+            setIsChecked,
+            id,
+            required,
+            disabled
+        };
+
+        return <CheckboxPrimitiveContext.Provider value={contextValues}>
+            <CheckboxPrimitiveTrigger ref={ref} className={className} disabled={disabled} required={required} {...props}>
+                {children}
+            </CheckboxPrimitiveTrigger>
+            <input
+                ref={inputRef}
+                type="checkbox" style={{
+                    position: 'absolute',
+                    pointerEvents: 'none',
+                    opacity: 0,
+                    margin: 0,
+                    transform: 'translateX(-100%)'
+                }} name={name} value={value} checked={isChecked === true} disabled={disabled} required={required} readOnly />
+        </CheckboxPrimitiveContext.Provider>;
+    }
+);
 
 CheckboxPrimitiveRoot.displayName = 'CheckboxPrimitiveRoot';
 

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
@@ -7,10 +7,34 @@ import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
 export type CheckboxPrimitiveTriggerElement = ElementRef<typeof ButtonPrimitive>;
 export type CheckboxPrimitiveTriggerProps = ComponentPropsWithoutRef<typeof ButtonPrimitive>;
 
-const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, CheckboxPrimitiveTriggerProps>(({ children, className = '', ...props }, ref) => {
-    const { isChecked, setIsChecked, id, required, disabled } = React.useContext(CheckboxPrimitiveContext);
-    return <ButtonPrimitive ref={ref} onClick={() => setIsChecked(!isChecked)} role="checkbox" id={id} aria-checked={isChecked} aria-required={required} data-checked={isChecked} disabled={disabled} data-disabled={disabled} className={className} {...props}>{children}</ButtonPrimitive>;
-});
+const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, CheckboxPrimitiveTriggerProps>(
+    ({ children, className = '', ...props }, ref) => {
+        const { isChecked, setIsChecked, id, required, disabled } = React.useContext(CheckboxPrimitiveContext);
+        const toggleChecked = () => {
+            const next = isChecked === 'indeterminate' || isChecked === null ? true : !isChecked;
+            setIsChecked(next);
+        };
+        const dataState = isChecked === 'indeterminate' || isChecked === null
+            ? 'indeterminate'
+            : isChecked ? 'checked' : 'unchecked';
+        const ariaChecked: boolean | 'mixed' =
+            isChecked === 'indeterminate' || isChecked === null ? 'mixed' : isChecked;
+        return <ButtonPrimitive
+            ref={ref}
+            onClick={toggleChecked}
+            role="checkbox"
+            id={id}
+            aria-checked={ariaChecked}
+            aria-required={required}
+            data-checked={isChecked as any}
+            data-state={dataState}
+            disabled={disabled}
+            data-disabled={disabled}
+            className={className}
+            {...props}
+        >{children}</ButtonPrimitive>;
+    }
+);
 
 CheckboxPrimitiveTrigger.displayName = 'CheckboxPrimitiveTrigger';
 


### PR DESCRIPTION
## Summary
- support tri-state Checkbox with `data-state` and proper `aria-checked`
- ensure hidden input reflects indeterminate state
- add comprehensive tests for checkbox state transitions, form participation, a11y, and RTL

## Testing
- `npm test`