### PR TITLE
ci: run lint and tests only on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/**'
-      - 'styles/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'scripts/**'
-      - 'rollup.config.cjs'
-      - 'rollup-css.config.cjs'
-      - 'rollup-tokens.config.cjs'
-      - 'tsconfig.json'
-      - 'postcss.config.js'
-      - '.changeset/**'
-      - '.github/workflows/**'
   pull_request:
     branches: [ main, security-fixes ]
     paths:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to run linting and tests only on pull requests, reducing redundant runs on direct pushes.
  * Pull request validation remains active for targeted branches, ensuring consistent quality checks while streamlining pipelines.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->