### PR TITLE
docs(a11y): centralize keyboard shortcut labels

### DIFF
--- a/docs/app/docs/components/accordion/docs/codeUsage.js
+++ b/docs/app/docs/components/accordion/docs/codeUsage.js
@@ -1,6 +1,10 @@
-import Kbd from '@radui/ui/Kbd';
 import Text from '@radui/ui/Text';
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    ACCESSIBLE_KEYBOARD_KEYS,
+    KEYBOARD_SHORTCUT_COLUMNS,
+    renderKeyboardShortcut
+} from '@/utils/accessibility/keyboard';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/accordion/docs/example_1.tsx');
 
@@ -37,80 +41,71 @@ export const api_documentation = {
 }
 
 export const keyboardShortcuts = {
-    columns: [
-        {
-            name: 'Shortcut',
-            id: 'shortcut'
-        },
-        {
-            name: 'Description',
-            id: 'description'
-        }
-    ],
+    columns: KEYBOARD_SHORTCUT_COLUMNS,
     data: [
         {
-            shortcut: <Kbd>Space</Kbd>,
+            shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.SPACE),
             description: <Text>
               When focus is on an Accordion.Trigger of a collapsed section, expands the section.
             </Text>,
             id: "space"
         },
         {
-          shortcut: <Kbd>Enter</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ENTER),
           description: <Text>
             When focus is on an Accordion.Trigger of an expanded section, collapses the section.
           </Text>,
           id: "enter"
         },
         {
-          shortcut: <Kbd>Tab</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.TAB),
           description: <Text>
             When focus is on an Accordion.Trigger of a collapsed section, focuses the next Accordion.Trigger.
           </Text>,
           id: "tab"
         },
         {
-          shortcut: <Kbd>Shift + Tab</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.SHIFT_TAB),
           description: <Text>
             When focus is on an Accordion.Trigger of an expanded section, focuses the previous Accordion.Trigger.
           </Text>,
           id: "shift-tab"
         },
         {
-          shortcut: <Kbd>ArrowDown</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ARROW_DOWN),
           description: <Text>
             When focus is on an Accordion.Trigger of a collapsed section, focuses the next Accordion.Trigger.
           </Text>,
           id: "arrow-down"
         },
         {
-          shortcut: <Kbd>ArrowUp</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ARROW_UP),
           description: <Text>
             When focus is on an Accordion.Trigger of an expanded section, focuses the previous Accordion.Trigger.
           </Text>,
           id:   "arrow-up"
         },
         // {
-        //   shortcut: <Kbd>ArrowRight</Kbd>,
+        //   shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ARROW_RIGHT),
         //   description: <Text>
         //     When focus is on an Accordion.Trigger of a collapsed section, focuses the next Accordion.Trigger.
         //   </Text>
         // },
         // {
-        //   shortcut: <Kbd>ArrowLeft</Kbd>,
+        //   shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ARROW_LEFT),
         //   description: <Text>
         //     When focus is on an Accordion.Trigger of an expanded section, focuses the previous Accordion.Trigger.
         //   </Text>
         // }
         {
-          shortcut: <Kbd>Home</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.HOME),
           description: <Text>
             When focus is on an Accordion.Trigger, focuses the first Accordion.Trigger. [TODO]
           </Text>,
           id: "home"
         },
         {
-          shortcut: <Kbd>End</Kbd>,
+          shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.END),
           description: <Text>
             When focus is on an Accordion.Trigger, focuses the last Accordion.Trigger. [TODO]
           </Text>,

--- a/docs/app/docs/components/tooltip/docs/codeUsage.js
+++ b/docs/app/docs/components/tooltip/docs/codeUsage.js
@@ -1,6 +1,10 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
-import Kbd from '@radui/ui/Kbd';
 import Text from '@radui/ui/Text';
+import {
+    ACCESSIBLE_KEYBOARD_KEYS,
+    KEYBOARD_SHORTCUT_COLUMNS,
+    renderKeyboardShortcut
+} from '@/utils/accessibility/keyboard';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tooltip/docs/examples/tooltip_example1.tsx');
 const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tooltip/docs/anatomy.tsx');
@@ -41,40 +45,31 @@ export const api_documentation = {
 
 // Keyboard shortcuts
 export const keyboardShortcuts = {
-    columns: [
-        {
-            name: 'Shortcut',
-            id: 'shortcut'
-        },
-        {
-            name: 'Description',
-            id: 'description'
-        }
-    ],
+    columns: KEYBOARD_SHORTCUT_COLUMNS,
     data: [
         {
-            shortcut: <Kbd>Tab</Kbd>,
+            shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.TAB),
             description: <Text>
                 Moves focus to the trigger element.
             </Text>,
             id: "tab"
         },
         {
-            shortcut: <Kbd>Space</Kbd>,
+            shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.SPACE),
             description: <Text>
                 When focus is on the trigger, toggles the tooltip.
             </Text>,
             id: "space"
         },
         {
-            shortcut: <Kbd>Enter</Kbd>,
+            shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ENTER),
             description: <Text>
                 When focus is on the trigger, toggles the tooltip.
             </Text>,
             id: "enter"
         },
         {
-            shortcut: <Kbd>Escape</Kbd>,
+            shortcut: renderKeyboardShortcut(ACCESSIBLE_KEYBOARD_KEYS.ESCAPE),
             description: <Text>
                 Dismisses an open tooltip.
             </Text>,

--- a/docs/app/docs/guides/accessibility/content.mdx
+++ b/docs/app/docs/guides/accessibility/content.mdx
@@ -1,3 +1,6 @@
+import Kbd from '@radui/ui/Kbd';
+import { ACCESSIBLE_KEYBOARD_KEYS } from '@/utils/accessibility/keyboard';
+
 # Accessibility
 
 Accessibility is not an add on in Rad UI.  
@@ -29,10 +32,10 @@ ARIA is used deliberately and only when necessary. Native semantics are preferre
 All Rad UI components are designed to be fully operable using a keyboard.
 
 Supported interactions include:
-- Tab and Shift + Tab for navigation
+- <Kbd>{ACCESSIBLE_KEYBOARD_KEYS.TAB}</Kbd> and <Kbd>{ACCESSIBLE_KEYBOARD_KEYS.SHIFT_TAB}</Kbd> for navigation
 - Arrow keys for directional movement
-- Enter and Space for activation
-- Escape for dismissal where applicable
+- <Kbd>{ACCESSIBLE_KEYBOARD_KEYS.ENTER}</Kbd> and <Kbd>{ACCESSIBLE_KEYBOARD_KEYS.SPACE}</Kbd> for activation
+- <Kbd>{ACCESSIBLE_KEYBOARD_KEYS.ESCAPE}</Kbd> for dismissal where applicable
 
 Keyboard behavior follows platform conventions so interactions feel familiar and predictable.
 

--- a/docs/utils/accessibility/keyboard.tsx
+++ b/docs/utils/accessibility/keyboard.tsx
@@ -1,0 +1,32 @@
+import Kbd from '@radui/ui/Kbd';
+
+export const ACCESSIBLE_KEYBOARD_KEYS = Object.freeze({
+    ARROW_DOWN: 'ArrowDown',
+    ARROW_LEFT: 'ArrowLeft',
+    ARROW_RIGHT: 'ArrowRight',
+    ARROW_UP: 'ArrowUp',
+    END: 'End',
+    ENTER: 'Enter',
+    ESCAPE: 'Escape',
+    HOME: 'Home',
+    SHIFT_TAB: 'Shift + Tab',
+    SPACE: 'Space',
+    TAB: 'Tab'
+});
+
+export const KEYBOARD_SHORTCUT_COLUMNS = Object.freeze([
+    {
+        name: 'Shortcut',
+        id: 'shortcut'
+    },
+    {
+        name: 'Description',
+        id: 'description'
+    }
+]);
+
+export function renderKeyboardShortcut(shortcut: string | string[]) {
+    const label = Array.isArray(shortcut) ? shortcut.join(' / ') : shortcut;
+
+    return <Kbd>{label}</Kbd>;
+}


### PR DESCRIPTION
## What changed
- added a shared `docs/utils/accessibility/keyboard.tsx` registry for keyboard shortcut labels and shared table columns
- switched the accordion and tooltip keyboard interaction tables to use the shared constants and renderer
- updated the accessibility guide to render the same shared keyboard labels in its keyboard navigation section

## Why
Issue #1898 asked for internal enums/constants for accessible keyboard content so docs can render shortcut labels consistently instead of duplicating raw strings in each page.

Closes #1898.

## Tests / validation
- `npm run build` in `docs/` attempted from the issue worktree
  - blocked by an existing unrelated docs failure: toast docs import `@radui/ui/Toast`, which is not currently exported by the package
- targeted ESLint attempted for the edited docs files
  - blocked by existing Next/Babel resolution problems in the docs lint setup for the isolated worktree

## Risks / follow-ups
- only the current keyboard interaction docs that already rendered shortcut tables were migrated in this change; additional docs pages can adopt the shared keyboard constants over time
- the unrelated docs build/lint environment issues should be fixed separately to restore clean validation for docs-only changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced consistency of keyboard shortcut references across accessibility documentation guides and component examples.

* **Refactor**
  * Centralized keyboard shortcut definitions and rendering logic to improve maintainability and reduce duplication across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->