### PR TITLE
ci: release only on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  check:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.head_repository.full_name == github.repository
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      release: ${{ steps.bump.outputs.release }}
+
+    steps:
+      - name: Checkout (pinned SHA, minimal history)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Check for version bump
+        id: bump
+        run: |
+          prev=$(git show HEAD^:package.json | jq -r .version)
+          curr=$(jq -r .version package.json)
+          if [ "$prev" != "$curr" ]; then
+            echo "release=true" >> $GITHUB_OUTPUT
+          else
+            echo "release=false" >> $GITHUB_OUTPUT
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.release == 'true'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline to publish only when a new version is detected, ensuring accurate, intentional releases.
  * Existing publish steps are preserved and now run conditionally after a preliminary check.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->