### PR TITLE
detach support added for all comps

### DIFF
--- a/.changeset/floppy-spoons-appear.md
+++ b/.changeset/floppy-spoons-appear.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+detach prop support for all comps

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -11,6 +11,7 @@ const COMPONENT_NAME = 'Accordion';
 
 export type AccordionRootProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'defaultValue'> & {
     customRootClass?: string;
+    detach?: boolean;
     transitionDuration?: number;
     transitionTimingFunction?: string;
     orientation?: 'horizontal' | 'vertical';
@@ -31,6 +32,7 @@ const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootPro
     transitionDuration = 0,
     transitionTimingFunction = 'linear',
     customRootClass,
+    detach = false,
     loop = true,
     openMultiple = false,
     value,
@@ -39,7 +41,7 @@ const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootPro
     ...props
 }, forwardedRef) => {
     const accordionRef = useRef<HTMLDivElement | null>(null);
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const [fixedHeight, setFixedHeight] = useState<number | null>(null);
     const heightLockTimeoutRef = useRef<NodeJS.Timeout>();
     const previousActiveItemsRef = useRef<(number | string)[]>([]);

--- a/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
+++ b/src/components/ui/AlertDialog/fragments/AlertDialogRoot.tsx
@@ -12,6 +12,7 @@ type DialogPrimitiveRootProps = React.ComponentPropsWithoutRef<typeof DialogPrim
 
 export type AlertDialogRootProps = Omit<DialogPrimitiveRootProps, 'open' | 'onOpenChange'> & {
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
     defaultOpen?: boolean;
     open?: boolean;
@@ -24,12 +25,13 @@ const AlertDialogRoot = forwardRef<AlertDialogRootElement, AlertDialogRootProps>
     children,
     className = '',
     customRootClass = '',
+    detach = false,
     defaultOpen = false,
     open,
     onOpenChange,
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, onOpenChange);
     const [titleId, setTitleId] = useState<string | undefined>(undefined);

--- a/src/components/ui/AspectRatio/AspectRatio.tsx
+++ b/src/components/ui/AspectRatio/AspectRatio.tsx
@@ -7,14 +7,15 @@ const COMPONENT_NAME = 'AspectRatio';
 
 export type AspectRatioProps = ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     ratio?: string;
 };
 
-const AspectRatio = React.forwardRef<ElementRef<'div'>, AspectRatioProps>(({ children, customRootClass, className, ratio = '1', ...props }, ref) => {
+const AspectRatio = React.forwardRef<ElementRef<'div'>, AspectRatioProps>(({ children, customRootClass, detach = false, className, ratio = '1', ...props }, ref) => {
     if (isNaN(Number(ratio)) && !ratio.match(/^(\d+)\/(\d+)$/)) ratio = '1';
     if (Number(ratio) <= 0) ratio = '1';
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return (
         <div ref={ref} style={{ aspectRatio: ratio }} className={clsx(rootClass, className)} {...props}>
             {children}

--- a/src/components/ui/Avatar/fragments/AvatarRoot.tsx
+++ b/src/components/ui/Avatar/fragments/AvatarRoot.tsx
@@ -9,14 +9,15 @@ const COMPONENT_NAME = 'Avatar';
 
 export type AvatarRootProps = React.ComponentPropsWithoutRef<typeof AvatarPrimitiveRoot> & {
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
     size?: string;
     variant?: string;
     color?: string;
 }
 
-const AvatarRoot = React.forwardRef<React.ElementRef<typeof AvatarPrimitiveRoot>, AvatarRootProps>(({ children, customRootClass = '', className = '', size = '', variant = '', color = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const AvatarRoot = React.forwardRef<React.ElementRef<typeof AvatarPrimitiveRoot>, AvatarRootProps>(({ children, customRootClass = '', detach = false, className = '', size = '', variant = '', color = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('avatar', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
+++ b/src/components/ui/AvatarGroup/fragments/AvatarGroupRoot.tsx
@@ -6,14 +6,15 @@ import { useCreateDataAttribute, useComposeAttributes } from '~/core/hooks/creat
 
 export type AvatarGroupRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string | '';
+    detach?: boolean;
     size?: string;
     variant?: string;
 };
 
 const COMPONENT_NAME = 'AvatarGroup';
 
-const AvatarGroupRoot = React.forwardRef<HTMLDivElement, AvatarGroupRootProps>(({ customRootClass = '', size = '', variant = '', children, className = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const AvatarGroupRoot = React.forwardRef<HTMLDivElement, AvatarGroupRootProps>(({ customRootClass = '', detach = false, size = '', variant = '', children, className = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const dataAttributes = useCreateDataAttribute('avatar', { variant, size });
     const composedAttributes = useComposeAttributes(dataAttributes());
 

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -8,13 +8,14 @@ import { useCreateDataAttribute, useComposeAttributes, useCreateDataAccentColorA
 const COMPONENT_NAME = 'Badge';
 export type BadgeProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     color?: string;
 };
 
-const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(({ children, customRootClass = '', detach = false, className = '', color = '', variant = '', size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('badge', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/BlockQuote/BlockQuote.tsx
+++ b/src/components/ui/BlockQuote/BlockQuote.tsx
@@ -7,14 +7,15 @@ const COMPONENT_NAME = 'BlockQuote';
 
 export type BlockQuoteProps = React.ComponentPropsWithoutRef<'blockquote'> & {
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     variant?: string;
     size?: string;
 };
 
 const BlockQuote = React.forwardRef<React.ElementRef<'blockquote'>, BlockQuoteProps>(
-    ({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, customRootClass = '', detach = false, className = '', color = '', variant = '', size = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         const data_attributes: Record<string, string> = {};
 

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -14,6 +14,7 @@ const COMPONENT_NAME = 'Button';
 
 export type ButtonProps = {
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     color?: string;
@@ -24,6 +25,7 @@ const Button = forwardRef<ElementRef<typeof ButtonPrimitive>, ButtonProps>(
         children,
         type = 'button',
         customRootClass = '',
+        detach = false,
         className = '',
         variant = '',
         size = '',
@@ -32,7 +34,7 @@ const Button = forwardRef<ElementRef<typeof ButtonPrimitive>, ButtonProps>(
         onClick,
         ...props
     }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         // apply data attribute for accent color
         // apply attribute only if color is present
         const dataAttributes = useCreateDataAttribute('button', { variant, size });

--- a/src/components/ui/Callout/fragments/CalloutRoot.tsx
+++ b/src/components/ui/Callout/fragments/CalloutRoot.tsx
@@ -16,14 +16,15 @@ type CalloutRootProps = PrimitiveDivProps & {
     intent?: string; // Semantic intent: 'destructive' | 'warning' | 'info' | etc.
     size?: string;
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const CalloutRoot = React.forwardRef<CalloutRootElement, CalloutRootProps>(
     (
-        { children, asChild = false, className = '', color = '', variant = '', intent = '', size = '', customRootClass = '', ...props },
+        { children, asChild = false, className = '', color = '', variant = '', intent = '', size = '', customRootClass = '', detach = false, ...props },
         ref
     ) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         // Backward compatibility: if variant is "destructive", treat it as intent
         // This allows existing code to continue working while migrating to intent/variant separation

--- a/src/components/ui/Card/fragments/CardRoot.tsx
+++ b/src/components/ui/Card/fragments/CardRoot.tsx
@@ -5,12 +5,13 @@ import { useCreateDataAttribute } from '~/core/hooks/createDataAttribute';
 const COMPONENT_NAME = 'Card';
 export type CardRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
 };
 
-const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>(({ children, customRootClass, className = '', variant = '', size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const CardRoot = React.forwardRef<HTMLDivElement, CardRootProps>(({ children, customRootClass, detach = false, className = '', variant = '', size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const dataAttributes = useCreateDataAttribute('card', { variant, size });
 
     return (

--- a/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
+++ b/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
@@ -10,13 +10,14 @@ const COMPONENT_NAME = 'Checkbox';
 export type CheckboxRootElement = ElementRef<typeof CheckboxPrimitiveRoot>;
 export type CheckboxRootProps = {
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     variant?: string;
     size?: string;
 } & ComponentPropsWithoutRef<typeof CheckboxPrimitiveRoot>;
 
-const CheckboxRoot = forwardRef<CheckboxRootElement, CheckboxRootProps>(({ children, className = '', customRootClass, color = '', variant, size, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const CheckboxRoot = forwardRef<CheckboxRootElement, CheckboxRootProps>(({ children, className = '', customRootClass, detach = false, color = '', variant, size, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('checkbox', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
+++ b/src/components/ui/CheckboxCards/fragments/CheckboxCardsRoot.tsx
@@ -10,13 +10,14 @@ const COMPONENT_NAME = 'CheckboxCards';
 export type CheckboxCardsRootElement = ElementRef<typeof CheckboxGroupPrimitive.Root>;
 export type CheckboxCardsRootProps = {
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     variant?: string;
     size?: string;
 } & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Root>;
 
-const CheckboxCardsRoot = forwardRef<CheckboxCardsRootElement, CheckboxCardsRootProps>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const CheckboxCardsRoot = forwardRef<CheckboxCardsRootElement, CheckboxCardsRootProps>(({ children, customRootClass = '', detach = false, className = '', color = '', variant = '', size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('checkbox-cards', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
@@ -10,13 +10,14 @@ const COMPONENT_NAME = 'CheckboxGroup';
 export type CheckboxGroupRootElement = ElementRef<typeof CheckboxGroupPrimitive.Root>;
 export type CheckboxGroupRootProps = {
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     variant?: string;
     size?: string;
 } & ComponentPropsWithoutRef<typeof CheckboxGroupPrimitive.Root>;
 
-const CheckboxGroupRoot = forwardRef<CheckboxGroupRootElement, CheckboxGroupRootProps>(({ children, customRootClass = '', className = '', color = '', variant = '', size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const CheckboxGroupRoot = forwardRef<CheckboxGroupRootElement, CheckboxGroupRootProps>(({ children, customRootClass = '', detach = false, className = '', color = '', variant = '', size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('checkbox-group', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/Code/Code.tsx
+++ b/src/components/ui/Code/Code.tsx
@@ -7,6 +7,7 @@ const COMPONENT_NAME = 'Code';
 
 export type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     color?: string;
@@ -15,13 +16,14 @@ export type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
 const Code = React.forwardRef<React.ElementRef<'code'>, CodeProps>(({
     children,
     customRootClass = '',
+    detach = false,
     color = '',
     variant = '',
     size = '',
     className,
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const data_attributes: Record<string, string> = {};
 

--- a/src/components/ui/Collapsible/fragments/CollapsibleRoot.tsx
+++ b/src/components/ui/Collapsible/fragments/CollapsibleRoot.tsx
@@ -11,13 +11,14 @@ export type CollapsibleRootProps = React.ComponentPropsWithoutRef<
     typeof CollapsiblePrimitive.Root
 > & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const CollapsibleRoot = React.forwardRef<
     CollapsibleRootElement,
     CollapsibleRootProps
->(({ children, className = '', transitionDuration = 0, disabled, customRootClass, ...props }, forwardedRef) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+>(({ children, className = '', transitionDuration = 0, disabled, customRootClass, detach = false, ...props }, forwardedRef) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return (
         <CollapsibleContext.Provider value={{ rootClass }}>
             <CollapsiblePrimitive.Root

--- a/src/components/ui/Combobox/fragments/ComboboxRoot.tsx
+++ b/src/components/ui/Combobox/fragments/ComboboxRoot.tsx
@@ -8,11 +8,12 @@ const COMPONENT_NAME = 'Combobox';
 type ComboboxRootElement = React.ElementRef<typeof ComboboxPrimitive.Root>;
 type ComboboxRootProps = React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Root> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const ComboboxRoot = React.forwardRef<ComboboxRootElement, ComboboxRootProps>(
-    ({ customRootClass, children, defaultValue, value, onValueChange, shift, ...props }, forwardedRef) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ customRootClass, detach = false, children, defaultValue, value, onValueChange, shift, ...props }, forwardedRef) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         return (
             <ComboboxRootContext.Provider value={{ rootClass }}>

--- a/src/components/ui/ContextMenu/fragments/ContextMenuRoot.tsx
+++ b/src/components/ui/ContextMenu/fragments/ContextMenuRoot.tsx
@@ -9,19 +9,20 @@ export type ContextMenuRootElement = ElementRef<typeof MenuPrimitive.Root>;
 export type ContextMenuRootProps = {
   children: React.ReactNode;
   customRootClass?: string;
+  detach?: boolean;
   className?: string;
 } & ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 
 const COMPONENT_NAME = 'ContextMenu';
 
-const ContextMenuRoot = forwardRef<ContextMenuRootElement, ContextMenuRootProps>(({ children, customRootClass, className, open, defaultOpen = false, onOpenChange, ...props }, ref) => {
+const ContextMenuRoot = forwardRef<ContextMenuRootElement, ContextMenuRootProps>(({ children, customRootClass, detach = false, className, open, defaultOpen = false, onOpenChange, ...props }, ref) => {
     const [isOpen, setIsOpen] = useControllableState(
         open,
         defaultOpen,
         onOpenChange
     );
     const [coords, setCoords] = React.useState({ x: 0, y: 0 });
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return (
         <ContextMenuContext.Provider value={{ rootClass, setCoords, setIsOpen }} >
             <MenuPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, className)} mainAxisOffset={-coords.y} crossAxisOffset={coords.x} open={isOpen} onOpenChange={setIsOpen} {...props}>

--- a/src/components/ui/DataList/fragments/DataListRoot.tsx
+++ b/src/components/ui/DataList/fragments/DataListRoot.tsx
@@ -8,10 +8,11 @@ const COMPONENT_NAME = 'DataList';
 type DataListRootElement = ElementRef<'div'>;
 export interface DataListRootProps extends ComponentPropsWithoutRef<'div'> {
     customRootClass?: string;
+    detach?: boolean;
 }
 
-const DataListRoot = forwardRef<DataListRootElement, DataListRootProps>(({ children, className = '', customRootClass = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const DataListRoot = forwardRef<DataListRootElement, DataListRootProps>(({ children, className = '', customRootClass = '', detach = false, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return <DataListContext.Provider
         value={{
             rootClass

--- a/src/components/ui/Dialog/fragments/DialogRoot.tsx
+++ b/src/components/ui/Dialog/fragments/DialogRoot.tsx
@@ -13,11 +13,12 @@ type DialogPrimitiveRootProps = React.ComponentPropsWithoutRef<typeof DialogPrim
 
 export type DialogRootProps = DialogPrimitiveRootProps & {
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
 };
 
-const DialogRoot = forwardRef<DialogRootElement, DialogRootProps>(({ children, customRootClass = '', className = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const DialogRoot = forwardRef<DialogRootElement, DialogRootProps>(({ children, customRootClass = '', detach = false, className = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const contextProps = { rootClass };
 

--- a/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
@@ -9,12 +9,13 @@ const COMPONENT_NAME = 'Disclosure';
 
 export type DisclosureRootProps = React.ComponentPropsWithoutRef<'div'> & {
      customRootClass?: string;
+     detach?: boolean;
      defaultOpen?: number | null;
 };
 
-const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, ...props }, forwardedRef) => {
+const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, detach = false, 'aria-label': ariaLabel, ...props }, forwardedRef) => {
     const disclosureRef = useRef<React.ElementRef<'div'> | null>(null);
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const [activeItem, setActiveItem] = useState<number | null>(null);
 

--- a/src/components/ui/DropdownMenu/fragments/DropdownMenuRoot.tsx
+++ b/src/components/ui/DropdownMenu/fragments/DropdownMenuRoot.tsx
@@ -8,13 +8,14 @@ export type DropdownMenuRootElement = ElementRef<typeof MenuPrimitive.Root>;
 export type DropdownMenuRootProps = {
   children: React.ReactNode;
   customRootClass?: string;
+  detach?: boolean;
   className?: string;
 } & ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 
 const COMPONENT_NAME = 'DropdownMenu';
 
-const DropdownMenuRoot = forwardRef<DropdownMenuRootElement, DropdownMenuRootProps>(({ children, customRootClass, className, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const DropdownMenuRoot = forwardRef<DropdownMenuRootElement, DropdownMenuRootProps>(({ children, customRootClass, detach = false, className, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return (
         <DropdownMenuContext.Provider value={{ rootClass }} >
             <MenuPrimitive.Root ref={ref} className={clsx(`${rootClass}-root`, className)} {...props}>

--- a/src/components/ui/Em/Em.tsx
+++ b/src/components/ui/Em/Em.tsx
@@ -7,10 +7,11 @@ const COMPONENT_NAME = 'Em';
 
 export type EmProps = ComponentPropsWithoutRef<'em'> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
-const Em = React.forwardRef<ElementRef<'em'>, EmProps>(({ children, customRootClass, className, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const Em = React.forwardRef<ElementRef<'em'>, EmProps>(({ children, customRootClass, detach = false, className, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     return (
         <em ref={ref} className={clsx(rootClass, className)} {...props}>
             {children}

--- a/src/components/ui/Heading/Heading.tsx
+++ b/src/components/ui/Heading/Heading.tsx
@@ -14,6 +14,8 @@ export type HeadingProps = {
     as?: HeadingTag;
     /** Custom root class for specialized styling */
     customRootClass?: string;
+    /** Remove all Rad UI generated classes when true */
+    detach?: boolean;
 } & React.ComponentPropsWithoutRef<'h1'>;
 
 /**
@@ -23,10 +25,11 @@ const Heading = React.forwardRef<React.ElementRef<'h1'>, HeadingProps>(({
     children,
     as = 'h1',
     customRootClass = '',
+    detach = false,
     className = '',
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, as);
+    const rootClass = customClassSwitcher(customRootClass, as, detach);
     const Tag: HeadingTag = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(as) ? as : 'h1';
 
     return React.createElement(Tag, {

--- a/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
@@ -12,13 +12,14 @@ export type HoverCardRootProps = ComponentPropsWithoutRef<'div'> & {
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
     customRootClass?: string;
+    detach?: boolean;
     openDelay?: number;
     closeDelay?: number;
 };
 
-const HoverCardRoot = forwardRef<HoverCardRootElement, HoverCardRootProps>(({ children, open: controlledOpen = undefined, onOpenChange, customRootClass = '', openDelay = 100, closeDelay = 200, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
-    const rootTriggerClass = customClassSwitcher(customRootClass, `${COMPONENT_NAME}-trigger`);
+const HoverCardRoot = forwardRef<HoverCardRootElement, HoverCardRootProps>(({ children, open: controlledOpen = undefined, onOpenChange, customRootClass = '', detach = false, openDelay = 100, closeDelay = 200, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
+    const rootTriggerClass = customClassSwitcher(customRootClass, `${COMPONENT_NAME}-trigger`, detach);
     const arrowRef = useRef<SVGSVGElement | null>(null);
     const ARROW_HEIGHT = 8;
     const SPACING_GAP = 2;

--- a/src/components/ui/Kbd/Kbd.tsx
+++ b/src/components/ui/Kbd/Kbd.tsx
@@ -9,11 +9,12 @@ const COMPONENT_NAME = 'Kbd';
 export type KbdElement = ElementRef<'kbd'>;
 export interface KbdProps extends ComponentPropsWithoutRef<'kbd'> {
     customRootClass?: string;
+    detach?: boolean;
     size?: string;
 }
 
-const Kbd = forwardRef<KbdElement, KbdProps>(({ children, customRootClass, className, size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const Kbd = forwardRef<KbdElement, KbdProps>(({ children, customRootClass, detach = false, className, size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('kbd', { size });
 

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -9,6 +9,7 @@ const COMPONENT_NAME = 'Link';
 
 export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
     customRootClass?: string;
+    detach?: boolean;
     size?: string;
     asChild?: boolean;
 }
@@ -16,8 +17,8 @@ export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
 type LinkElement = ElementRef<'a'>;
 
 const Link = React.forwardRef<LinkElement, LinkProps>(
-    ({ children, href = '#', customRootClass, className, size = '', asChild = false, ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, href = '#', customRootClass, detach = false, className, size = '', asChild = false, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const dataAttributes = useCreateDataAttribute('link', { size });
         const Anchor = Primitive.a as any;
         return (

--- a/src/components/ui/Menubar/fragments/MenubarRoot.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarRoot.tsx
@@ -8,13 +8,14 @@ export type MenubarRootElement = ElementRef<typeof Floater.Composite>;
 export type MenubarRootProps = {
   children: React.ReactNode;
   customRootClass?: string;
+  detach?: boolean;
   className?: string;
 } & ComponentPropsWithoutRef<typeof Floater.Composite>;
 
 const COMPONENT_NAME = 'Menubar';
 
-const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children, customRootClass, className, dir, loop, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children, customRootClass, detach = false, className, dir, loop, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const [items, setItems] = React.useState<MenubarItem[]>([]);
     const [activeIndex, setActiveIndex] = React.useState(0);
 

--- a/src/components/ui/Minimap/fragments/MinimapRoot.tsx
+++ b/src/components/ui/Minimap/fragments/MinimapRoot.tsx
@@ -11,10 +11,11 @@ const COMPONENT_NAME = 'Minimap';
 
 type MinimapRootProps = React.HTMLAttributes<HTMLDivElement> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
-const MinimapRoot = ({ children, className, customRootClass = '', ...props }: MinimapRootProps) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const MinimapRoot = ({ children, className, customRootClass = '', detach = false, ...props }: MinimapRootProps) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const rootRef = React.useRef<HTMLDivElement>(null);
 
     return <MinimapContext.Provider value={{ rootClass, rootRef }}>

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
@@ -15,6 +15,7 @@ export interface NavigationMenuRootProps extends React.ComponentPropsWithoutRef<
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     customRootClass?: string;
+    detach?: boolean;
 }
 
 const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, NavigationMenuRootProps>(
@@ -25,12 +26,13 @@ const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, Navigatio
             defaultValue = '',
             onValueChange,
             customRootClass,
+            detach = false,
             className,
             ...props
         },
         ref
     ) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const [isOpen, setIsOpen] = useControllableState(value, defaultValue, onValueChange);
 
         return (

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -21,6 +21,7 @@ export type ProgressRootProps = {
     maxValue: number;
     getValueLabel?: (value: number, minValue: number, maxValue: number) => string;
     customRootClass?: string;
+    detach?: boolean;
     children: React.ReactNode;
 } & ComponentPropsWithoutRef<typeof Primitive.div>;
 
@@ -38,6 +39,7 @@ const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
             maxValue = 100,
             children,
             customRootClass,
+            detach = false,
             getValueLabel,
             className,
             ...props
@@ -48,7 +50,7 @@ const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
             (typeof STATE_ENUMS)[keyof typeof STATE_ENUMS]
                 >(STATE_ENUMS.LOADING);
 
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? '';
 
         useEffect(() => {

--- a/src/components/ui/Quote/Quote.tsx
+++ b/src/components/ui/Quote/Quote.tsx
@@ -7,11 +7,12 @@ const COMPONENT_NAME = 'Quote';
 
 export type QuoteProps = React.ComponentPropsWithoutRef<'q'> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const Quote = React.forwardRef<React.ElementRef<'q'>, QuoteProps>(
-    ({ children, customRootClass, className, ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, customRootClass, detach = false, className, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         return (
             <q ref={ref} className={clsx(rootClass, className)} {...props}>
                 {children}

--- a/src/components/ui/Radio/Radio.tsx
+++ b/src/components/ui/Radio/Radio.tsx
@@ -13,6 +13,7 @@ export type RadioElement = React.ElementRef<typeof RadioPrimitive>;
 
 export type RadioProps = Omit<RadioPrimitiveProps, 'size'> & {
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
     size?: string;
     color?: string;
@@ -20,10 +21,10 @@ export type RadioProps = Omit<RadioPrimitiveProps, 'size'> & {
 };
 
 const Radio = React.forwardRef<RadioElement, RadioProps>(function Radio(
-    { name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props },
+    { name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, detach = false, variant = '', size = '', color = '', ...props },
     ref
 ) {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const [isChecked, setIsChecked] = React.useState(checked);
 
     const dataAttributes = useCreateDataAttribute('button', { variant, size });

--- a/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
+++ b/src/components/ui/RadioCards/fragments/RadioCardsRoot.tsx
@@ -15,6 +15,7 @@ type RadioCardsRootProps = RadioGroupPrimitiveRootProps & {
     children: React.ReactNode;
     className?: string;
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     color?: string;
@@ -22,8 +23,8 @@ type RadioCardsRootProps = RadioGroupPrimitiveRootProps & {
     defaultValue?: string;
 };
 const RadioCardsRoot = forwardRef<RadioCardsRootElement, RadioCardsRootProps>(
-    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, className = '', customRootClass = '', detach = false, variant = '', size = '', color = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         const dataAttributes = useCreateDataAttribute('radio-cards', { variant, size });
         const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
@@ -16,6 +16,7 @@ type RadioGroupRootProps = {
     children: React.ReactNode;
     className?: string;
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     color?: string;
@@ -23,8 +24,8 @@ type RadioGroupRootProps = {
 } & RadioGroupPrimitiveProps.Root;
 
 const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootProps>(
-    ({ children, className = '', customRootClass = '', variant = '', size = '', color = '', ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, className = '', customRootClass = '', detach = false, variant = '', size = '', color = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const dataAttributes = useCreateDataAttribute('radio-group', { variant, size });
 
         const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
@@ -11,6 +11,7 @@ const COMPONENT_NAME = 'ScrollArea';
 type ScrollAreaRootElement = ElementRef<'div'>;
 type ScrollAreaRootProps = ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     type?: 'auto' | 'always' | 'scroll' | 'hover';
 };
 
@@ -18,10 +19,11 @@ const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({
     children,
     className = '',
     customRootClass = '',
+    detach = false,
     type = 'hover',
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const internalRootRef = useRef<HTMLDivElement>(null);
     const scrollYThumbRef = useRef<HTMLDivElement>(null);
     const scrollXThumbRef = useRef<HTMLDivElement>(null);

--- a/src/components/ui/Select/fragments/SelectRoot.tsx
+++ b/src/components/ui/Select/fragments/SelectRoot.tsx
@@ -8,11 +8,12 @@ const COMPONENT_NAME = 'Select';
 type SelectRootElement = React.ElementRef<typeof ComboboxPrimitive.Root>;
 type SelectRootProps = React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Root> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const SelectRoot = React.forwardRef<SelectRootElement, SelectRootProps>(
-    ({ customRootClass, children, defaultValue, value, onValueChange, shift, ...props }, forwardedRef) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ customRootClass, detach = false, children, defaultValue, value, onValueChange, shift, ...props }, forwardedRef) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         return (
             <SelectRootContext.Provider value={{ rootClass }}>

--- a/src/components/ui/Separator/Separator.tsx
+++ b/src/components/ui/Separator/Separator.tsx
@@ -12,6 +12,7 @@ type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
 export type SeparatorProps = {
     orientation?: 'horizontal' | 'vertical';
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     decorative?: boolean;
 } & PrimitiveDivProps;
@@ -22,13 +23,14 @@ const Separator = React.forwardRef<SeparatorElement, SeparatorProps>(
             orientation = 'horizontal',
             className,
             customRootClass,
+            detach = false,
             color = '',
             decorative = false,
             ...props
         },
         ref
     ) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const orientationClass = orientation === 'vertical' ? `${rootClass}-vertical` : `${rootClass}-horizontal`;
         const data_attributes: Record<string, string> = {};
 

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -8,6 +8,7 @@ const COMPONENT_NAME = 'Skeleton';
 export type SkeletonProps = React.ComponentPropsWithoutRef<'div'> & {
     loading: boolean;
     customRootClass?: string;
+    detach?: boolean;
     height: string;
     width: string;
     radius?: string;
@@ -19,6 +20,7 @@ const Skeleton = React.forwardRef<React.ElementRef<'div'>, SkeletonProps>(
             loading = true,
             className = '',
             customRootClass = '',
+            detach = false,
             children,
             height,
             width,
@@ -30,7 +32,7 @@ const Skeleton = React.forwardRef<React.ElementRef<'div'>, SkeletonProps>(
     ) => {
         if (!loading) return <>{children}</>;
 
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         return (
             <div

--- a/src/components/ui/Slider/fragments/SliderRoot.tsx
+++ b/src/components/ui/Slider/fragments/SliderRoot.tsx
@@ -13,6 +13,7 @@ export type SliderRootProps = {
     children: React.ReactNode;
     className?: string;
     customRootClass?: string;
+    detach?: boolean;
     defaultValue?: number | number[];
     value?: number | number[];
     onValueChange?: (value: number | number[]) => void;
@@ -31,6 +32,7 @@ const SliderRoot = forwardRef<SliderRootElement, SliderRootProps>(({
     children,
     className = '',
     customRootClass = '',
+    detach = false,
     defaultValue,
     value: valueProp,
     onValueChange,
@@ -45,7 +47,7 @@ const SliderRoot = forwardRef<SliderRootElement, SliderRootProps>(({
     formatValue,
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const [value, setValue] = useControllableState<number | number[]>(
         valueProp,

--- a/src/components/ui/Spinner/Spinner.tsx
+++ b/src/components/ui/Spinner/Spinner.tsx
@@ -8,13 +8,14 @@ const COMPONENT_NAME = 'Spinner';
 
 export type SpinnerProps = {
     customRootClass?: string;
+    detach?: boolean;
     size?: string;
 } & ComponentPropsWithoutRef<'span'>;
 
 type SpinnerElement = ElementRef<'span'>;
 
-const Spinner = React.forwardRef<SpinnerElement, SpinnerProps>(({ className, customRootClass = '', size = '', ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const Spinner = React.forwardRef<SpinnerElement, SpinnerProps>(({ className, customRootClass = '', detach = false, size = '', ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const dataAttributes = useCreateDataAttribute('spinner', { size });
 
     return (

--- a/src/components/ui/Splitter/fragments/SplitterRoot.tsx
+++ b/src/components/ui/Splitter/fragments/SplitterRoot.tsx
@@ -7,6 +7,7 @@ import SplitterContext, { SplitterContextValue, SplitterOrientation } from '../c
 export interface SplitterRootProps extends React.ComponentPropsWithoutRef<'div'> {
   orientation?: SplitterOrientation;
   customRootClass?: string;
+  detach?: boolean;
   defaultSizes?: number[];
   minSizes?: number[];
   maxSizes?: number[];
@@ -32,6 +33,7 @@ const SplitterRoot = React.forwardRef<
     children,
     className,
     customRootClass = '',
+    detach = false,
     defaultSizes = [50, 50],
     minSizes = [0, 0],
     maxSizes = [100, 100],
@@ -39,7 +41,7 @@ const SplitterRoot = React.forwardRef<
     style,
     ...props
 }, forwardedRef) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const [sizes, setSizes] = useState<number[]>(defaultSizes);
     const [isDragging, setIsDragging] = useState(false);

--- a/src/components/ui/Steps/fragments/StepRoot.tsx
+++ b/src/components/ui/Steps/fragments/StepRoot.tsx
@@ -11,6 +11,7 @@ const COMPONENT_NAME = 'Steps';
 
 type StepsRootProps = React.HTMLAttributes<HTMLDivElement> & {
     customRootClass?: string;
+    detach?: boolean;
     orientation?: 'horizontal' | 'vertical';
     value?: number;
     defaultValue?: number;
@@ -21,6 +22,7 @@ const StepsRoot = ({
     children,
     className,
     customRootClass,
+    detach = false,
     orientation = 'horizontal',
     value,
     defaultValue,
@@ -29,7 +31,7 @@ const StepsRoot = ({
 }: StepsRootProps) => {
     const [currentStep, setCurrentStep] = useControllableState<number>(value, defaultValue ?? 0, onValueChange);
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     return <StepsContext.Provider value={{ currentStep, setCurrentStep, rootClass, orientation }}>
         <Primitive.div className={clsx(rootClass, className, `${rootClass}-${orientation}`)} data-orientation={orientation} {...props}>{children}</Primitive.div>

--- a/src/components/ui/Strong/Strong.tsx
+++ b/src/components/ui/Strong/Strong.tsx
@@ -7,12 +7,13 @@ const COMPONENT_NAME = 'Strong';
 
 export type StrongProps = React.ComponentPropsWithoutRef<'strong'> & {
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
 };
 
 const Strong = React.forwardRef<React.ElementRef<'strong'>, StrongProps>(
-    ({ children, className, customRootClass, ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, className, customRootClass, detach = false, ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         return (
             <strong ref={ref} className={clsx(rootClass, className)} {...props}>
                 {children}

--- a/src/components/ui/Switch/fragments/SwitchRoot.tsx
+++ b/src/components/ui/Switch/fragments/SwitchRoot.tsx
@@ -17,6 +17,7 @@ export type SwitchRootElement = ElementRef<typeof ButtonPrimitive>;
 export type SwitchRootProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> & {
     children: React.ReactNode;
     customRootClass?: string;
+    detach?: boolean;
     color?: string;
     variant?: string;
     size?: string;
@@ -33,6 +34,7 @@ export type SwitchRootProps = ComponentPropsWithoutRef<typeof ButtonPrimitive> &
 const SwitchRoot = forwardRef<SwitchRootElement, SwitchRootProps>(({
     children,
     customRootClass,
+    detach = false,
     color = '',
     variant,
     size,
@@ -52,7 +54,7 @@ const SwitchRoot = forwardRef<SwitchRootElement, SwitchRootProps>(({
         onCheckedChange
     );
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const dataAttributes = useCreateDataAttribute('switch', { variant, size });
     const accentAttributes = useCreateDataAccentColorAttribute(color);

--- a/src/components/ui/TabNav/fragments/TabNavRoot.tsx
+++ b/src/components/ui/TabNav/fragments/TabNavRoot.tsx
@@ -11,6 +11,7 @@ export type TabNavRootProps = React.ComponentPropsWithoutRef<'div'> & {
     loop?: boolean,
     orientation?: 'horizontal' | 'vertical',
     customRootClass?: string,
+    detach?: boolean,
     color?: string;
     value?: string,
     defaultValue?: string,
@@ -18,11 +19,11 @@ export type TabNavRootProps = React.ComponentPropsWithoutRef<'div'> & {
 }
 
 const TabNavRoot = forwardRef<React.ElementRef<'div'>, TabNavRootProps>(({
-    className, loop = true, orientation = 'horizontal', children, color, customRootClass = '', defaultValue = '',
+    className, loop = true, orientation = 'horizontal', children, color, customRootClass = '', detach = false, defaultValue = '',
     onValueChange = () => {},
     value, ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const [tabValue, setTabValue] = useControllableState<string>(
         value,

--- a/src/components/ui/Table/fragments/TableRoot.tsx
+++ b/src/components/ui/Table/fragments/TableRoot.tsx
@@ -7,15 +7,17 @@ const COMPONENT_NAME = 'Table';
 
 type TableRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
 };
 
 const TableRoot = React.forwardRef<React.ElementRef<'div'>, TableRootProps>(({
     children,
     className = '',
     customRootClass = '',
+    detach = false,
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     // Its important to wrap the table in a div with the class 'rad-ui-table' so that the table can be styled properly
     // so we created a new class for <table> element as a one off case in pattern when it comes to naming classes/conventions

--- a/src/components/ui/Tabs/fragments/TabContent.tsx
+++ b/src/components/ui/Tabs/fragments/TabContent.tsx
@@ -9,14 +9,15 @@ const COMPONENT_NAME = 'TabContent';
 
 export type TabContentProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     value?: string;
     asChild?: boolean;
     forceMount?: boolean;
 };
 
 const TabContent = React.forwardRef<React.ElementRef<'div'>, TabContentProps>(
-    ({ className = '', value, children, customRootClass, asChild = false, forceMount = false, ...props }, forwardedRef) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ className = '', value, children, customRootClass, detach = false, asChild = false, forceMount = false, ...props }, forwardedRef) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const context = useContext(TabsRootContext);
         if (!context) throw new Error('TabContent must be used within a TabRoot');
         const { tabValue: activeValue, orientation } = context;

--- a/src/components/ui/Tabs/fragments/TabRoot.tsx
+++ b/src/components/ui/Tabs/fragments/TabRoot.tsx
@@ -13,6 +13,7 @@ const COMPONENT_NAME = 'Tabs';
 
 export type TabRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     value?: string;
     color?: string;
     defaultValue?: string;
@@ -28,6 +29,7 @@ const TabRoot = React.forwardRef<React.ElementRef<'div'>, TabRootProps>(({
     defaultValue = '',
     onValueChange = () => {},
     customRootClass = '',
+    detach = false,
     value,
     className,
     color,
@@ -37,7 +39,7 @@ const TabRoot = React.forwardRef<React.ElementRef<'div'>, TabRootProps>(({
     asChild = false,
     ...props
 }, forwardedRef) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const [tabValue, setTabValue] = useControllableState<string>(
         value,

--- a/src/components/ui/Text/Text.tsx
+++ b/src/components/ui/Text/Text.tsx
@@ -14,6 +14,7 @@ const TAGS = ['div', 'span', 'p', 'label'];
 export type TextProps = {
     children: React.ReactNode;
     customRootClass?: string;
+    detach?: boolean;
     className?: string;
     as?: string;
 } & ComponentPropsWithoutRef<'p'>;
@@ -22,10 +23,10 @@ type TextElement = ElementRef<'p'>;
 
 const Text = forwardRef<TextElement, TextProps>(
     (
-        { children, customRootClass = '', className = '', as = 'p', ...props },
+        { children, customRootClass = '', detach = false, className = '', as = 'p', ...props },
         ref
     ) => {
-        const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClassName = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
         if (!TAGS.includes(as)) {
             as = 'p';

--- a/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
+++ b/src/components/ui/TextArea/fragments/TextAreaRoot.tsx
@@ -7,6 +7,7 @@ const COMPONENT_NAME = 'TextArea';
 
 export type TextAreaRootProps = React.ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
+    detach?: boolean;
     variant?: string;
     size?: string;
     resize?: 'none' | 'vertical' | 'horizontal' | 'both';
@@ -15,8 +16,8 @@ export type TextAreaRootProps = React.ComponentPropsWithoutRef<'div'> & {
 };
 
 const TextAreaRoot = React.forwardRef<React.ElementRef<'div'>, TextAreaRootProps>(
-    ({ children, customRootClass = '', className = '', variant = '', size = '', resize = 'both', color = '', radius = '', ...props }, ref) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    ({ children, customRootClass = '', detach = false, className = '', variant = '', size = '', resize = 'both', color = '', radius = '', ...props }, ref) => {
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const dataAttributes = useCreateDataAttribute('textarea', { variant, size, resize, radius });
         const accentAttributes = useCreateDataAccentColorAttribute(color);
         const composedAttributes = useComposeAttributes(dataAttributes(), accentAttributes());

--- a/src/components/ui/Toggle/Toggle.tsx
+++ b/src/components/ui/Toggle/Toggle.tsx
@@ -14,6 +14,8 @@ export type ToggleElement = React.ElementRef<typeof TogglePrimitive>;
 export interface ToggleProps extends Omit<React.ComponentPropsWithoutRef<typeof TogglePrimitive>, 'onPressedChange'> {
     /** Optional custom root class name to override default styling */
     customRootClass?: string;
+    /** Remove all Rad UI generated classes when true */
+    detach?: boolean;
     /** Accent color for the toggle */
     color?: string;
     /** Callback fired when toggle state changes */
@@ -38,6 +40,7 @@ export interface ToggleProps extends Omit<React.ComponentPropsWithoutRef<typeof 
 const Toggle = forwardRef<ToggleElement, ToggleProps>(({
     defaultPressed = false,
     customRootClass = '',
+    detach = false,
     children,
     className = '',
     color = '',
@@ -56,7 +59,7 @@ const Toggle = forwardRef<ToggleElement, ToggleProps>(({
     // We don't need the validation anymore since the hook handles this
     // This is now handled by the hook's type safety and error messages
 
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const data_attributes: Record<string, string> = {};
 

--- a/src/components/ui/Toggle/tests/Toggle.test.js
+++ b/src/components/ui/Toggle/tests/Toggle.test.js
@@ -13,6 +13,13 @@ describe('Toggle component', () => {
         expect(container.firstChild).toHaveClass('custom-class-toggle');
     });
 
+    test('removes all classes when detach is true', () => {
+        const { container } = render(<Toggle detach={true} onPressedChange={() => {}}>Test Toggle</Toggle>);
+        const toggle = container.firstChild;
+        expect(toggle).not.toHaveClass('rad-ui-toggle');
+        expect(toggle?.className.split(' ').filter(c => c.startsWith('rad-ui-') || c.includes('-toggle')).length).toBe(0);
+    });
+
     test('applies className correctly', () => {
         const { container } = render(<Toggle className="test-class" onPressedChange={() => {}}>Test Toggle</Toggle>);
         expect(container.firstChild).toHaveClass('test-class');

--- a/src/components/ui/ToggleGroup/fragments/ToggleGroupRoot.tsx
+++ b/src/components/ui/ToggleGroup/fragments/ToggleGroupRoot.tsx
@@ -19,6 +19,8 @@ type ToggleGroupRootProps = React.ComponentPropsWithoutRef<'div'> & {
     orientation?: 'horizontal' | 'vertical';
     /** Custom root class name to override default styling */
     customRootClass?: string;
+    /** Remove all Rad UI generated classes when true */
+    detach?: boolean;
     /** Current value or values for the toggle group (controlled mode) */
     value?: any;
     /** Initial value or values for the toggle group (uncontrolled mode) */
@@ -47,6 +49,7 @@ const ToggleGroupRoot = React.forwardRef<ToggleGroupRootElement, ToggleGroupRoot
     loop = true,
     orientation = 'horizontal',
     customRootClass = '',
+    detach = false,
     value,
     defaultValue = [],
     onValueChange,
@@ -58,7 +61,7 @@ const ToggleGroupRoot = React.forwardRef<ToggleGroupRootElement, ToggleGroupRoot
     children,
     ...props
 }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     // Use controllable state for value management
     const [activeToggles, setActiveToggles] = useControllableState(

--- a/src/components/ui/ToggleGroup/stories/ToggleGroup.stories.tsx
+++ b/src/components/ui/ToggleGroup/stories/ToggleGroup.stories.tsx
@@ -15,7 +15,7 @@ const DEFAULT_PRESSED_STATE = false;
 const Template = (args: any) => {
     return (
         <SandboxEditor className="space-y-4 pt-4">
-            <ToggleGroup.Root type={args.type} className={args.className} color={args.color}>
+            <ToggleGroup.Root type={args.type} className={args.className} color={args.color} customRootClass='s'>
                 {
                     items.map((item, index) => {
                         return (

--- a/src/components/ui/Toolbar/fragments/ToolbarRoot.tsx
+++ b/src/components/ui/Toolbar/fragments/ToolbarRoot.tsx
@@ -13,6 +13,7 @@ export type ToolbarRootProps = React.ComponentPropsWithoutRef<'div'> & {
   loop?: boolean;
   dir?: 'ltr' | 'rtl';
   customRootClass?: string;
+  detach?: boolean;
   asChild?: boolean;
 };
 
@@ -24,13 +25,14 @@ const ToolbarRoot = React.forwardRef<HTMLDivElement, ToolbarRootProps>(
             dir = 'ltr',
             className = '',
             customRootClass = '',
+            detach = false,
             asChild = false,
             children,
             ...props
         },
         ref
     ) => {
-        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+        const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
         const context = React.useMemo(() => ({ rootClass, orientation, dir }), [rootClass, orientation, dir]);
         const dataAttributes: Record<string, string> = {
             'data-orientation': orientation as string

--- a/src/components/ui/Tree/fragments/TreeRoot.tsx
+++ b/src/components/ui/Tree/fragments/TreeRoot.tsx
@@ -13,14 +13,15 @@ const COMPONENT_NAME = 'Tree';
 export type TreeRootElement = ElementRef<typeof Primitive.div>;
 export type TreeRootProps = {
     customRootClass?: string;
+    detach?: boolean;
     'aria-label'?: string;
     'aria-labelledby'?: string;
 } & ComponentPropsWithoutRef<typeof Primitive.div>;
 
-const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }, ref) => {
+const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, className = '', customRootClass = '', detach = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }, ref) => {
     const treeRef = useRef<TreeRootElement>(null);
     useImperativeHandle(ref, () => treeRef.current as TreeRootElement);
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     const treeContextValue = {
         rootClass,

--- a/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/ui/VisuallyHidden/VisuallyHidden.tsx
@@ -9,6 +9,7 @@ const COMPONENT_NAME = 'VisuallyHidden';
 export type VisuallyHiddenElement = ElementRef<typeof Primitive.div>;
 export type VisuallyHiddenProps = {
     customRootClass?: string;
+    detach?: boolean;
     style?: CSSProperties;
 } & ComponentPropsWithoutRef<typeof Primitive.div>;
 
@@ -27,8 +28,8 @@ const VISUALLY_HIDDEN_STYLES: CSSProperties = {
     userSelect: 'none'
 } as const;
 
-const VisuallyHidden = forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(({ children, customRootClass, className, style = {}, ...props }, ref) => {
-    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME);
+const VisuallyHidden = forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(({ children, customRootClass, detach = false, className, style = {}, ...props }, ref) => {
+    const rootClass = customClassSwitcher(customRootClass, COMPONENT_NAME, detach);
 
     return (
         <Primitive.div

--- a/src/core/customClassSwitcher/customClassSwitcher.test.tsx
+++ b/src/core/customClassSwitcher/customClassSwitcher.test.tsx
@@ -28,6 +28,11 @@ describe('customClassSwitcher', () => {
         expect(customClassSwitcher('', componentName)).toBe('rad-ui-my-component');
     });
 
+    it('returns empty string when detach is true', () => {
+        expect(customClassSwitcher('', componentName, true)).toBe('');
+        expect(customClassSwitcher(customRootClass, componentName, true)).toBe('');
+    });
+
     it('uses default parameters when called without arguments', () => {
         // @ts-ignore testing missing args
         expect(customClassSwitcher()).toBe('');

--- a/src/core/customClassSwitcher/index.ts
+++ b/src/core/customClassSwitcher/index.ts
@@ -4,7 +4,11 @@ const RAD_UI_CLASS_PREFIX = 'rad-ui';
  * Applies a custom root class the user provides, else applies the default rad-ui classes to the component
  * Rad UI's classes are based on this logic
  * */
-export const customClassSwitcher = (customRootClass: string = '', componentName: string = ''): string => {
+export const customClassSwitcher = (customRootClass: string = '', componentName: string = '', detach: boolean = false): string => {
+    if (detach) {
+        return '';
+    }
+
     if (!componentName) {
         return '';
     }

--- a/src/core/utils/mergeRefs.ts
+++ b/src/core/utils/mergeRefs.ts
@@ -1,15 +1,15 @@
 export function mergeRefs<T>(
-  ...refs: (React.Ref<T> | undefined)[]
+    ...refs: (React.Ref<T> | undefined)[]
 ): React.RefCallback<T> {
-  return (value) => {
-    refs.forEach((ref) => {
-      if (!ref) return;
+    return (value) => {
+        refs.forEach((ref) => {
+            if (!ref) return;
 
-      if (typeof ref === "function") {
-        ref(value);
-      } else {
-        (ref as React.MutableRefObject<T | null>).current = value;
-      }
-    });
-  };
+            if (typeof ref === 'function') {
+                ref(value);
+            } else {
+                (ref as React.MutableRefObject<T | null>).current = value;
+            }
+        });
+    };
 }


### PR DESCRIPTION
should close #1513 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `detach` prop support across all UI components. When enabled, components will not apply Rad UI's generated CSS classes, allowing for complete styling customization.

* **Tests**
  * Added test coverage for the new `detach` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->