### PR TITLE
build: exclude storybook files from rollup build

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -27,7 +27,10 @@ const components = getComponentDirectories();
 const typescriptPluginInstance = typescript({
     tsconfig: './tsconfig.json',
     sourceMap: false,
-    outDir: 'dist/temp-cleanup' // Match Rollup's output directory
+    outDir: 'dist/temp-cleanup', // Match Rollup's output directory
+    // Storybook stories are only for interactive docs and testing; excluding them
+    // keeps the published package lean and avoids unnecessary build work.
+    exclude: ['**/*.stories.*']
 });
 const aliasPluginInstance = alias({
     entries: [


### PR DESCRIPTION
## Summary
- ignore `*.stories.*` files during rollup compile to keep builds lean
- document why storybook stories are excluded from the build

## Testing
- `npm run build:rollup`
- `grep -n "stories" /tmp/build.log | head`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to exclude story files from TypeScript processing, reducing build time and avoiding unnecessary type-checking of non-production files.
  * Improves build reliability and reduces noise from development-only files without changing the app’s behavior or public API.
  * No impact on input/output paths or distributed bundle; purely a build optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->