### PR TITLE
build: exclude storybook files from rollup build

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -27,7 +27,10 @@ const components = getComponentDirectories();
 const typescriptPluginInstance = typescript({
     tsconfig: './tsconfig.json',
     sourceMap: false,
-    outDir: 'dist/temp-cleanup' // Match Rollup's output directory
+    outDir: 'dist/temp-cleanup', // Match Rollup's output directory
+    // Storybook stories are only for interactive docs and testing; excluding them
+    // keeps the published package lean and avoids unnecessary build work.
+    exclude: ['**/*.stories.*']
 });
 const aliasPluginInstance = alias({
     entries: [


### PR DESCRIPTION
## Summary
- ignore `*.stories.*` files during rollup compile to keep builds lean
- document why storybook stories are excluded from the build

## Testing
- `npm run build:rollup`
- `grep -n "stories" /tmp/build.log | head`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build to exclude non-essential story assets from the package, reducing the published size and improving download and installation times.
  * Speeds up CI and local builds by skipping unnecessary files during type processing.
  * No functional changes to the library or API; existing behavior remains unchanged for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->