### PR TITLE
test: add portal test utilities

### DIFF
--- a/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
+++ b/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithPortal, assertFocusReturn } from '~/test-utils/portal';
 import '@testing-library/jest-dom';
 import DropdownMenu from '../DropdownMenu';
 
@@ -66,5 +68,25 @@ describe('DropdownMenu', () => {
     it('should return null when Trigger used outside Root', () => {
         const { container } = render(<DropdownMenu.Trigger>Open</DropdownMenu.Trigger>);
         expect(container.firstChild).toBeNull();
+    });
+
+    it('renders in portal and returns focus when closed', async () => {
+        const user = userEvent.setup();
+        const { getByText, portalRoot, cleanup } = renderWithPortal(
+            <DropdownMenu.Root>
+                <DropdownMenu.Trigger>Menu</DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                    <DropdownMenu.Content>
+                        <DropdownMenu.Item label="Profile">Profile</DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+        );
+
+        await user.click(getByText('Menu'));
+        expect(portalRoot).toContainElement(getByText('Profile'));
+        await user.keyboard('{Escape}');
+        assertFocusReturn(getByText('Menu'));
+        cleanup();
     });
 });

--- a/src/components/ui/Tooltip/tests/Tooltip.behavior.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.behavior.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderWithPortal, assertFocusReturn } from '~/test-utils/portal';
 import Tooltip from '../Tooltip';
 import axe from 'axe-core';
 
@@ -94,5 +95,22 @@ describe('Tooltip interactions', () => {
         const trigger = screen.getByText('RTL');
         await userEvent.hover(trigger);
         expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+    });
+
+    test('portal renders tooltip content and focus is restored on escape', async () => {
+        const user = userEvent.setup();
+        const { getByText, cleanup } = renderWithPortal(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Tip</Tooltip.Trigger>
+                <Tooltip.Content>content</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        const trigger = getByText('Tip');
+        trigger.focus();
+        await screen.findByRole('tooltip');
+        await user.keyboard('{Escape}');
+        assertFocusReturn(trigger);
+        cleanup();
     });
 });

--- a/src/test-utils/portal.ts
+++ b/src/test-utils/portal.ts
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export function renderWithPortal(ui: React.ReactElement) {
+    const portalRoot = document.createElement('div');
+    portalRoot.setAttribute('id', 'rad-ui-theme-container');
+    document.body.appendChild(portalRoot);
+    const result = render(ui);
+    return {
+        ...result,
+        portalRoot,
+        cleanup: () => {
+            result.unmount();
+            portalRoot.remove();
+        }
+    };
+}
+
+export async function assertFocusTrap(container: HTMLElement) {
+    const user = userEvent.setup();
+    const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+    );
+    if (focusable.length === 0) {
+        throw new Error('No focusable elements found in container');
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    first.focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(last);
+
+    last.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(first);
+}
+
+export function assertFocusReturn(element: HTMLElement) {
+    expect(element).toHaveFocus();
+}
+
+export function assertScrollLock() {
+    expect(document.body.getAttribute('data-scroll-locked')).toBe('1');
+}
+
+export function assertScrollUnlock() {
+    expect(document.body.getAttribute('data-scroll-locked')).toBeNull();
+}


### PR DESCRIPTION
## Summary
- add shared portal test helpers for mounting, focus return, and scroll lock
- verify portal mounting and focus behavior in Dialog, DropdownMenu, and Tooltip tests

## Testing
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded accessibility and interaction test coverage for dialogs, dropdown menus, and tooltips rendered in portals.
  - Validates keyboard focus trapping, focus return after close (including Escape), and scroll lock/unlock behavior to better mirror real user scenarios.
  - Introduces shared testing utilities to render portal content and assert focus and scroll states, improving test reliability and consistency.
  - No user-facing changes; these improvements strengthen quality assurance without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->