### PR TITLE
NumberField: Add locale support for number formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@radui/ui",
-  "version": "0.0.47",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@radui/ui",
-      "version": "0.0.47",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.27.4",

--- a/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
+++ b/src/components/ui/NumberField/contexts/NumberFieldContext.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 export type NumberFieldContextType = {
   inputValue: number|'';
-  handleOnChange: (input: number|'') => void;
+  formattedValue: string;
+  locale?: string;
+  handleOnChange: (input: string) => void;
   handleStep: (opts: { direction: 'increment' | 'decrement'; type: 'small' | 'large' }) => void;
   id?: string;
   name?: string;

--- a/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldInput.tsx
@@ -13,6 +13,8 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
     }
     const {
         inputValue,
+        formattedValue,
+        locale,
         handleOnChange,
         handleStep,
         id,
@@ -44,10 +46,10 @@ const NumberFieldInput = forwardRef<NumberFieldInputElement, NumberFieldInputPro
     return (
         <input
             ref={ref}
-            type="number"
+            type="text"
             onKeyDown={handleKeyDown}
-            value={inputValue === '' ? '' : inputValue}
-            onChange={(e) => { const val = e.target.value; handleOnChange(val === '' ? '' : Number(val)); }}
+            value={locale ? formattedValue : (inputValue === '' ? '' : inputValue)}
+            onChange={(e) => handleOnChange(e.target.value)}
             id={id}
             name={name}
             disabled={disabled}

--- a/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
+++ b/src/components/ui/NumberField/fragments/NumberFieldRoot.tsx
@@ -1,116 +1,178 @@
-import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
-import { useControllableState } from '~/core/hooks/useControllableState';
-import NumberFieldContext from '../contexts/NumberFieldContext';
-import { customClassSwitcher } from '~/core';
-import clsx from 'clsx';
+import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from "react";
+import { useControllableState } from "~/core/hooks/useControllableState";
+import NumberFieldContext from "../contexts/NumberFieldContext";
+import { customClassSwitcher } from "~/core";
+import clsx from "clsx";
 
-const COMPONENT_NAME = 'NumberField';
+const COMPONENT_NAME = "NumberField";
 
-export type NumberFieldRootElement = ElementRef<'div'>;
+export type NumberFieldRootElement = ElementRef<"div">;
 export type NumberFieldRootProps = {
-    name?: string
-    defaultValue?: number | ''
-    value?: number | ''
-    onValueChange?: (value: number | '') => void
-    step?: number
-    largeStep?: number
-    min?: number
-    max?: number
-    disabled?: boolean
-    readOnly?: boolean
-    required?: boolean
-} & ComponentPropsWithoutRef<'div'>;
+  name?: string;
+  defaultValue?: number | "";
+  value?: number | "";
+  onValueChange?: (value: number | "") => void;
+  step?: number;
+  largeStep?: number;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  locale?: string;
+} & ComponentPropsWithoutRef<"div">;
 
-const NumberFieldRoot = forwardRef<NumberFieldRootElement, NumberFieldRootProps>(({ children, name, defaultValue = '', value, onValueChange, largeStep, step, min, max, disabled, readOnly, required, id, className, ...props }, ref) => {
+const NumberFieldRoot = forwardRef<
+  NumberFieldRootElement,
+  NumberFieldRootProps
+>(
+  (
+    {
+      children,
+      name,
+      defaultValue = "",
+      value,
+      onValueChange,
+      largeStep,
+      step = 1,
+      min,
+      max,
+      disabled,
+      readOnly,
+      required,
+      id,
+      className,
+      locale,
+      ...props
+    },
+    ref,
+  ) => {
     const rootClass = customClassSwitcher(className, COMPONENT_NAME);
-    const [inputValue, setInputValue] = useControllableState<number | ''>(
-        value,
-        defaultValue,
-        onValueChange);
+    const [inputValue, setInputValue] = useControllableState<number | "">(
+      value,
+      defaultValue,
+      onValueChange,
+    );
 
-    const handleOnChange = (input: number| '') => {
-        if (input === '') {
-            setInputValue('');
-            return;
-        }
-        if (max !== undefined && input > max) {
-            setInputValue(max);
-            return;
-        }
+    const getDecimalSeparator = (locale: string) => {
+      const parts = new Intl.NumberFormat(locale).formatToParts(1234.5);
+      return parts.find((part) => part.type === "decimal")?.value || ".";
+    };
 
-        if (min !== undefined && input < min) {
-            setInputValue(min);
-            return;
-        }
+    const handleOnChange = (val: string) => {
+      if (val === "") {
+        setInputValue("");
+        return;
+      }
 
-        setInputValue(input);
+      const decimal = getDecimalSeparator(locale || "en-US");
+      const regex = new RegExp(`[^0-9${decimal}]`, "g");
+      const cleaned = val.replace(regex, "");
+      const normalized = cleaned.replace(decimal, ".");
+      const numericValue = parseFloat(normalized);
+
+      if (isNaN(numericValue)) {
+        return;
+      }
+
+      if (max !== undefined && numericValue > max) {
+        setInputValue(max);
+        return;
+      }
+
+      if (min !== undefined && numericValue < min) {
+        setInputValue(min);
+        return;
+      }
+
+      setInputValue(numericValue);
     };
     const applyStep = (amount: number) => {
-        setInputValue((prev) => {
-            let temp = prev;
-            if (temp === '') {
-                if (min !== undefined) {
-                    temp = min;
-                } else {
-                    temp = -1;
-                }
-            }
-            const nextValue = temp + amount;
+      setInputValue((prev) => {
+        let temp = prev;
+        if (temp === "") {
+          if (min !== undefined) {
+            temp = min;
+          } else {
+            temp = 0;
+          }
+        }
+        const nextValue = temp + amount;
 
-            if (max !== undefined && nextValue > max) {
-                return max;
-            }
-
-            if (min !== undefined && nextValue < min) {
-                return min;
-            }
-
-            return nextValue;
-        });
-    };
-
-    const handleStep = ({ type, direction } : {type: 'small'| 'large', direction: 'increment' | 'decrement' }) => {
-        let amount = 0;
-
-        switch (type) {
-        case 'small':
-            if (!step) return;
-            amount = step;
-            break;
-        case 'large':
-            if (!largeStep) return;
-            amount = largeStep;
-            break;
+        if (max !== undefined && nextValue > max) {
+          return max;
         }
 
-        if (direction === 'decrement') {
-            amount *= -1;
+        if (min !== undefined && nextValue < min) {
+          return min;
         }
 
-        applyStep(amount);
+        return nextValue;
+      });
     };
+
+    const handleStep = ({
+      type,
+      direction,
+    }: {
+      type: "small" | "large";
+      direction: "increment" | "decrement";
+    }) => {
+      let amount = 0;
+
+      switch (type) {
+        case "small":
+          if (!step) {
+            return;
+          }
+          amount = step;
+          break;
+        case "large":
+          if (!largeStep) return;
+          amount = largeStep;
+          break;
+      }
+
+      if (direction === "decrement") {
+        amount *= -1;
+      }
+
+      applyStep(amount);
+    };
+
+    const formattedValue = new Intl.NumberFormat(locale ? locale : "en-US", {
+      maximumFractionDigits: 20,
+    }).format(inputValue === "" ? 0 : inputValue);
 
     const contextValues = {
-        inputValue,
-        handleOnChange,
-        handleStep,
-        id,
-        name,
-        disabled,
-        readOnly,
-        required,
-        rootClass
+      inputValue,
+      formattedValue,
+      locale,
+      handleOnChange,
+      handleStep,
+      id,
+      name,
+      disabled,
+      readOnly,
+      required,
+      rootClass,
     };
 
     return (
-        <div ref={ref} className={clsx(`${rootClass}-root`, className)} {...props}>
-            <NumberFieldContext.Provider value={contextValues}>
-                {children}
-            </NumberFieldContext.Provider>
-        </div>
+      <div
+        ref={ref}
+        className={clsx(`${rootClass}-root`, className)}
+        {...props}
+      >
+        <NumberFieldContext.Provider value={contextValues}>
+          {children}
+        </NumberFieldContext.Provider>
+      </div>
     );
-});
+  },
+);
 
 NumberFieldRoot.displayName = COMPONENT_NAME;
 
 export default NumberFieldRoot;
+

--- a/src/components/ui/NumberField/stories/NumberField.stories.tsx
+++ b/src/components/ui/NumberField/stories/NumberField.stories.tsx
@@ -1,58 +1,114 @@
-import React from 'react';
-import NumberField from '../NumberField';
-import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
+import React from "react";
+import NumberField from "../NumberField";
+import SandboxEditor from "~/components/tools/SandboxEditor/SandboxEditor";
 
 export default {
-    title: 'WIP/NumberField',
-    component: NumberField
+  title: "WIP/NumberField",
+  component: NumberField,
 };
 
 export const Basic = () => (
-    <SandboxEditor>
-        <NumberField.Root defaultValue={5} step={1} min={-10} max={110} largeStep={5}>
-            <NumberField.Decrement>-</NumberField.Decrement>
-            <NumberField.Input />
-            <NumberField.Increment>+</NumberField.Increment>
-        </NumberField.Root>
-    </SandboxEditor>
+  <SandboxEditor>
+    <NumberField.Root
+      defaultValue={5}
+      step={1}
+      min={-10}
+      max={110}
+      largeStep={5}
+    >
+      <NumberField.Decrement>-</NumberField.Decrement>
+      <NumberField.Input />
+      <NumberField.Increment>+</NumberField.Increment>
+    </NumberField.Root>
+  </SandboxEditor>
 );
 
 export const Controlled = () => {
-    const [value, setValue] = React.useState<number | ''>(3);
-    return (
-        <SandboxEditor>
-            <NumberField.Root value={value} onValueChange={setValue} defaultValue={3} step={1} min={0} max={10} largeStep={5}>
-                <NumberField.Decrement>-</NumberField.Decrement>
-                <NumberField.Input />
-                <NumberField.Increment>+</NumberField.Increment>
-            </NumberField.Root>
-            <div style={{ marginTop: 8 }}>Current value: {value}</div>
-        </SandboxEditor>
-    );
+  const [value, setValue] = React.useState<number | "">(3);
+  return (
+    <SandboxEditor>
+      <NumberField.Root
+        value={value}
+        onValueChange={setValue}
+        defaultValue={3}
+        step={1}
+        min={0}
+        max={10}
+        largeStep={5}
+      >
+        <NumberField.Decrement>-</NumberField.Decrement>
+        <NumberField.Input />
+        <NumberField.Increment>+</NumberField.Increment>
+      </NumberField.Root>
+      <div style={{ marginTop: 8 }}>Current value: {value}</div>
+    </SandboxEditor>
+  );
 };
 
 export const FormExample = () => {
-    const [fieldValue, setFieldValue] = React.useState<number | ''>(2);
-    const [submitted, setSubmitted] = React.useState<number | null>(null);
-    return (
-        <SandboxEditor>
-            <form
-                onSubmit={e => {
-                    e.preventDefault();
-                    setSubmitted(fieldValue === '' ? null : fieldValue);
-                }}
-            >
-                <NumberField.Root name="quantity" value={fieldValue} onValueChange={setFieldValue} defaultValue={2} step={1} min={0} max={10} largeStep={5}>
-                    <NumberField.Decrement>-</NumberField.Decrement>
-                    <NumberField.Input />
-                    <NumberField.Increment>+</NumberField.Increment>
-
-                </NumberField.Root>
-                <button type="submit" style={{ marginTop: 8 }}>Submit</button>
-            </form>
-            {submitted !== null && (
-                <div style={{ marginTop: 8 }}>Submitted value: {submitted}</div>
-            )}
-        </SandboxEditor>
-    );
+  const [fieldValue, setFieldValue] = React.useState<number | "">(2);
+  const [submitted, setSubmitted] = React.useState<number | null>(null);
+  return (
+    <SandboxEditor>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSubmitted(fieldValue === "" ? null : fieldValue);
+        }}
+      >
+        <NumberField.Root
+          name="quantity"
+          value={fieldValue}
+          onValueChange={setFieldValue}
+          defaultValue={2}
+          step={1}
+          min={0}
+          max={10}
+          largeStep={5}
+        >
+          <NumberField.Decrement>-</NumberField.Decrement>
+          <NumberField.Input />
+          <NumberField.Increment>+</NumberField.Increment>
+        </NumberField.Root>
+        <button type="submit" style={{ marginTop: 8 }}>
+          Submit
+        </button>
+      </form>
+      {submitted !== null && (
+        <div style={{ marginTop: 8 }}>Submitted value: {submitted}</div>
+      )}
+    </SandboxEditor>
+  );
 };
+
+export const WithLocale = () => (
+    <SandboxEditor>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div>
+                <p>German (de-DE)</p>
+                <NumberField.Root defaultValue={1234567.89} locale="de-DE" step={1}>
+                    <NumberField.Decrement>-</NumberField.Decrement>
+                    <NumberField.Input style={{ width: '200px' }} />
+                    <NumberField.Increment>+</NumberField.Increment>
+                </NumberField.Root>
+            </div>
+            <div>
+                <p>French (fr-FR)</p>
+                <NumberField.Root defaultValue={1234567.89} locale="fr-FR" step={1}>
+                    <NumberField.Decrement>-</NumberField.Decrement>
+                    <NumberField.Input style={{ width: '200px' }} />
+                    <NumberField.Increment>+</NumberField.Increment>
+                </NumberField.Root>
+            </div>
+            <div>
+                <p>Indian (en-IN)</p>
+                <NumberField.Root defaultValue={1234567.89} locale="en-IN" step={1}>
+                    <NumberField.Decrement>-</NumberField.Decrement>
+                    <NumberField.Input style={{ width: '200px' }} />
+                    <NumberField.Increment>+</NumberField.Increment>
+                </NumberField.Root>
+            </div>
+        </div>
+    </SandboxEditor>
+);
+


### PR DESCRIPTION
This implementation allows numbers to be formatted according to different regional conventions. 
The NumberField.Root component accepts a locale prop that uses  the Intl.NumberFormat API to format the displayed value based on the provided locale. 