### PR TITLE
feat(agents): add spell-check readability skill

### DIFF
--- a/agents/skills/spell-check-readability.md
+++ b/agents/skills/spell-check-readability.md
@@ -1,0 +1,89 @@
+# Spell Check And Readability Review
+
+Use this skill when a change introduces or modifies user-facing copy, code
+comments, documentation, stories, examples, changelog text, issue templates, or
+public API names that humans need to read and trust.
+
+## Source Of Truth
+
+Start with [Knowledge Master List](../../knowledge/MASTER_LIST.md).
+
+Then inspect only the files relevant to the current task and review the actual
+diff before making edits. This workflow is intentionally manual. Do not add new
+spell-check infrastructure, dependencies, CI jobs, or config files unless the
+task explicitly asks for them.
+
+## Goal
+
+Improve readability and catch spelling mistakes in the touched scope without
+creating noisy wording churn or changing stable API contracts casually.
+
+## What To Review
+
+Prioritize:
+
+- Documentation, guides, README sections, and issue or PR templates.
+- Component stories, examples, demo copy, and empty states.
+- Accessibility text such as labels, descriptions, helper text, and error
+  messages.
+- Code comments, test names, and contributor-facing scripts or instructions.
+- Public API names only when a typo is clearly incorrect and the rename is
+  intentional, safe, and justified.
+
+## Review Workflow
+
+1. Start from the diff or the narrow task scope. Do not sweep the entire
+   repository unless the task explicitly asks for a broad audit.
+2. Read surrounding sentences, not isolated words. Fix grammar, spelling, and
+   awkward phrasing only when the result is clearly more accurate or readable.
+3. Preserve product terminology, package names, code identifiers, URLs, quoted
+   external text, and intentional branding even when they look unusual.
+4. Be careful with technical vocabulary. Do not "correct" library terms such as
+   `unstyled`, `headless`, `data-*`, `Storybook`, `TypeScript`, or component
+   names that are already established in the repo.
+5. If a typo appears in a private variable or test title, fix it directly. If a
+   typo appears in a public export, prop, selector, data attribute, or
+   documented API, treat that as an API change and only rename it when the task
+   expects that level of change.
+
+## Fix Rules
+
+- Prefer minimal edits that preserve existing meaning.
+- Do not rewrite paragraphs just to match personal style.
+- Do not expand scope into tone, SEO, or marketing revisions unless the task is
+  specifically about that content.
+- If a sentence is ambiguous, fix the ambiguity before polishing the wording.
+- Keep examples consistent with the repo's actual APIs and terminology after the
+  edit.
+
+## Helpful Checks
+
+Use fast local searches when useful, for example:
+
+- Search for a suspicious term with `rg`.
+- Review changed prose with `git diff --word-diff`.
+- Re-scan neighboring docs or examples that repeat the same phrase.
+
+Manual judgment is the default. Tooling is optional only if it already exists in
+the repo or the user explicitly asks for it.
+
+## Verification
+
+After edits, run the smallest checks that match the touched files.
+
+- If only Markdown or agent docs changed, verify formatting by rereading the
+  rendered structure in plain text and run `git diff --check`.
+- If code comments, stories, or UI copy changed, run the narrowest relevant repo
+  command from `knowledge/MASTER_LIST.md` or `package.json`.
+- If a command is unnecessary or unavailable, say so explicitly in the final
+  summary.
+
+## Deliverable
+
+Report:
+
+- Which files or content types were reviewed.
+- What wording, spelling, or readability issues were fixed.
+- Whether any suspicious terms were intentionally left unchanged because they are
+  public API, branding, or external language.
+- Which checks were run.

--- a/knowledge/MASTER_LIST.md
+++ b/knowledge/MASTER_LIST.md
@@ -72,4 +72,6 @@ Open these as needed based on the task:
 
 - Treat this file as the starting point, not the only source of truth.
 - Pull in only the minimum additional docs needed for the task to keep context focused.
+- Agent-specific task playbooks live in `agents/`.
+- When a change touches docs, user-facing copy, comments, examples, or public API names, consider running the spell and readability workflow in `agents/skills/spell-check-readability.md`.
 - If this file becomes outdated, update it as part of the change.


### PR DESCRIPTION
## Summary
- add a new `agents/skills/spell-check-readability.md` workflow for manual spell and readability review
- document in `knowledge/MASTER_LIST.md` that agent task playbooks live in `agents/` and point agents to the new spell-check workflow when changes touch human-readable content
- keep the solution intentionally lightweight with no new spell-check infrastructure or CI

## Why
Issue #1899 asked for an agent skill instead of investing in dedicated spell-check infrastructure. This adds a reusable workflow that helps agents catch readability and spelling issues in docs, copy, comments, examples, and API-facing text while keeping scope narrow.

## Validation
- reviewed the new markdown content directly
- ran `git diff --check`

## Risks / Follow-ups
- this is guidance only, so it improves agent behavior but does not enforce spelling checks automatically

Closes #1899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive workflow documentation for reviewing and correcting spelling and readability issues across user-facing copy, documentation, examples, API names, and related materials, with detailed process steps, fix rules, helpful checks, and verification guidance
  * Updated master knowledge reference guide to cross-reference the new workflow documentation and related agent task playbooks for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->