### PR TITLE
test: capture radio warning

### DIFF
--- a/src/core/primitives/Radio/tests/Radio.test.tsx
+++ b/src/core/primitives/Radio/tests/Radio.test.tsx
@@ -41,9 +41,14 @@ describe('RadioPrimitive', () => {
     });
 
     it('supports asChild prop (renders without error)', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         render(<RadioPrimitive {...baseProps} asChild />);
         const radio = screen.getByRole('radio');
         expect(radio).toBeInTheDocument();
+        expect(warnSpy).toHaveBeenCalledWith(
+            'Primitive.input: asChild prop requires exactly one valid child element.'
+        );
+        warnSpy.mockRestore();
     });
 
     it('forwards refs', () => {


### PR DESCRIPTION
## Summary
- assert and silence `Primitive.input` warning when `asChild` has no child

## Testing
- `npm test src/core/primitives/Radio/tests/Radio.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the Radio component to verify a console warning is emitted when the asChild prop is used incorrectly.
  * Ensures the component still renders as expected while validating warning behavior.
  * Enhances confidence in developer-facing warnings without impacting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->