### PR TITLE
Add snapOnStep, smallStep support for NumberField

### DIFF
--- a/.changeset/ninety-cats-pull.md
+++ b/.changeset/ninety-cats-pull.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+AddedsnapOnStep, smallStep support for NumberField

--- a/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
+++ b/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
@@ -10,6 +10,7 @@ export type NumberFieldContextType = {
   readOnly?: boolean;
   required?: boolean;
   rootClass?: string;
+  locale?: string;
 };
 
 const NumberFieldContext = React.createContext<NumberFieldContextType | null>(null);

--- a/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
+++ b/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 export type NumberFieldContextType = {
   inputValue: number|'';
-  handleOnChange: (input: number|'') => void;
-  handleStep: (opts: { direction: 'increment' | 'decrement'; type: 'small' | 'large' }) => void;
+  handleOnChange: (input: number) => void;
+  handleStep: (opts: { direction: 'increment' | 'decrement'; type: 'small' | 'normal' | 'large' }) => void;
   id?: string;
   name?: string;
   disabled?: boolean;

--- a/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
+++ b/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export type NumberFieldContextType = {
   inputValue: number|'';
-  handleOnChange: (input: number) => void;
+  handleOnChange: (input: number | '') => void;
   handleStep: (opts: { direction: 'increment' | 'decrement'; type: 'small' | 'normal' | 'large' }) => void;
   id?: string;
   name?: string;

--- a/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldDecrement.tsx
@@ -15,7 +15,7 @@ const NumberFieldDecrement = forwardRef<NumberFieldDecrementElement, NumberField
     return (
         <button
             ref={ref}
-            onClick={() => handleStep({ direction: 'decrement', type: 'small' })}
+            onClick={() => handleStep({ direction: 'decrement', type: 'normal' })}
             className={clsx(`${rootClass}-decrement`, className)}
             disabled={disabled || readOnly}
             type="button"

--- a/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldIncrement.tsx
@@ -16,7 +16,7 @@ const NumberFieldIncrement = forwardRef<NumberFieldIncrementElement, NumberField
     return (
         <button
             ref={ref}
-            onClick={() => handleStep({ direction: 'increment', type: 'small' })}
+            onClick={() => handleStep({ direction: 'increment', type: 'normal' })}
             className={clsx(`${rootClass}-increment`, className)}
             disabled={disabled || readOnly}
             type="button"

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -40,13 +40,21 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
             event.preventDefault();
             handleStep({ direction: 'decrement', type: 'large' });
         }
+        if (event.key === 'ArrowUp' && event.altKey) {
+            event.preventDefault();
+            handleStep({ direction: 'increment', type: 'small' });
+        }
+        if (event.key === 'ArrowDown' && event.altKey) {
+            event.preventDefault();
+            handleStep({ direction: 'decrement', type: 'small' });
+        }
     };
     return (
         <input
             ref={ref}
             type="number"
             onKeyDown={handleKeyDown}
-            value={inputValue === '' ? '' : inputValue}
+            value={inputValue}
             onChange={(e) => { const val = e.target.value; handleOnChange(val === '' ? '' : Number(val)); }}
             id={id}
             name={name}

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -26,11 +26,11 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'ArrowUp' && !event.shiftKey) {
             event.preventDefault();
-            handleStep({ direction: 'increment', type: 'small' });
+            handleStep({ direction: 'increment', type: 'normal' });
         }
         if (event.key === 'ArrowDown' && !event.shiftKey) {
             event.preventDefault();
-            handleStep({ direction: 'decrement', type: 'small' });
+            handleStep({ direction: 'decrement', type: 'normal' });
         }
         if (event.key === 'ArrowUp' && event.shiftKey) {
             event.preventDefault();

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -49,30 +49,14 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
             event.preventDefault();
             handleStep({ direction: 'decrement', type: 'small' });
         }
-        const allowedKeys = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
-
-        // Allow digits
-        if (event.key >= '0' && event.key <= '9') return;
-
-        // Allow one dot if not present
-        if (event.key === '.' && !event.currentTarget.value.includes('.')) return;
-
-        // Allow minus only at start
-        if (event.key === '-' && event.currentTarget.selectionStart === 0 && !event.currentTarget.value.includes('-')) return;
-
-        // Allow navigation keys
-        if (allowedKeys.includes(event.key)) return;
-
-        // Prevent other keys
-        event.preventDefault();
     };
     return (
         <input
             ref={ref}
-            type="text"
+            type="number"
             onKeyDown={handleKeyDown}
             value={inputValue}
-            onChange={(e) => { const val = e.target.value; handleOnChange(val); }}
+            onChange={(e) => { const val = e.target.value; handleOnChange(val === '' ? '' : Number(val)); }}
             id={id}
             name={name}
             disabled={disabled}

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -20,6 +20,7 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
         disabled,
         readOnly,
         required,
+        locale,
         rootClass
     } = context;
 

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -49,20 +49,22 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
             event.preventDefault();
             handleStep({ direction: 'decrement', type: 'small' });
         }
-        const allowedKeys = ["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Tab"];
+        const allowedKeys = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
 
-    // Allow digits
-    if (event.key >= "0" && event.key <= "9") return;
+        // Allow digits
+        if (event.key >= '0' && event.key <= '9') return;
 
-    // Allow one dot if not present
-    if (event.key === "." && !event.currentTarget.value.includes(".")) return;
+        // Allow one dot if not present
+        if (event.key === '.' && !event.currentTarget.value.includes('.')) return;
 
-    // Allow minus only at start
-    if (event.key === "-" && event.currentTarget.selectionStart === 0 && !event.currentTarget.value.includes("-")) return;
+        // Allow minus only at start
+        if (event.key === '-' && event.currentTarget.selectionStart === 0 && !event.currentTarget.value.includes('-')) return;
 
-    // Allow navigation keys
-    if (allowedKeys.includes(event.key)) return;
+        // Allow navigation keys
+        if (allowedKeys.includes(event.key)) return;
 
+        // Prevent other keys
+        event.preventDefault();
     };
     return (
         <input
@@ -70,7 +72,7 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
             type="text"
             onKeyDown={handleKeyDown}
             value={inputValue}
-            onChange={(e) => { const val = e.target.value; handleOnChange(val) }}
+            onChange={(e) => { const val = e.target.value; handleOnChange(val); }}
             id={id}
             name={name}
             disabled={disabled}

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -49,14 +49,28 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
             event.preventDefault();
             handleStep({ direction: 'decrement', type: 'small' });
         }
+        const allowedKeys = ["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Tab"];
+
+    // Allow digits
+    if (event.key >= "0" && event.key <= "9") return;
+
+    // Allow one dot if not present
+    if (event.key === "." && !event.currentTarget.value.includes(".")) return;
+
+    // Allow minus only at start
+    if (event.key === "-" && event.currentTarget.selectionStart === 0 && !event.currentTarget.value.includes("-")) return;
+
+    // Allow navigation keys
+    if (allowedKeys.includes(event.key)) return;
+
     };
     return (
         <input
             ref={ref}
-            type="number"
+            type="text"
             onKeyDown={handleKeyDown}
             value={inputValue}
-            onChange={(e) => { const val = e.target.value; handleOnChange(val === '' ? '' : Number(val)); }}
+            onChange={(e) => { const val = e.target.value; handleOnChange(val) }}
             id={id}
             name={name}
             disabled={disabled}

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -26,12 +26,16 @@ export type NumberFieldRootProps = {
 
 const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep = 10, step = 1, smallStep = 0.1, snapOnStep = false, locale, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
-    const [inputValue, setInputValue] = useControllableState<number>(
+    const [inputValue, setInputValue] = useControllableState<number | ''>(
         value,
         defaultValue,
         onValueChange);
 
-    const handleOnChange = (input: number) => {
+    const handleOnChange = (input: number | '') => {
+        if (input === '') {
+            setInputValue('');
+            return;
+        }
         if (max !== undefined && input > max) {
             setInputValue(max);
             return;
@@ -50,11 +54,11 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
             let nextValue: number;
 
             // Handle empty input
-            // if (prev === '' || prev === null) {
-            //     temp = min !== undefined ? min : 0;
-            // } else {
-            temp = Number(prev);
-            // }
+            if (prev === '' || prev === null) {
+                temp = min !== undefined ? min : 0;
+            } else {
+                temp = Number(prev);
+            }
 
             // Round to nearest step
             if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) {

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -51,7 +51,7 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
     const applyStep = (amount: number) => {
         setInputValue((prev) => {
             let temp: number;
-            let nextValue: number;
+            let nextValue: number ;
 
             // Handle empty input
             if (prev === '' || prev === null) {
@@ -60,20 +60,21 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
                 temp = Number(prev);
             }
 
-            if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) { temp = Math.round(temp / largeStep) * largeStep; }
+            // Round to nearest step
+            if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) { 
+                temp = Math.round(temp / largeStep) * largeStep;
+             }
 
-            // Find decimal places in amount only
             const amountDecimals = (amount.toString().split('.')[1] || '').length;
-            if (amountDecimals === 0) {
-                nextValue = temp + amount;
-            }
-            else{
-            const factor = Math.pow(10, amountDecimals);
+            const tempDecimals = (temp.toString().split('.')[1] || '').length;
+            const decimal = amountDecimals > tempDecimals ? amountDecimals : tempDecimals;
 
-            // Scale value to integer, apply step, then scale back
-            let scaledValue =  Math.round(temp * factor) + Math.round(amount * factor);
-             nextValue = scaledValue / factor;
-            }
+            // multiply temp and amount with same decimal count to remove decimal places
+            nextValue = (temp*Math.pow(10,decimal)) + (amount*Math.pow(10,decimal));
+
+            // divide nextValue by same decimal count
+            nextValue = nextValue / Math.pow(10,decimal);
+           
 
             // Clamp to min/max
             if (max !== undefined && nextValue > max) return max;

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -49,30 +49,29 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
     };
     const applyStep = (amount: number) => {
         setInputValue((prev) => {
-            let temp = prev;
-            if (temp === '') {
-                if (min !== undefined) {
-                    temp = min;
-                } else {
-                    temp = -1;
-                }
+            let temp: number;
+
+            // Handle empty input
+            if (prev === '' || prev === null) {
+                temp = min !== undefined ? min : 0;
+            } else {
+                temp = Number(prev);
             }
 
-            const tempDec = (temp.toString().split('.')[1] || '').length;
-            const amountDec = (amount.toString().split('.')[1] || '').length;
-            const decimals = Math.max(tempDec, amountDec);
-            const factor = Math.pow(10, decimals);
-            const scaled = Math.round(temp * factor) + amount * factor;
-            let nextValue = scaled / factor;
-            nextValue = snapOnStep ? Math.round(nextValue / step) * step : nextValue;
+            console.log(temp % largeStep);
+            if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) { temp = Math.round(temp / largeStep) * largeStep; }
 
-            if (max !== undefined && nextValue > max) {
-                return max;
-            }
+            // Find decimal places in amount only
+            const amountDecimals = (amount.toString().split('.')[1] || '').length;
+            const factor = Math.pow(10, amountDecimals);
 
-            if (min !== undefined && nextValue < min) {
-                return min;
-            }
+            // Scale value to integer, apply step, then scale back
+            const scaledValue = temp * factor + amount;
+            const nextValue = scaledValue / factor;
+
+            // Clamp to min/max
+            if (max !== undefined && nextValue > max) return max;
+            if (min !== undefined && nextValue < min) return min;
 
             return nextValue;
         });

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -16,6 +16,7 @@ export type NumberFieldRootProps = {
     largeStep?: number
     smallStep?: number
     snapOnStep?: boolean
+    locale?: string
     min?: number
     max?: number
     disabled?: boolean
@@ -23,7 +24,7 @@ export type NumberFieldRootProps = {
     required?: boolean
 } & ComponentPropsWithoutRef<'div'>;
 
-const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep = 10, step = 1, smallStep = 0.1, snapOnStep = false, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
+const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep = 10, step = 1, smallStep = 0.1, snapOnStep = false, locale, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
     const [inputValue, setInputValue] = useControllableState<number | ''>(
         value,
@@ -50,6 +51,7 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
     const applyStep = (amount: number) => {
         setInputValue((prev) => {
             let temp: number;
+            let nextValue: number;
 
             // Handle empty input
             if (prev === '' || prev === null) {
@@ -58,16 +60,20 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
                 temp = Number(prev);
             }
 
-            console.log(temp % largeStep);
             if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) { temp = Math.round(temp / largeStep) * largeStep; }
 
             // Find decimal places in amount only
             const amountDecimals = (amount.toString().split('.')[1] || '').length;
+            if (amountDecimals === 0) {
+                nextValue = temp + amount;
+            }
+            else{
             const factor = Math.pow(10, amountDecimals);
 
             // Scale value to integer, apply step, then scale back
-            const scaledValue = temp * factor + amount;
-            const nextValue = scaledValue / factor;
+            let scaledValue =  Math.round(temp * factor) + Math.round(amount * factor);
+             nextValue = scaledValue / factor;
+            }
 
             // Clamp to min/max
             if (max !== undefined && nextValue > max) return max;
@@ -112,6 +118,7 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
         disabled,
         readOnly,
         required,
+        locale,
         rootClass
     };
 

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -26,16 +26,12 @@ export type NumberFieldRootProps = {
 
 const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep = 10, step = 1, smallStep = 0.1, snapOnStep = false, locale, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
-    const [inputValue, setInputValue] = useControllableState<number | ''>(
+    const [inputValue, setInputValue] = useControllableState<number>(
         value,
         defaultValue,
         onValueChange);
 
-    const handleOnChange = (input: number| '') => {
-        if (input === '') {
-            setInputValue('');
-            return;
-        }
+    const handleOnChange = (input: number) => {
         if (max !== undefined && input > max) {
             setInputValue(max);
             return;
@@ -51,30 +47,31 @@ const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>
     const applyStep = (amount: number) => {
         setInputValue((prev) => {
             let temp: number;
-            let nextValue: number ;
+            let nextValue: number;
 
             // Handle empty input
-            if (prev === '' || prev === null) {
-                temp = min !== undefined ? min : 0;
-            } else {
-                temp = Number(prev);
-            }
+            // if (prev === '' || prev === null) {
+            //     temp = min !== undefined ? min : 0;
+            // } else {
+            temp = Number(prev);
+            // }
 
             // Round to nearest step
-            if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) { 
+            if (temp % largeStep != 0 && snapOnStep && largeStep === Math.abs(amount)) {
                 temp = Math.round(temp / largeStep) * largeStep;
-             }
+            }
 
             const amountDecimals = (amount.toString().split('.')[1] || '').length;
             const tempDecimals = (temp.toString().split('.')[1] || '').length;
             const decimal = amountDecimals > tempDecimals ? amountDecimals : tempDecimals;
 
             // multiply temp and amount with same decimal count to remove decimal places
-            nextValue = (temp*Math.pow(10,decimal)) + (amount*Math.pow(10,decimal));
+            nextValue = (temp * Math.pow(10, decimal)) + (amount * Math.pow(10, decimal));
 
             // divide nextValue by same decimal count
-            nextValue = nextValue / Math.pow(10,decimal);
-           
+            nextValue = nextValue / Math.pow(10, decimal);
+            const factor = Math.pow(10, decimal);
+            nextValue = (Math.round(temp * factor) + Math.round(amount * factor)) / factor;
 
             // Clamp to min/max
             if (max !== undefined && nextValue > max) return max;

--- a/src/components/ui/NumberField/stories/NumberField.stories.tsx
+++ b/src/components/ui/NumberField/stories/NumberField.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Basic = () => (
     <SandboxEditor>
-        <NumberField.Root defaultValue={5} step={1} min={-10} max={110} largeStep={5} snapOnStep={true}>
+        <NumberField.Root defaultValue={5} step={1} min={-10} max={110} largeStep={5}>
             <NumberField.Decrement>-</NumberField.Decrement>
             <NumberField.Input />
             <NumberField.Increment>+</NumberField.Increment>

--- a/src/components/ui/NumberField/stories/NumberField.stories.tsx
+++ b/src/components/ui/NumberField/stories/NumberField.stories.tsx
@@ -21,7 +21,7 @@ export const Controlled = () => {
     const [value, setValue] = React.useState<number | ''>(3);
     return (
         <SandboxEditor>
-            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} min={0} max={10} largeStep={5}>
+            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} min={-10} max={10} snapOnStep={true} largeStep={5}>
                 <NumberField.Decrement>-</NumberField.Decrement>
                 <NumberField.Input />
                 <NumberField.Increment>+</NumberField.Increment>

--- a/src/components/ui/NumberField/stories/NumberField.stories.tsx
+++ b/src/components/ui/NumberField/stories/NumberField.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Basic = () => (
     <SandboxEditor>
-        <NumberField.Root defaultValue={5} step={1} min={-10} max={110} largeStep={5}>
+        <NumberField.Root defaultValue={5} step={1} min={-10} max={110} largeStep={5} snapOnStep={true}>
             <NumberField.Decrement>-</NumberField.Decrement>
             <NumberField.Input />
             <NumberField.Increment>+</NumberField.Increment>
@@ -21,7 +21,7 @@ export const Controlled = () => {
     const [value, setValue] = React.useState<number | ''>(3);
     return (
         <SandboxEditor>
-            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} snapOnStep={true} largeStep={5}>
+            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} largeStep={5}>
                 <NumberField.Decrement>-</NumberField.Decrement>
                 <NumberField.Input />
                 <NumberField.Increment>+</NumberField.Increment>

--- a/src/components/ui/NumberField/stories/NumberField.stories.tsx
+++ b/src/components/ui/NumberField/stories/NumberField.stories.tsx
@@ -21,7 +21,7 @@ export const Controlled = () => {
     const [value, setValue] = React.useState<number | ''>(3);
     return (
         <SandboxEditor>
-            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} min={-10} max={10} snapOnStep={true} largeStep={5}>
+            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} snapOnStep={true} largeStep={5}>
                 <NumberField.Decrement>-</NumberField.Decrement>
                 <NumberField.Input />
                 <NumberField.Increment>+</NumberField.Increment>


### PR DESCRIPTION
closes #1599 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NumberField adds locale, smallStep, and snapOnStep options; stepping supports 'small' | 'normal' | 'large' with improved decimal-accurate increments, snapping to large-step multiples, and min/max clamping.
  - ArrowUp/Down now use "normal" step; Alt+ArrowUp/Down perform small steps; Increment/Decrement controls default to "normal".

- **Documentation**
  - Controlled example updated (min/max removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->