### PR TITLE
docs: add audit guides, incident template, and changeset validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/post-release-incident.md
+++ b/.github/ISSUE_TEMPLATE/post-release-incident.md
@@ -1,0 +1,47 @@
+---
+name: Post-release regression incident
+about: Track a regression discovered after a published release
+title: '[REGRESSION] '
+labels: ''
+assignees: ''
+---
+
+## Affected release
+
+- Package version(s) (e.g. `@radui/ui@x.y.z`):
+- Release date / tag / changelog link:
+
+## Summary
+
+What regressed, in one or two sentences?
+
+## Severity
+
+- [ ] Critical (data loss, security, crash loop)
+- [ ] High (broken primary flows for many users)
+- [ ] Medium (incorrect UI/behavior with workaround)
+- [ ] Low (cosmetic, edge case)
+
+## Reproduction
+
+1.
+2.
+3.
+
+**Expected behavior**
+
+**Actual behavior**
+
+## Environment
+
+- Framework / bundler (e.g. Next.js, Vite):
+- Browser / OS (if relevant):
+
+## Mitigation
+
+- Is there a known workaround?
+- Suggested rollback or patch strategy (if any):
+
+## Links
+
+- Related PR(s) / issue(s):

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,10 @@ jobs:
         run: npm ci
         continue-on-error: false
 
+      - name: Validate changesets
+        run: npm run validate:changesets
+        continue-on-error: false
+
       - name: Run ESLint
         run: npm run lint
         continue-on-error: false

--- a/docs/app/docs/components/accordion/docs/example_1.tsx
+++ b/docs/app/docs/components/accordion/docs/example_1.tsx
@@ -1,42 +1,81 @@
 "use client"
-import Accordion from "@radui/ui/Accordion";
-import { ChevronDown } from "lucide-react";
 
+import type { ComponentProps } from "react"
+import Accordion from "@radui/ui/Accordion"
+import { ChevronDown } from "lucide-react"
+
+// Mirrors `WithAnimation` in `src/components/ui/Accordion/stories/Accordion.stories.tsx`
 const items = [
   {
-    id: "react",
-    title: "React",
-    content: "React is a JavaScript library for building user interfaces."
+    title: "The Matrix (1999)",
+    content: (
+      <div>
+        <ul>
+          <li>Summary: A hacker discovers the true nature of reality and his role in the war against its controllers.</li>
+          <li>Key Characters: Neo, Morpheus, Trinity, Agent Smith</li>
+          <li>Memorable Quote: &quot;There is no spoon.&quot;</li>
+        </ul>
+      </div>
+    )
   },
   {
-    id: "angular",
-    title: "Angular",
-    content: "Angular is a platform and framework for building single-page client applications using HTML and TypeScript."
+    title: "The Dark Knight (2008)",
+    content: (
+      <div>
+        <ul>
+          <li>Summary: Batman faces his greatest challenge yet as the Joker wreaks havoc on Gotham City.</li>
+          <li>Key Characters: Batman, Joker, Harvey Dent, Alfred</li>
+          <li>Memorable Quote: &quot;Why so serious?&quot;</li>
+        </ul>
+      </div>
+    )
   },
   {
-    id: "vue",
-    title: "Vue",
-    content: "Vue.js is a progressive framework for building user interfaces."
+    title: "Inception (2010)",
+    content: (
+      <div>
+        <ul>
+          <li>Summary: A thief who enters people&apos;s dreams to steal their secrets must plant an idea in someone&apos;s mind.</li>
+          <li>Key Characters: Cobb, Ariadne, Mal, Saito</li>
+          <li>Memorable Quote: &quot;You mustn&apos;t be afraid to dream a little bigger, darling.&quot;</li>
+        </ul>
+      </div>
+    )
+  },
+  {
+    title: "The Shawshank Redemption (1994)",
+    content: (
+      <div>
+        <ul>
+          <li>Summary: A banker is wrongly convicted</li>
+          <li>Key Characters: Andy Dufresne, Red, Warden Norton, Tommy</li>
+          <li>Memorable Quote: &quot;Get busy living or get busy dying.&quot;</li>
+        </ul>
+      </div>
+    )
   }
 ]
 
-const AccordionExample = () => {
+type AccordionExampleProps = ComponentProps<typeof Accordion.Root>
+
+const AccordionExample = ({ ...args }: AccordionExampleProps) => {
   return (
-  <div className="w-64 md:w-96">
-    <Accordion.Root collapsible transitionDuration={200}>
-      {items.map((item) => (
-        <Accordion.Item key={item.id} value={item.id}>
-          <Accordion.Header>
-            <Accordion.Trigger>
-              {item.title}
-              <ChevronDown className="rad-ui-accordion-chevron" />
-            </Accordion.Trigger>
-          </Accordion.Header>
-          <Accordion.Content>{item.content}</Accordion.Content>
-        </Accordion.Item>
-      ))}
-    </Accordion.Root>
-  </div>)
+    <div className="mx-auto mt-10 w-full max-w-[600px]">
+      <Accordion.Root collapsible transitionDuration={200} {...args}>
+        {items.map((item, index) => (
+          <Accordion.Item key={index} value={index}>
+            <Accordion.Header>
+              <Accordion.Trigger>
+                {item.title}
+                <ChevronDown />
+              </Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>{item.content}</Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </div>
+  )
 }
 
-export default AccordionExample;
+export default AccordionExample

--- a/docs/app/docs/contributing/changeset-quality/content.mdx
+++ b/docs/app/docs/contributing/changeset-quality/content.mdx
@@ -1,0 +1,52 @@
+# Changeset quality rubric
+
+Every user-visible change should have a **clear changeset** so maintainers can produce accurate release notes.
+
+## Required content
+
+- **What changed** in plain language (not only a PR title).
+- **Who is affected** (app developers, design-system consumers, Storybook readers, etc.).
+- **How to adopt** the change when it is not obvious (new prop, renamed export, new CSS dependency).
+
+## Breaking changes
+
+When `"@radui/ui": major` is used in a changeset:
+
+- Include an explicit marker such as **`BREAKING:`** or the phrase **Breaking change** in the changeset body.
+- Describe **before / after** usage or point to a migration section in docs.
+
+The repository validates this rule in CI for major bumps (see `scripts/validate-changesets.mjs`).
+
+## Examples
+
+**Patch / minor (good)**
+
+```md
+---
+"@radui/ui": patch
+---
+
+Fix Tooltip positioning when the anchor scrolls inside a transformed parent.
+```
+
+**Major (good)**
+
+```md
+---
+"@radui/ui": major
+---
+
+Breaking change: `Dialog` now requires a `Title` part for accessibility. Migrate by wrapping titles with `Dialog.Title` or pass `aria-labelledby` as documented.
+```
+
+**Major (needs improvement)**
+
+```md
+---
+"@radui/ui": major
+---
+
+Update Dialog
+```
+
+The last example will fail CI until it documents the breaking behavior.

--- a/docs/app/docs/contributing/changeset-quality/page.tsx
+++ b/docs/app/docs/contributing/changeset-quality/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/changeset-quality/seo.ts
+++ b/docs/app/docs/contributing/changeset-quality/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const changesetQualityMetadata = generateSeoMetadata({
+  title: 'Changeset quality | Rad UI',
+  description: 'How to write high-signal changesets, including mandatory notes for breaking changes.'
+})
+
+export default changesetQualityMetadata

--- a/docs/app/docs/contributing/contributor-checklist/content.mdx
+++ b/docs/app/docs/contributing/contributor-checklist/content.mdx
@@ -1,0 +1,30 @@
+# Contributor checklist (docs, tests, accessibility)
+
+Use this checklist before opening a PR. Skip items that clearly do not apply (for example, copy-only fixes).
+
+## Documentation
+
+- [ ] **Docs site**: If behavior or public API changed, updated the relevant docs page(s) under the docs app.
+- [ ] **Storybook**: Added or updated stories when visuals, states, or interactions changed.
+- [ ] **README / exports**: If you changed `package.json` exports or installation steps, updated root docs accordingly.
+
+## Tests
+
+- [ ] **Unit / component tests**: Added or updated tests for new behavior and regressions.
+- [ ] **Edge cases**: Covered empty states, controlled vs uncontrolled usage (if applicable), and keyboard interaction where relevant.
+
+## Accessibility
+
+- [ ] **Roles and labels**: Interactive elements have appropriate roles, labels, and (where needed) descriptions.
+- [ ] **Keyboard**: Focus order and focus visibility are reasonable; Escape / arrow keys behave as expected for the pattern.
+- [ ] **Motion**: Respects `prefers-reduced-motion` when adding animation (if applicable).
+
+## Release hygiene
+
+- [ ] **Changeset**: Added a `.changeset` entry when the change should appear in the changelog (see [Changeset quality](/docs/contributing/changeset-quality)).
+- [ ] **Breaking changes**: Documented breaking behavior explicitly in the changeset when bumping major.
+
+## Reviewer-friendly PR
+
+- [ ] Linked the tracking issue (if any) and summarized **what** and **why**.
+- [ ] Called out screenshots or Storybook links for visual changes.

--- a/docs/app/docs/contributing/contributor-checklist/page.tsx
+++ b/docs/app/docs/contributing/contributor-checklist/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/contributor-checklist/seo.ts
+++ b/docs/app/docs/contributing/contributor-checklist/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const contributorChecklistMetadata = generateSeoMetadata({
+  title: 'Contributor checklist | Rad UI',
+  description: 'Checklist for documentation, tests, and accessibility when contributing to Rad UI.'
+})
+
+export default contributorChecklistMetadata

--- a/docs/app/docs/contributing/release-candidate-checklist/content.mdx
+++ b/docs/app/docs/contributing/release-candidate-checklist/content.mdx
@@ -1,0 +1,26 @@
+# Release candidate checklist (parity and accessibility)
+
+Use this checklist before tagging a **release candidate** (for example `next` prerelease) or a stable release when the train includes user-facing changes.
+
+## Parity
+
+- [ ] **Changelog**: `.changeset` entries are accurate; no accidental omission of breaking notes.
+- [ ] **Docs**: Docs site builds cleanly; new or changed components have up-to-date docs pages.
+- [ ] **Storybook**: `build-storybook` succeeds; representative stories exist for new components or states.
+- [ ] **Package output**: `npm run build:rollup` and `npm run check:types` pass on a clean tree.
+
+## Accessibility sign-off
+
+- [ ] **Smoke keyboard pass**: Primary interactive components in this release behave correctly with keyboard only.
+- [ ] **Labels**: Form controls and custom widgets expose accessible names where applicable.
+- [ ] **Focus**: Modals, dialogs, and popovers manage focus (trap + restore) per project patterns.
+
+## Quality gates
+
+- [ ] **CI green**: Lint, tests, and coverage workflows are passing on the release branch.
+- [ ] **Visual regression**: Chromatic (or agreed substitute) reviewed for unexpected diffs.
+
+## Communication
+
+- [ ] **Migration notes**: Breaking changes include actionable upgrade steps in the changelog / release notes.
+- [ ] **Known issues**: Any deferred bugs are documented in the release notes or linked issues.

--- a/docs/app/docs/contributing/release-candidate-checklist/page.tsx
+++ b/docs/app/docs/contributing/release-candidate-checklist/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/release-candidate-checklist/seo.ts
+++ b/docs/app/docs/contributing/release-candidate-checklist/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const releaseCandidateChecklistMetadata = generateSeoMetadata({
+  title: 'Release candidate checklist | Rad UI',
+  description: 'Pre-release parity and accessibility sign-off checklist for Rad UI maintainers.'
+})
+
+export default releaseCandidateChecklistMetadata

--- a/docs/app/docs/contributing/security-dependency-sla/content.mdx
+++ b/docs/app/docs/contributing/security-dependency-sla/content.mdx
@@ -1,0 +1,36 @@
+# Security and dependency update SLA (runtime dependencies)
+
+This document sets **maintainer-facing** expectations for how quickly we respond to **security issues** and **runtime dependency** updates. It is not a legal SLA; timelines assume healthy volunteer bandwidth.
+
+## Definitions
+
+- **Runtime dependencies**: Packages listed under `dependencies` in the root `package.json` (code shipped to consumers).
+- **Security advisory**: A CVE, GitHub Dependabot security alert, or credible report that indicates exploitable risk in a dependency we ship or in our published code.
+
+## Security advisories
+
+| Severity | Target response |
+| --- | --- |
+| Critical (remote code execution, auth bypass, data exfiltration in default usage) | Acknowledge within **72 hours**; ship a fix or documented mitigation as soon as practical |
+| High | Acknowledge within **1 week**; prioritize a patch release in the next release window |
+| Medium / Low | Triage in the next **2–4 weeks**; batch with other maintenance work |
+
+**Practices**
+
+- Prefer **patch/minor** dependency bumps that resolve CVEs without breaking the public API.
+- If a fix requires a **breaking** change, document it in a changeset with an explicit **breaking** note and follow the [Changeset quality](/docs/contributing/changeset-quality) guidance.
+
+## Routine dependency updates (runtime)
+
+- **Patch releases** of runtime deps (bug fixes): roll up **at least monthly** or sooner if a release is already planned.
+- **Minor** updates: evaluate **per release**; run tests, Storybook, and docs build before merging.
+- **Major** updates: schedule explicitly; treat as a **mini-migration** with notes for consumers.
+
+## What this does not cover
+
+- `devDependencies` used only in CI, Storybook, or tooling — update on a best-effort basis, prioritizing security alerts for **secrets** and **supply-chain** tooling (e.g. lockfile integrity, provenance).
+- Transitive dependencies — rely on **Dependabot** and `npm audit` signals; bump direct deps to pull in fixed transitive versions where possible.
+
+## Reporting
+
+Report security issues via the contact path described in the repository **Security** policy (GitHub Security Advisories). Please avoid filing public issues for undisclosed vulnerabilities.

--- a/docs/app/docs/contributing/security-dependency-sla/page.tsx
+++ b/docs/app/docs/contributing/security-dependency-sla/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/security-dependency-sla/seo.ts
+++ b/docs/app/docs/contributing/security-dependency-sla/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const securityDependencySlaMetadata = generateSeoMetadata({
+  title: 'Security and dependency update SLA | Rad UI',
+  description: 'Response-time expectations for security advisories and runtime dependency updates in Rad UI.'
+})
+
+export default securityDependencySlaMetadata

--- a/docs/app/docs/contributing/upgrade-and-codemods/content.mdx
+++ b/docs/app/docs/contributing/upgrade-and-codemods/content.mdx
@@ -1,0 +1,27 @@
+# Upgrade assistant and codemods
+
+## Upgrading
+
+1. **Read the release notes** for your target version in the GitHub Releases page for [`rad-ui/ui`](https://github.com/rad-ui/ui/releases).
+2. **Bump the dependency** in your app (`@radui/ui`) following your package manager’s workflow.
+3. **Run your test suite** and a quick manual smoke test of critical flows.
+
+Patch and minor releases should be drop-in when the changelog reports no breaking changes. For **major** releases, follow the breaking-change section in the changelog and update any deprecated APIs.
+
+## Codemods index
+
+Codemods are small scripts that rewrite consumer code during major upgrades. When available, they will live under `codemods/` in the repository root and be listed here.
+
+| Codemod | From → to | Status |
+| --- | --- | --- |
+| — | — | *No codemods are published yet; this table will be updated as they are added.* |
+
+## When we add a codemod
+
+Each codemod entry will include:
+
+- **Purpose**: What API shape it updates.
+- **Command**: How to run it (for example `npx @radui/codemod@x …`).
+- **Safety**: What it does not touch (for example, dynamic imports).
+
+Until then, prefer explicit TypeScript errors and the [Changeset quality](/docs/contributing/changeset-quality) notes shipped with each major bump to guide manual migration.

--- a/docs/app/docs/contributing/upgrade-and-codemods/page.tsx
+++ b/docs/app/docs/contributing/upgrade-and-codemods/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/upgrade-and-codemods/seo.ts
+++ b/docs/app/docs/contributing/upgrade-and-codemods/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const upgradeAndCodemodsMetadata = generateSeoMetadata({
+  title: 'Upgrades and codemods | Rad UI',
+  description: 'How to upgrade Rad UI between versions and where to find codemods.'
+})
+
+export default upgradeAndCodemodsMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -19,36 +19,6 @@ export const docsNavigationSections = [
     },
     {
         type:"CATEGORY",
-        title:"Guides",
-        items:[
-            {
-                title:"Accessibility",
-                path:"/docs/guides/accessibility"
-            },
-            {
-                title:"Date, Time & Timezones",
-                path:"/docs/guides/date-time-and-timezones"
-            },
-            {
-                title:"Internationalization",
-                path:"/docs/guides/internationalization"
-            },
-            {
-                title:"IME / Input Method QA",
-                path:"/docs/guides/ime-input-method-qa"
-            },
-            {
-                title:"Mobile & Touch QA",
-                path:"/docs/guides/mobile-touch-qa"
-            },
-            {
-                title:"SSR & No-JS Fallback",
-                path:"/docs/guides/ssr-and-no-js-fallback"
-            }
-        ]
-    },
-    {
-        type:"CATEGORY",
         title:"Components",
         items:[
             {
@@ -160,6 +130,36 @@ export const docsNavigationSections = [
                 path:"/docs/components/visually-hidden"
             }
 
+        ]
+    },
+    {
+        type:"CATEGORY",
+        title:"Guides",
+        items:[
+            {
+                title:"Accessibility",
+                path:"/docs/guides/accessibility"
+            },
+            {
+                title:"Date, Time & Timezones",
+                path:"/docs/guides/date-time-and-timezones"
+            },
+            {
+                title:"Internationalization",
+                path:"/docs/guides/internationalization"
+            },
+            {
+                title:"IME / Input Method QA",
+                path:"/docs/guides/ime-input-method-qa"
+            },
+            {
+                title:"Mobile & Touch QA",
+                path:"/docs/guides/mobile-touch-qa"
+            },
+            {
+                title:"SSR & No-JS Fallback",
+                path:"/docs/guides/ssr-and-no-js-fallback"
+            }
         ]
     },
     {

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -24,6 +24,26 @@ export const docsNavigationSections = [
             {
                 title:"Accessibility",
                 path:"/docs/guides/accessibility"
+            },
+            {
+                title:"Date, Time & Timezones",
+                path:"/docs/guides/date-time-and-timezones"
+            },
+            {
+                title:"Internationalization",
+                path:"/docs/guides/internationalization"
+            },
+            {
+                title:"IME / Input Method QA",
+                path:"/docs/guides/ime-input-method-qa"
+            },
+            {
+                title:"Mobile & Touch QA",
+                path:"/docs/guides/mobile-touch-qa"
+            },
+            {
+                title:"SSR & No-JS Fallback",
+                path:"/docs/guides/ssr-and-no-js-fallback"
             }
         ]
     },
@@ -165,6 +185,26 @@ export const docsNavigationSections = [
             {
                 title:"Component Coverage",
                 path:"/docs/contributing/component-coverage"
+            },
+            {
+                title:"Security & Dependency SLA",
+                path:"/docs/contributing/security-dependency-sla"
+            },
+            {
+                title:"Contributor Checklist",
+                path:"/docs/contributing/contributor-checklist"
+            },
+            {
+                title:"Release Candidate Checklist",
+                path:"/docs/contributing/release-candidate-checklist"
+            },
+            {
+                title:"Upgrade & Codemods",
+                path:"/docs/contributing/upgrade-and-codemods"
+            },
+            {
+                title:"Changeset Quality",
+                path:"/docs/contributing/changeset-quality"
             }
         ]
     }

--- a/docs/app/docs/guides/date-time-and-timezones/content.mdx
+++ b/docs/app/docs/guides/date-time-and-timezones/content.mdx
@@ -1,0 +1,27 @@
+# Date, time, and timezones
+
+Rad UI does not ship calendar or date-picker primitives today. If we introduce **date or time** UI, follow these guidelines so behavior stays predictable across locales and timezones.
+
+## Storage model
+
+- Prefer storing **UTC instants** (for example `Date` with clear UTC semantics, or epoch ms) for **absolute** moments.
+- Store **calendar dates** (birthdays, all-day holidays) as a **plain date** (YYYY-MM-DD) without a timezone, or use a dedicated date library.
+
+## Presentation
+
+- **Display** in the user’s local timezone for absolute times unless a different zone is explicitly part of the product requirement.
+- **Formatting** should use `Intl.DateTimeFormat` (or a well-vetted library) so locale rules are respected.
+
+## Testing
+
+- Add unit tests around **DST boundaries** and **timezone offsets** when logic converts between zones.
+- Snapshot tests for formatted strings can be fragile; prefer testing **structure** and **invariants** (ordering, equality) over exact strings.
+
+## Accessibility
+
+- Expose **machine-readable** values (`datetime` attributes, ISO strings in `aria-label`) when showing human-formatted dates.
+- Ensure **keyboard** and **screen reader** support for any calendar grid.
+
+## Dependencies
+
+- If we add a date library, document **why** and keep the **runtime bundle impact** justified.

--- a/docs/app/docs/guides/date-time-and-timezones/page.tsx
+++ b/docs/app/docs/guides/date-time-and-timezones/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/date-time-and-timezones/seo.ts
+++ b/docs/app/docs/guides/date-time-and-timezones/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const dateTimeGuideMetadata = generateSeoMetadata({
+  title: 'Date, time, and timezones | Rad UI',
+  description: 'Guidance for date and time handling if Rad UI introduces date-related components.'
+})
+
+export default dateTimeGuideMetadata

--- a/docs/app/docs/guides/ime-input-method-qa/content.mdx
+++ b/docs/app/docs/guides/ime-input-method-qa/content.mdx
@@ -1,0 +1,25 @@
+# IME and input method QA (text-entry components)
+
+Components that wrap or manage text input (`input`, `textarea`, contenteditable surfaces) must behave correctly with **input method editors** (IME) used for Chinese, Japanese, Korean, and other languages.
+
+## Composition events
+
+During IME composition, the browser fires **`compositionstart`**, **`compositionupdate`**, and **`compositionend`**. Logic that **commits** or **filters** input on every `input` or `change` event can break composition.
+
+**Checklist**
+
+- [ ] Do not **close overlays** or **move focus** mid-composition unless required by the platform pattern.
+- [ ] Debounced search or validation should **wait until composition ends** where feasible.
+- [ ] Avoid **mutating controlled value** in ways that reset the IME pre-edit string unexpectedly.
+
+## Manual test matrix
+
+| Scenario | Expected |
+| --- | --- |
+| macOS Japanese IME (Romaji → Hiragana/Kanji) in a text field | Composition completes; committed text matches selection |
+| Windows Microsoft IME (Chinese) | No dropped characters; caret stable |
+| Korean Hangul composition | Syllable blocks commit correctly |
+
+## Automation
+
+IME behavior is **hard to cover reliably** in unit tests alone. Prefer **manual QA** for releases that touch text-entry internals, and **Playwright** only when a stable, low-flake scenario exists.

--- a/docs/app/docs/guides/ime-input-method-qa/page.tsx
+++ b/docs/app/docs/guides/ime-input-method-qa/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/ime-input-method-qa/seo.ts
+++ b/docs/app/docs/guides/ime-input-method-qa/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const imeQaGuideMetadata = generateSeoMetadata({
+  title: 'IME and input method QA | Rad UI',
+  description: 'Manual QA checklist for text-entry components with input method editors (IME).'
+})
+
+export default imeQaGuideMetadata

--- a/docs/app/docs/guides/internationalization/content.mdx
+++ b/docs/app/docs/guides/internationalization/content.mdx
@@ -1,0 +1,23 @@
+# Internationalization and locale-sensitive formatting
+
+Rad UI components are **headless** and **do not** ship translated strings. Applications own translations and locale selection.
+
+## Principles
+
+- **Avoid hard-coded copy** in examples; when we must ship demo text, keep it minimal and clearly marked as demo-only.
+- **Do not** bake locale-specific formatting into components; accept **values** or **formatters** from the app.
+
+## Formatting
+
+- Use **`Intl`** APIs (`Intl.NumberFormat`, `Intl.DateTimeFormat`, `Intl.ListFormat`, `Intl.RelativeTimeFormat`) for locale-aware output.
+- For **pluralization**, use ICU message format or your i18n framework’s plural rules; avoid naive string concatenation.
+
+## Layout and semantics
+
+- Allow **translated strings** to vary in length; avoid fixed widths that clip content.
+- **RTL**: Rad UI components should respect logical CSS (`margin-inline`, `inset-inline`) where layout is directional; test with `dir="rtl"` when adding new layout primitives.
+
+## Testing
+
+- Storybook stories can showcase **pseudo-translation** or **long strings** to catch layout issues.
+- Automated tests should not depend on a single locale’s formatted output unless the assertion is locale-scoped.

--- a/docs/app/docs/guides/internationalization/page.tsx
+++ b/docs/app/docs/guides/internationalization/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/internationalization/seo.ts
+++ b/docs/app/docs/guides/internationalization/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const i18nGuideMetadata = generateSeoMetadata({
+  title: 'Internationalization and locale formatting | Rad UI',
+  description: 'Guidance for i18n and locale-sensitive formatting when building with Rad UI.'
+})
+
+export default i18nGuideMetadata

--- a/docs/app/docs/guides/mobile-touch-qa/content.mdx
+++ b/docs/app/docs/guides/mobile-touch-qa/content.mdx
@@ -1,0 +1,30 @@
+# Mobile and touch interaction QA
+
+Use this checklist when touching **interactive** components (buttons, dialogs, menus, sliders, scroll areas).
+
+## Touch targets
+
+- [ ] **Minimum size**: Interactive hit targets are at least **44×44 CSS px** (or the design system’s documented minimum).
+- [ ] **Spacing**: Adjacent targets are not overlapping in a way that causes mis-taps.
+
+## Gestures and scroll
+
+- [ ] **Scroll chaining**: Nested scroll areas do not trap scrolling unexpectedly on mobile.
+- [ ] **Pull-to-refresh**: Full-screen overlays do not fight browser overscroll (where applicable).
+
+## Virtual keyboard
+
+- [ ] **Focus**: Focusing inputs in a dialog does not scroll the viewport into a broken state.
+- [ ] **Dismiss**: Keyboard dismiss behavior matches platform expectations (e.g. tapping outside).
+
+## Browsers
+
+| Environment | Notes |
+| --- | --- |
+| iOS Safari | Test `-webkit` touch quirks, 100vh behavior, and focus/scroll |
+| Chrome Android | Test toolbar show/hide resize and pointer events |
+
+## Automation
+
+- **Playwright** mobile projects can cover **basic** tap/scroll flows.
+- **Manual** QA remains valuable for gesture timing, IME interaction, and OS-level behaviors.

--- a/docs/app/docs/guides/mobile-touch-qa/page.tsx
+++ b/docs/app/docs/guides/mobile-touch-qa/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/mobile-touch-qa/seo.ts
+++ b/docs/app/docs/guides/mobile-touch-qa/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const mobileTouchQaMetadata = generateSeoMetadata({
+  title: 'Mobile and touch interaction QA | Rad UI',
+  description: 'Manual QA checklist for touch targets, gestures, and mobile browsers.'
+})
+
+export default mobileTouchQaMetadata

--- a/docs/app/docs/guides/ssr-and-no-js-fallback/content.mdx
+++ b/docs/app/docs/guides/ssr-and-no-js-fallback/content.mdx
@@ -1,0 +1,26 @@
+# SSR and no-JS fallback
+
+Rad UI is a **React** component library. Components assume client-side hydration for interactive behavior (state, effects, event listeners).
+
+## Server-side rendering (SSR)
+
+- **Render** static structure on the server when your framework supports it (React DOM server APIs, Next.js, Remix, etc.).
+- **Avoid** `window` / `document` in render paths; use `useEffect` or guarded checks for browser-only APIs.
+- **Hydration**: Ensure `suppressHydrationWarning` is **not** used to hide mismatches unless there is a documented reason (e.g. time-dependent demo text).
+
+## No JavaScript
+
+Without JavaScript, **interactive components will not function**. Recommended patterns:
+
+- **Progressive enhancement**: Ship meaningful **HTML** in the SSR output (headings, links, forms that can post without JS where applicable).
+- **Fallback content**: For critical UI, provide a **noscript** or server-rendered alternative for **read-only** views (for example, a static table instead of a sortable grid).
+
+## Frameworks
+
+- **Next.js App Router**: Follow React Server Components boundaries; keep client-only Rad UI in `"use client"` components when required.
+- **Streaming**: Avoid layout shifts that depend on client-only measurement; prefer stable skeletons or CSS.
+
+## Testing
+
+- Add **SSR smoke tests** when a component touches browser-only APIs or layout measurement.
+- For **no-JS**, rely on **manual** or **e2e** checks that critical content renders without executing scripts (where applicable to your product).

--- a/docs/app/docs/guides/ssr-and-no-js-fallback/page.tsx
+++ b/docs/app/docs/guides/ssr-and-no-js-fallback/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/ssr-and-no-js-fallback/seo.ts
+++ b/docs/app/docs/guides/ssr-and-no-js-fallback/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const ssrNoJsGuideMetadata = generateSeoMetadata({
+  title: 'SSR and no-JS fallback | Rad UI',
+  description: 'Guidance for server rendering and progressive enhancement when using Rad UI.'
+})
+
+export default ssrNoJsGuideMetadata

--- a/docs/app/globals.scss
+++ b/docs/app/globals.scss
@@ -159,11 +159,6 @@ code .selector {
   scroll-behavior: auto !important;
 }
 
-body.docs-no-motion,
-body.docs-no-motion *,
-body.docs-no-motion *::before,
-body.docs-no-motion *::after {
-  transition: none !important;
-  animation: none !important;
-  scroll-behavior: auto !important;
-}
+/* Avoid `transition: none !important` on the whole docs shell: it overrides
+   inline height transitions on Rad UI components (e.g. Accordion) in demos.
+   Prefer `prefers-reduced-motion` in component CSS when reducing motion. */

--- a/docs/app/layout.js
+++ b/docs/app/layout.js
@@ -147,7 +147,7 @@ export default async function RootLayout({ children, ...props }) {
           }}
         />
       </head>
-      <body className="docs-no-motion h-screen overflow-hidden">
+      <body className="h-screen overflow-hidden">
         <PostHogProvider>
           <Main darkModeSsrValue={darkModeSsrValue}>
             {children}

--- a/docs/components/navigation/Category.tsx
+++ b/docs/components/navigation/Category.tsx
@@ -2,7 +2,7 @@ import NavItem from './NavItem'
 
 const Category = ({ categoryItem, pathname, setIsDocsNavOpen }) => {
     return <div className="mb-5">
-        <div className='px-3 pb-1.5 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-gray-800'>{categoryItem.title}</div>
+        <div className='px-3 pb-1.5 text-[0.7rem] font-bold uppercase tracking-[0.14em] text-gray-1000'>{categoryItem.title}</div>
         <ul>
             {categoryItem.items.map((item, itemKey) => {
                 return <li key={itemKey} onClick={() => setIsDocsNavOpen(false)}>

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,20 +1,25 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import createMDX from '@next/mdx'
+import remarkGfm from 'remark-gfm'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 /** @type {import('next').NextConfig} */
-
-const createMDX = require('@next/mdx')
-
 const nextConfig = {
     // Configure `pageExtensions` to include markdown and MDX files
     pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
-    
+
     typescript: {
         ignoreBuildErrors: true,
     },
-    
+
     // SEO and Performance optimizations
     compress: true,
     poweredByHeader: false,
     generateEtags: true,
-    
+
     // Image optimization
     images: {
         formats: ['image/webp', 'image/avif'],
@@ -22,9 +27,9 @@ const nextConfig = {
         imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
         minimumCacheTTL: 60,
     },
-    
+
     // Headers for security and caching
-    async headers() {
+    async headers () {
         return [
             {
                 source: '/(.*)',
@@ -67,9 +72,9 @@ const nextConfig = {
             },
         ]
     },
-    
+
     // Redirects for SEO
-    async redirects() {
+    async redirects () {
         return [
             {
                 source: '/docs',
@@ -80,7 +85,7 @@ const nextConfig = {
     },
 
     // PostHog API rewrites
-    async rewrites() {
+    async rewrites () {
         return [
             {
                 source: '/ingest/static/:path*',
@@ -113,10 +118,10 @@ const nextConfig = {
 }
 
 const withMDX = createMDX({
-    // Add markdown plugins here, as desired
     options: {
-        remarkPlugins: ['remark-gfm'],
+        // remark-gfm is a function; Turbopack requires serializable loader options. Use `next dev --webpack` (see package.json).
+        remarkPlugins: [remarkGfm],
     },
 })
 
-module.exports = withMDX(nextConfig)
+export default withMDX(nextConfig)

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .next && next dev",
+    "dev": "rimraf .next && next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "compile-components:esbuild": "node build-components.cjs",
     "check:types": "tsc --noEmit",
     "check:exports": "node scripts/generate-exports.cjs --check",
+    "validate:changesets": "node scripts/validate-changesets.mjs",
     "build-components:esbuild": "npm run compile-components:esbuild && npm run process-components",
     "build:esbuild": "npm run prebuild && npm run build:css && npm run build-components:esbuild",
     "release": "npm publish --access public",

--- a/scripts/validate-changesets.mjs
+++ b/scripts/validate-changesets.mjs
@@ -28,8 +28,8 @@ function hasMajorBump (frontmatter) {
   return /"@radui\/ui"\s*:\s*major\b/m.test(frontmatter)
 }
 
-function documentsBreakingChange (fullContent) {
-  return /BREAKING|Breaking change|breaking change/m.test(fullContent)
+function documentsBreakingChange (body) {
+  return /BREAKING|Breaking change|breaking change/m.test(body)
 }
 
 let failed = false
@@ -43,7 +43,7 @@ for (const file of readChangesetFiles()) {
     failed = true
     continue
   }
-  if (hasMajorBump(parsed.frontmatter) && !documentsBreakingChange(content)) {
+  if (hasMajorBump(parsed.frontmatter) && !documentsBreakingChange(parsed.body)) {
     console.error(
       `[changeset] ${file}: major bump for "@radui/ui" must include a breaking-change note (e.g. "BREAKING:" or "Breaking change" in the changeset body).`
     )

--- a/scripts/validate-changesets.mjs
+++ b/scripts/validate-changesets.mjs
@@ -1,0 +1,56 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const changesetDir = path.join(__dirname, '..', '.changeset')
+
+function readChangesetFiles () {
+  if (!fs.existsSync(changesetDir)) {
+    return []
+  }
+  return fs.readdirSync(changesetDir).filter((name) => name.endsWith('.md') && name !== 'README.md')
+}
+
+function parseChangeset (content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
+  if (!match) {
+    return null
+  }
+  const frontmatter = match[1]
+  return {
+    frontmatter,
+    body: match[2] ?? ''
+  }
+}
+
+function hasMajorBump (frontmatter) {
+  return /"@radui\/ui"\s*:\s*major\b/m.test(frontmatter)
+}
+
+function documentsBreakingChange (fullContent) {
+  return /BREAKING|Breaking change|breaking change/m.test(fullContent)
+}
+
+let failed = false
+
+for (const file of readChangesetFiles()) {
+  const fullPath = path.join(changesetDir, file)
+  const content = fs.readFileSync(fullPath, 'utf8')
+  const parsed = parseChangeset(content)
+  if (!parsed) {
+    console.error(`[changeset] Invalid frontmatter in ${file}`)
+    failed = true
+    continue
+  }
+  if (hasMajorBump(parsed.frontmatter) && !documentsBreakingChange(content)) {
+    console.error(
+      `[changeset] ${file}: major bump for "@radui/ui" must include a breaking-change note (e.g. "BREAKING:" or "Breaking change" in the changeset body).`
+    )
+    failed = true
+  }
+}
+
+if (failed) {
+  process.exit(1)
+}


### PR DESCRIPTION
- Add post-release regression issue template (#1881)
- Add contributing docs: SLA, checklists, upgrade/codemods index, changeset rubric (#1880, #1879, #1877, #1878, #1874)
- Add guides: date/time, i18n, IME QA, mobile/touch QA, SSR/no-JS (#1873, #1872, #1871, #1870, #1869)
- Enforce major changeset breaking notes in CI (#1874)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added many new contributor and guide pages (changeset quality, contributor checklist, release-candidate checklist, security SLA, upgrades/codemods, date/time, i18n, IME QA, mobile/touch, SSR/no-JS).
  * Updated docs navigation to expose these new guides.

* **Chores**
  * CI now validates changeset quality.
  * Added post-release incident reporting template and a changeset validation script.

* **Style**
  * Adjusted docs site typography and reduced-motion handling; updated an accordion example in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->