### PR TITLE
fix: remove react-remove-scroll from dialog overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "clsx": "^2.1.1",
-        "react-remove-scroll": "^2.7.2"
+        "clsx": "^2.1.1"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.2",
@@ -16507,73 +16506,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -20332,47 +20264,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -450,8 +450,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.16",
-    "clsx": "^2.1.1",
-    "react-remove-scroll": "^2.7.2"
+    "clsx": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveOverlay.tsx
@@ -3,8 +3,6 @@ import React, { forwardRef, useContext } from 'react';
 import Floater from '~/core/primitives/Floater';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 
-import { RemoveScroll } from 'react-remove-scroll';
-
 export type DialogPrimitiveOverlayProps = React.ComponentPropsWithoutRef<typeof Floater.Overlay> & {
     asChild?: boolean;
     forceMount?: boolean;
@@ -17,33 +15,31 @@ const DialogPrimitiveOverlay = forwardRef<HTMLDivElement, DialogPrimitiveOverlay
     onClick,
     ...props
 }, ref) => {
-    const { isOpen, handleOverlayClick, refs } = useContext(DialogPrimitiveContext);
+    const { isOpen, handleOverlayClick } = useContext(DialogPrimitiveContext);
 
     const shouldRender = isOpen || forceMount;
     const dataState = isOpen ? 'open' : 'closed';
-    const floatingElement = (refs as { floating?: { current?: HTMLElement | null } }).floating?.current;
 
     return (
         <>
             {shouldRender && (
-                <RemoveScroll enabled={isOpen} shards={floatingElement ? [floatingElement] : []}>
-                    <Floater.Overlay
-                        ref={ref}
-                        onClick={(event) => {
-                            onClick?.(event);
+                <Floater.Overlay
+                    ref={ref}
+                    lockScroll={isOpen}
+                    onClick={(event) => {
+                        onClick?.(event);
 
-                            if (event.defaultPrevented) {
-                                return;
-                            }
+                        if (event.defaultPrevented) {
+                            return;
+                        }
 
-                            handleOverlayClick();
-                        }}
-                        data-state={dataState}
-                        {...props}
-                    >
-                        {children}
-                    </Floater.Overlay>
-                </RemoveScroll>
+                        handleOverlayClick();
+                    }}
+                    data-state={dataState}
+                    {...props}
+                >
+                    {children}
+                </Floater.Overlay>
             )}
         </>
     );

--- a/src/test-utils/portal.ts
+++ b/src/test-utils/portal.ts
@@ -51,9 +51,11 @@ export function assertFocusReturn(element: HTMLElement) {
 }
 
 export function assertScrollLock() {
-    expect(document.body.getAttribute('data-scroll-locked')).toBe('1');
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.paddingRight).not.toBe('');
 }
 
 export function assertScrollUnlock() {
-    expect(document.body.getAttribute('data-scroll-locked')).toBeNull();
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.paddingRight).toBe('');
 }


### PR DESCRIPTION
## Summary
- replace `DialogPrimitiveOverlay`'s `react-remove-scroll` wrapper with `FloatingOverlay`'s built-in `lockScroll` prop
- remove the direct `react-remove-scroll` dependency from `package.json` and `package-lock.json`
- update the shared portal scroll-lock test helper to assert the body styles applied by Floating UI instead of the removed library marker

## Why
Issue #1904 asks us to stop depending on `react-remove-scroll` now that Floating UI provides scroll locking on the overlay itself. This keeps the dialog overlay aligned with the rest of the floater usage and removes an unnecessary dependency.

## Validation
- `npm test -- --runInBand src/components/ui/Dialog/tests/Dialog.test.tsx src/components/ui/Dialog/tests/Dialog.portal.test.tsx src/components/ui/AlertDialog/tests/AlertDialog.test.tsx src/components/ui/AlertDialog/tests/AlertDialog.a11y.test.tsx`
- `npm run build:rollup` was attempted. It progressed past the dialog changes, but the repo's existing build pipeline emitted unrelated warnings and eventually hit an out-of-memory failure during the broader declaration build.

## Risks / Follow-ups
- The scroll-lock assertions now validate the observable body styles from Floating UI rather than `react-remove-scroll`'s private `data-scroll-locked` attribute.
- The broader `build:rollup` instability appears unrelated to this issue and may need a separate follow-up if it should be addressed.

Closes #1904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored scroll locking implementation in Dialog components.

* **Tests**
  * Updated scroll lock and unlock test assertions.

* **Chores**
  * Removed unused package from dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->