### PR TITLE
fix: keep accordion roving focus on enabled triggers

### DIFF
--- a/src/components/ui/Accordion/tests/Accordion.focus.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.focus.test.tsx
@@ -28,6 +28,23 @@ const FocusHarness = (props: Partial<AccordionRootProps>) => (
     </div>
 );
 
+const DisabledFirstHarness = (props: Partial<AccordionRootProps>) => (
+    <div>
+        <button type="button">Before</button>
+        <Accordion.Root collapsible {...props}>
+            {testItems.map((item, index) => (
+                <Accordion.Item value={index} key={index} disabled={index === 0}>
+                    <Accordion.Header>
+                        <Accordion.Trigger>{item.title}</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content>{item.content}</Accordion.Content>
+                </Accordion.Item>
+            ))}
+        </Accordion.Root>
+        <button type="button">After</button>
+    </div>
+);
+
 describe('Accordion focus behavior', () => {
     test('roving tabindex: only one trigger has tabIndex 0 in the accordion', () => {
         render(<FocusHarness />);
@@ -110,5 +127,29 @@ describe('Accordion focus behavior', () => {
         triggers.forEach((t) => {
             expect(t).toHaveAttribute('tabindex', '0');
         });
+    });
+
+    test('disabled first trigger does not consume the roving tabindex entry point', () => {
+        render(<DisabledFirstHarness />);
+        const first = screen.getByRole('button', { name: 'First' });
+        const second = screen.getByRole('button', { name: 'Second' });
+        const third = screen.getByRole('button', { name: 'Third' });
+
+        expect(first).toHaveAttribute('tabindex', '-1');
+        expect(second).toHaveAttribute('tabindex', '0');
+        expect(third).toHaveAttribute('tabindex', '-1');
+    });
+
+    test('Tab enters the first enabled trigger when the first item is disabled', async() => {
+        const user = userEvent.setup();
+        render(<DisabledFirstHarness />);
+        const before = screen.getByRole('button', { name: 'Before' });
+        const second = screen.getByRole('button', { name: 'Second' });
+
+        before.focus();
+        expect(before).toHaveFocus();
+
+        await user.tab();
+        expect(second).toHaveFocus();
     });
 });

--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusGroup.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusGroup.tsx
@@ -44,6 +44,13 @@ const RovingFocusGroup = ({
     // Ref registry for direct access to item elements
     const itemRefsMap = useRef(new Map<string, React.RefObject<HTMLElement>>());
 
+    const findFirstEnabledItemId = React.useCallback((itemIds: string[]) => {
+        return itemIds.find((itemId) => {
+            const itemRef = itemRefsMap.current.get(itemId);
+            return itemRef?.current?.getAttribute('data-child-disabled') !== 'true';
+        }) ?? null;
+    }, []);
+
     const SHOULD_RECOMPUTE_FOCUS_ITEMS = mode === 'tree';
     
     /**
@@ -127,12 +134,26 @@ const RovingFocusGroup = ({
         });
     }, [SHOULD_RECOMPUTE_FOCUS_ITEMS]);
 
-    // Set initial focus to the first item when items are added
+    // Keep the roving entry point on an enabled item so the group remains tabbable.
     useEffect(() => {
-        if (!focusedItemId && focusItems.length > 0) {
-            setFocusedItemId(focusItems[0]);
+        if (focusItems.length === 0) {
+            if (focusedItemId !== null) {
+                setFocusedItemId(null);
+            }
+            return;
         }
-    }, [focusItems, focusedItemId]);
+
+        const focusedItemRef = focusedItemId ? itemRefsMap.current.get(focusedItemId) : null;
+        const focusedItemIsEnabled = focusedItemId != null
+            && focusedItemRef?.current?.getAttribute('data-child-disabled') !== 'true';
+
+        if (!focusedItemIsEnabled) {
+            const firstEnabledItemId = findFirstEnabledItemId(focusItems);
+            if (firstEnabledItemId !== focusedItemId) {
+                setFocusedItemId(firstEnabledItemId);
+            }
+        }
+    }, [findFirstEnabledItemId, focusItems, focusedItemId, setFocusedItemId]);
 
     const sendValues = {
         focusedItemId,


### PR DESCRIPTION
## Summary
- keep the roving focus entry point on the first enabled item instead of blindly selecting the first registered item
- add Accordion regression coverage for a disabled first item so the group remains tabbable

## Why
A disabled Accordion item could become the roving focus entry point during initialization. When that happened, every trigger ended up with `tabIndex=-1`, which broke tab entry and keyboard navigation.

## Validation
- `npm test -- --runInBand src/components/ui/Accordion/tests`

## Risks / Follow-ups
- This changes shared `RovingFocusGroup` initialization, so other consumers will now also prefer the first enabled item when the current roving target is disabled. That aligns with expected roving focus behavior.

Closes #1915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus management to ensure keyboard navigation in accordions properly handles disabled items. Focus now correctly skips disabled items and automatically moves to the first enabled item in the group.

* **Tests**
  * Added focus behavior tests validating keyboard navigation with disabled accordion items, confirming focus skips disabled triggers and moves to enabled ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->