### PR TITLE
Silence Primitive asChild warning in tests

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -32,4 +32,14 @@ console.error = (...args: unknown[]) => {
     originalError(...(args as Parameters<typeof originalError>));
 };
 
+// Silence specific console warnings that are noisy in tests
+const originalWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+    const firstArg = String(args[0]);
+    if (firstArg.includes('asChild prop requires exactly one valid child element')) {
+        return;
+    }
+    originalWarn(...(args as Parameters<typeof originalWarn>));
+};
+
 export const ACCESSIBILITY_TEST_TAGS = ['wcag21a', 'wcag21aa'];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined test output by suppressing a specific repetitive warning from third-party components while preserving other warnings. Existing handling for “not wrapped in act(...)” remains unchanged. This reduces noise in CI and local runs, making failures easier to spot. No changes to public APIs or application behavior; adjustments are limited to the test harness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->