### PR TITLE
Add z-index to tooltip content.

### DIFF
--- a/docs/components/layout/Documentation/helpers/DocsTable.js
+++ b/docs/components/layout/Documentation/helpers/DocsTable.js
@@ -43,7 +43,9 @@ const InfoRenderer = ({ row }) => {
                                 </span>
                             </Button>
                         </Tooltip.Trigger>
-                        <Tooltip.Content>
+                        <Tooltip.Content
+                            className="z-[9999] bg-black rounded shadow-lg"
+                        >
                             <span className="flex flex-col gap-2">
                                 {infoText}
                             </span>


### PR DESCRIPTION
In the docs the tooltip is getting hidden. 

Before:

<img width="1470" height="916" alt="Screenshot 2025-10-22 at 5 47 01 PM" src="https://github.com/user-attachments/assets/d1d2d0a7-b3f7-4913-afd9-b6c155297354" />


After: 

<img width="1470" height="916" alt="Screenshot 2025-10-22 at 5 46 33 PM" src="https://github.com/user-attachments/assets/4074719f-a894-4fe8-9de3-38d663d57aa6" />

PR also adds background black and shadow to the tooltip. 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip styling with improved visual presentation, including better contrast, rounded corners, shadow effects, and layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->