### PR TITLE
perf(menubar): reduce unnecessary context-driven re-renders

### DIFF
--- a/src/components/ui/Menubar/fragments/MenubarMenu.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarMenu.tsx
@@ -25,9 +25,10 @@ const MenubarMenu = forwardRef<MenubarMenuElement, MenubarMenuProps>(({ children
         if (id) {
             registerItem(id);
         }
-    }, [id]);
+    }, [id, registerItem]);
 
     const isOpen = items.find((item: MenubarItem) => item.id === id)?.state === 'open';
+    const menuContextValue = React.useMemo(() => ({ isOpen }), [isOpen]);
     return (
 
         <MenuPrimitive.Root
@@ -39,7 +40,7 @@ const MenubarMenu = forwardRef<MenubarMenuElement, MenubarMenuProps>(({ children
             onOpenChange={(open) => id && updateItemState(id, open ? 'open' : 'closed')}
             {...props}
         >
-            <MenubarMenuContext.Provider value={{ isOpen }}>
+            <MenubarMenuContext.Provider value={menuContextValue}>
                 {children}
             </MenubarMenuContext.Provider>
         </MenuPrimitive.Root>

--- a/src/components/ui/Menubar/fragments/MenubarRoot.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarRoot.tsx
@@ -18,11 +18,12 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
     const [items, setItems] = React.useState<MenubarItem[]>([]);
     const [activeIndex, setActiveIndex] = React.useState(0);
 
-    const registerItem = (id: string, state: 'open' | 'closed' = 'closed') => {
+    const registerItem = React.useCallback((id: string, state: 'open' | 'closed' = 'closed') => {
         setItems((prev) => {
             // if already exists, just update its state
             const existing = prev.find((item) => item.id === id);
             if (existing) {
+                if (existing.state === state) return prev;
                 return prev.map((item) =>
                     item.id === id ? { ...item, state } : item
                 );
@@ -30,15 +31,15 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
             // else add new item
             return [...prev, { id, state }];
         });
-    };
+    }, []);
 
-    const updateItemState = (id: string, newState: 'open' | 'closed') => {
+    const updateItemState = React.useCallback((id: string, newState: 'open' | 'closed') => {
         setItems((prev) =>
-            prev.map((item) => (item.id === id ? { ...item, state: newState } : item))
+            prev.map((item) => (item.id === id && item.state !== newState ? { ...item, state: newState } : item))
         );
-    };
+    }, []);
 
-    const handleOnNavigate = (newIndex: number) => {
+    const handleOnNavigate = React.useCallback((newIndex: number) => {
         const prevItem = items[activeIndex];
         const nextItem = items[newIndex];
 
@@ -54,10 +55,15 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
         }
 
         setActiveIndex(newIndex);
-    };
+    }, [activeIndex, items, updateItemState]);
+
+    const contextValue = React.useMemo(
+        () => ({ rootClass, registerItem, items, updateItemState }),
+        [rootClass, registerItem, items, updateItemState]
+    );
 
     return (
-        <MenubarContext.Provider value={{ rootClass, registerItem, items, updateItemState }} >
+        <MenubarContext.Provider value={contextValue} >
             <Floater.Composite
                 ref={ref}
                 className={clsx(`${rootClass}-root`, className)} dir={dir} loop={loop} {...props} activeIndex={activeIndex}

--- a/src/components/ui/Menubar/tests/Menubar.test.tsx
+++ b/src/components/ui/Menubar/tests/Menubar.test.tsx
@@ -1,6 +1,7 @@
 import React, { createRef } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Menubar from '../Menubar';
+import MenubarContext from '../contexts/MenubarContext';
 
 describe('Menubar', () => {
     test('forwards refs to subcomponents', () => {
@@ -68,5 +69,39 @@ describe('Menubar', () => {
         expect(error).not.toHaveBeenCalled();
         warn.mockRestore();
         error.mockRestore();
+    });
+
+    test('does not re-render context consumers when parent re-renders without state changes', () => {
+        const renderSpy = jest.fn();
+
+        const RenderCounter = React.memo(() => {
+            const context = React.useContext(MenubarContext);
+            renderSpy();
+            return <span>{context?.rootClass}</span>;
+        });
+
+        const Wrapper = () => {
+            const [count, setCount] = React.useState(0);
+            return (
+                <>
+                    <button onClick={() => setCount((prev) => prev + 1)}>rerender {count}</button>
+                    <Menubar.Root>
+                        <RenderCounter />
+                        <Menubar.Menu>
+                            <Menubar.Trigger>File</Menubar.Trigger>
+                            <Menubar.Content>
+                                <Menubar.Item>New</Menubar.Item>
+                            </Menubar.Content>
+                        </Menubar.Menu>
+                    </Menubar.Root>
+                </>
+            );
+        };
+
+        const { getByText } = render(<Wrapper />);
+        const baselineRenderCount = renderSpy.mock.calls.length;
+
+        fireEvent.click(getByText(/rerender/i));
+        expect(renderSpy).toHaveBeenCalledTimes(baselineRenderCount);
     });
 });


### PR DESCRIPTION
### Motivation
- Prevent Menubar context consumers from being forced to re-render when parent components update without menubar state changes by stabilizing the context value and avoiding redundant state writes.

### Description
- Memoized `registerItem`, `updateItemState`, and `handleOnNavigate` with `useCallback` to keep function identities stable across re-renders.
- Added guards to `registerItem`/`updateItemState` to skip updates when an item's state is already the desired value to avoid needless state writes.
- Memoized the provider value with `useMemo` in `MenubarRoot` and memoized the `MenubarMenuContext` value in `MenubarMenu` to avoid cascading consumer updates.
- Fixed `useEffect` dependencies in `MenubarMenu` and added a regression test that asserts context consumers do not re-render when an unrelated parent re-renders.

### Testing
- Ran `npm test -- src/components/ui/Menubar/tests/Menubar.test.tsx --runInBand` and the suite passed (`4` tests passed).
- Ran `npm test -- src/components/ui/Menubar/tests/Menubar.a11y.test.tsx --runInBand` and the suite passed (`1` test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5c7f3b108331a21dd2ce7ea7f436)