### PR TITLE
test: expand RadioGroup behavior coverage for issue #1491

### DIFF
--- a/src/components/ui/RadioGroup/tests/RadioGroup.behavior.test.tsx
+++ b/src/components/ui/RadioGroup/tests/RadioGroup.behavior.test.tsx
@@ -20,45 +20,91 @@ describe('RadioGroup behavior', () => {
         const one = screen.getByTestId('one');
         const two = screen.getByTestId('two');
         const three = screen.getByTestId('three');
+
         await user.tab();
         expect(one).toHaveFocus();
+
         await user.keyboard('{ArrowRight}');
         expect(two).toHaveFocus();
         expect(two).toHaveAttribute('aria-checked', 'true');
+
         await user.keyboard('{End}');
         expect(three).toHaveFocus();
         expect(three).toHaveAttribute('aria-checked', 'true');
+
         await user.keyboard('{Home}');
         expect(one).toHaveFocus();
         expect(one).toHaveAttribute('aria-checked', 'true');
     });
 
-    test('controlled value syncs with onValueChange and defaultValue works', async() => {
+    test('controlled value syncs with onValueChange', async() => {
+        const onValueChange = jest.fn();
+
         const Controlled = () => {
             const [value, setValue] = React.useState('one');
             return (
-                <RadioGroup.Root value={value} onValueChange={setValue}>
+                <RadioGroup.Root
+                    value={value}
+                    onValueChange={(nextValue) => {
+                        onValueChange(nextValue);
+                        setValue(nextValue);
+                    }}
+                >
                     <RadioGroup.Item value="one" data-testid="c-one">one</RadioGroup.Item>
                     <RadioGroup.Item value="two" data-testid="c-two">two</RadioGroup.Item>
                     <RadioGroup.Item value="three" data-testid="c-three">three</RadioGroup.Item>
                 </RadioGroup.Root>
             );
         };
+
         render(<Controlled />);
         const user = userEvent.setup();
+
         await user.tab();
         await user.keyboard('{ArrowRight}');
-        expect(screen.getByTestId('c-two')).toHaveAttribute('aria-checked', 'true');
         await user.keyboard('{ArrowRight}');
-        expect(screen.getByTestId('c-three')).toHaveAttribute('aria-checked', 'true');
 
+        expect(onValueChange).toHaveBeenCalledWith('two');
+        expect(onValueChange).toHaveBeenCalledWith('three');
+        expect(screen.getByTestId('c-three')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('defaultValue is selected when provided', () => {
         render(
             <RadioGroup.Root defaultValue="two">
                 <RadioGroup.Item value="one" data-testid="u-one">one</RadioGroup.Item>
                 <RadioGroup.Item value="two" data-testid="u-two">two</RadioGroup.Item>
             </RadioGroup.Root>
         );
+
+        expect(screen.getByTestId('u-one')).toHaveAttribute('aria-checked', 'false');
         expect(screen.getByTestId('u-two')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('with no default selection, initial radios are unchecked and form submit starts empty', async() => {
+        let submitted: FormData | undefined;
+        const handleSubmit = (e: React.FormEvent) => {
+            e.preventDefault();
+            submitted = new FormData(e.target as HTMLFormElement);
+        };
+
+        render(
+            <form onSubmit={handleSubmit}>
+                <RadioGroup.Root name="empty-rg">
+                    <RadioGroup.Item value="one" data-testid="nd-one">one</RadioGroup.Item>
+                    <RadioGroup.Item value="two" data-testid="nd-two">two</RadioGroup.Item>
+                </RadioGroup.Root>
+                <button type="submit">submit empty</button>
+            </form>
+        );
+
+        expect(screen.getByTestId('nd-one')).toHaveAttribute('aria-checked', 'false');
+        expect(screen.getByTestId('nd-two')).toHaveAttribute('aria-checked', 'false');
+
+        const user = userEvent.setup();
+        await user.click(screen.getByText('submit empty'));
+
+        expect(submitted?.get('empty-rg')).toBe('');
     });
 
     test('form submission includes selected value and disabled radios skip focus', async() => {
@@ -78,12 +124,50 @@ describe('RadioGroup behavior', () => {
             </form>
         );
         const user = userEvent.setup();
+
         await user.tab();
         await user.keyboard('{ArrowRight}');
+
+        const disabled = screen.getByTestId('f-two');
         const three = screen.getByTestId('f-three');
+        expect(disabled).toHaveAttribute('aria-disabled', 'true');
         expect(three).toHaveFocus();
+
         await user.click(screen.getByText('submit'));
         expect(submitted?.get('rg')).toBe('three');
+    });
+
+    test('nested groups keep keyboard focus navigation scoped to the active group', async() => {
+        render(
+            <div>
+                <RadioGroup.Root data-testid="outer-group" defaultValue="outer-1">
+                    <RadioGroup.Item value="outer-1" data-testid="outer-1">outer 1</RadioGroup.Item>
+                    <RadioGroup.Item value="outer-2" data-testid="outer-2">outer 2</RadioGroup.Item>
+                </RadioGroup.Root>
+
+                <RadioGroup.Root data-testid="inner-group" defaultValue="inner-1">
+                    <RadioGroup.Item value="inner-1" data-testid="inner-1">inner 1</RadioGroup.Item>
+                    <RadioGroup.Item value="inner-2" data-testid="inner-2">inner 2</RadioGroup.Item>
+                </RadioGroup.Root>
+            </div>
+        );
+
+        const user = userEvent.setup();
+
+        await user.tab();
+        expect(screen.getByTestId('outer-1')).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(screen.getByTestId('outer-2')).toHaveFocus();
+        expect(screen.getByTestId('inner-1')).toHaveAttribute('aria-checked', 'true');
+        expect(screen.getByTestId('inner-2')).toHaveAttribute('aria-checked', 'false');
+
+        await user.tab();
+        expect(screen.getByTestId('inner-1')).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(screen.getByTestId('inner-2')).toHaveFocus();
+        expect(screen.getByTestId('outer-2')).toHaveAttribute('aria-checked', 'true');
     });
 
     test('data-state and data-disabled attributes reflect state', () => {


### PR DESCRIPTION
### Motivation
- Increase test coverage and lock down behavior described in issue #1491 around keyboard navigation, selection, and form integration for the `RadioGroup` component.  
- Ensure controlled and uncontrolled (default) usage behave correctly and that disabled items are skipped during keyboard navigation.  
- Verify nested groups, `asChild` semantics, RTL navigation, and accessibility expectations remain correct.

### Description
- Expanded `src/components/ui/RadioGroup/tests/RadioGroup.behavior.test.tsx` with additional scenarios including a dedicated controlled `onValueChange` test, separate `defaultValue` test, test for no-default selection + empty form submission, nested groups focus scoping, and explicit assertions for disabled-item skip behavior.  
- Added a spy for controlled updates to assert `onValueChange` is invoked with intermediate values when selection changes.  
- Kept and validated existing accessibility, `asChild` ref semantics, and RTL navigation assertions.

### Testing
- Ran `npm test -- src/components/ui/RadioGroup/tests/RadioGroup.behavior.test.tsx` and it passed (10 tests).  
- Ran `npm test -- src/components/ui/RadioGroup/tests/RadioGroup.test.tsx` and it passed (7 tests).  
- Ran coverage with `jest --coverage` for the RadioGroup behavior test and observed global coverage thresholds were not met (coverage run reported thresholds failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc59d039088331b5ccac048e1e8326)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for RadioGroup component's controlled and uncontrolled behavior, form submission, disabled states, and keyboard navigation in nested group scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->