### PR TITLE
fix: align Accordion Radix parity for content animation and single values

### DIFF
--- a/docs/app/docs/components/accordion/docs/component_api/root.tsx
+++ b/docs/app/docs/components/accordion/docs/component_api/root.tsx
@@ -111,7 +111,7 @@ const data = {
             name : "value",
             info_tooltips : "Controlled open item values."
         },
-        type : "(string | number)[]",
+        type : "single: string | number | '' | multiple: (string | number)[]",
         default : "--",
        },
        {
@@ -119,8 +119,8 @@ const data = {
             name : "defaultValue",
             info_tooltips : "Initial open item values for uncontrolled usage."
         },
-        type : "(string | number)[]",
-        default : "[]",
+        type : "single: string | number | multiple: (string | number)[]",
+        default : "single: -- | multiple: []",
        },
        {
         prop : {

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -9,7 +9,8 @@ import Primitive from '~/core/primitives/Primitive';
 
 const COMPONENT_NAME = 'Accordion';
 
-export type AccordionRootProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'defaultValue'> & {
+type AccordionItemValue = number | string;
+type AccordionRootBaseProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'defaultValue'> & {
     customRootClass?: string;
     transitionDuration?: number;
     transitionTimingFunction?: string;
@@ -28,9 +29,36 @@ export type AccordionRootProps = Omit<React.ComponentPropsWithoutRef<'div'>, 'de
      * Matches Radix: defaults to false (trigger does not collapse the only open item).
      */
     collapsible?: boolean;
-    value?: (number | string)[];
-    defaultValue?: (number | string)[];
-    onValueChange?: (value: (number | string)[]) => void;
+};
+
+export type AccordionSingleValue = AccordionItemValue | '';
+
+export type AccordionSingleRootProps = AccordionRootBaseProps & {
+    /** @deprecated Prefer `type="single"` or omit `type`. */
+    openMultiple?: false;
+    type?: 'single';
+    value?: AccordionSingleValue;
+    defaultValue?: AccordionItemValue;
+    onValueChange?: (value: AccordionSingleValue) => void;
+};
+
+export type AccordionMultipleRootProps = AccordionRootBaseProps & {
+    type: 'multiple';
+    value?: AccordionItemValue[];
+    defaultValue?: AccordionItemValue[];
+    onValueChange?: (value: AccordionItemValue[]) => void;
+};
+
+export type AccordionRootProps =
+    | AccordionSingleRootProps
+    | AccordionMultipleRootProps;
+
+const normalizeSingleValue = (value: AccordionSingleValue | undefined): AccordionItemValue[] => {
+    if (value === undefined || value === '') {
+        return [];
+    }
+
+    return [value];
 };
 
 const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootProps>(({
@@ -48,7 +76,7 @@ const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootPro
     type,
     collapsible = false,
     value,
-    defaultValue = [],
+    defaultValue,
     onValueChange,
     dir,
     ...props
@@ -61,17 +89,28 @@ const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootPro
     const collapsibleEffective = isMultiple ? true : collapsible;
 
     const processedValue = value !== undefined
-        ? (isMultiple ? value : (value.length > 0 ? [value[0]] : []))
+        ? (isMultiple
+            ? (Array.isArray(value) ? value : normalizeSingleValue(value))
+            : normalizeSingleValue(Array.isArray(value) ? value[0] : value))
         : undefined;
 
     const processedDefaultValue = isMultiple
-        ? defaultValue
-        : (defaultValue.length > 0 ? [defaultValue[0]] : []);
+        ? (Array.isArray(defaultValue) ? defaultValue : normalizeSingleValue(defaultValue))
+        : normalizeSingleValue(Array.isArray(defaultValue) ? defaultValue[0] : defaultValue);
 
-    const [activeItems, setActiveItems] = useControllableState<(number | string)[]>(
+    const handleValueChange = React.useCallback((nextValue: AccordionItemValue[]) => {
+        if (isMultiple) {
+            (onValueChange as ((value: AccordionItemValue[]) => void) | undefined)?.(nextValue);
+            return;
+        }
+
+        (onValueChange as ((value: AccordionSingleValue) => void) | undefined)?.(nextValue[0] ?? '');
+    }, [isMultiple, onValueChange]);
+
+    const [activeItems, setActiveItems] = useControllableState<AccordionItemValue[]>(
         processedValue,
-    processedDefaultValue,
-    onValueChange
+        processedDefaultValue,
+        handleValueChange
     );
 
     const rovingDir: 'ltr' | 'rtl' = dir === 'rtl' ? 'rtl' : 'ltr';

--- a/src/components/ui/Accordion/stories/Accordion.stories.tsx
+++ b/src/components/ui/Accordion/stories/Accordion.stories.tsx
@@ -103,22 +103,33 @@ export const OpenMultiple: Story = {
 };
 
 export const WithDeafultValue: Story = {
-    render: () => <AccordionExample defaultValue={[2]} />
+    render: () => <AccordionExample defaultValue={2} />
 };
 
 export const ControlledValue: Story = {
     render: () => {
-        const [value, setValue] = React.useState<number[]>([]);
+        const [value, setValue] = React.useState<number | number[] | ''>('');
         const [multiple, setMultiple] = React.useState(false);
 
         return (
             <>
                 <Button onClick={() => setMultiple(!multiple)}>{`Toggle Open Multiple (${multiple ? 'on' : 'off'})`}</Button>
-                <Button onClick={() => setValue([])}>Close All</Button>
-                <Button onClick={() => setValue([1])}>Open 2</Button>
-                <Button onClick={() => setValue([0])}>Open 0</Button>
-                <Button onClick={() => setValue([0, 1])}>Open 0, 1</Button>
-                <AccordionExample value={value} onValueChange={setValue} openMultiple={multiple} />
+                <Button onClick={() => setValue(multiple ? [] : '')}>Close All</Button>
+                <Button onClick={() => setValue(multiple ? [1] : 1)}>Open 2</Button>
+                <Button onClick={() => setValue(multiple ? [0] : 0)}>Open 0</Button>
+                <Button onClick={() => setValue(multiple ? [0, 1] : 0)}>Open 0, 1</Button>
+                {multiple ? (
+                    <AccordionExample
+                        type="multiple"
+                        value={Array.isArray(value) ? value : (value === '' ? [] : [value])}
+                        onValueChange={setValue}
+                    />
+                ) : (
+                    <AccordionExample
+                        value={Array.isArray(value) ? (value[0] ?? '') : value}
+                        onValueChange={setValue}
+                    />
+                )}
             </>
         );
     }

--- a/src/components/ui/Accordion/tests/Accordion.a11y.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.a11y.test.tsx
@@ -5,7 +5,7 @@ import * as axe from 'axe-core';
 import { TextEncoder } from 'util';
 
 import Accordion from '../Accordion';
-import { AccordionRootProps } from '../fragments/AccordionRoot';
+import { AccordionMultipleRootProps, AccordionRootProps, AccordionSingleRootProps } from '../fragments/AccordionRoot';
 import { ACCESSIBILITY_TEST_TAGS } from '~/setupTests';
 
 // Polyfill TextEncoder before requiring react-dom server utilities
@@ -21,18 +21,24 @@ const items = [
 ];
 
 // Helper to render a simple accordion
-const TestAccordion = (props: Partial<AccordionRootProps>) => (
-    <Accordion.Root collapsible {...props}>
-        {items.map((item, index) => (
-            <Accordion.Item value={index} key={index} disabled={(item as any).disabled}>
-                <Accordion.Header>
-                    <Accordion.Trigger>{item.title}</Accordion.Trigger>
-                </Accordion.Header>
-                <Accordion.Content index={index}>{item.content}</Accordion.Content>
-            </Accordion.Item>
-        ))}
-    </Accordion.Root>
-);
+const TestAccordion = (props: Partial<AccordionRootProps>) => {
+    const rootProps = props.type === 'multiple'
+        ? ({ collapsible: true, ...props } as AccordionMultipleRootProps)
+        : ({ collapsible: true, ...props } as AccordionSingleRootProps);
+
+    return (
+        <Accordion.Root {...rootProps}>
+            {items.map((item, index) => (
+                <Accordion.Item value={index} key={index} disabled={(item as any).disabled}>
+                    <Accordion.Header>
+                        <Accordion.Trigger>{item.title}</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content index={index}>{item.content}</Accordion.Content>
+                </Accordion.Item>
+            ))}
+        </Accordion.Root>
+    );
+};
 
 describe('Accordion accessibility', () => {
     describe('ARIA attributes', () => {
@@ -63,7 +69,7 @@ describe('Accordion accessibility', () => {
         });
 
         test('content has correct ARIA attributes', () => {
-            render(<TestAccordion defaultValue={[0]} />);
+            render(<TestAccordion defaultValue={0} />);
             const contents = screen.getAllByRole('region', { hidden: true });
 
             contents.forEach((content) => {
@@ -78,7 +84,7 @@ describe('Accordion accessibility', () => {
                 <TestAccordion
                     orientation="horizontal"
                     data-testid="accordion-root"
-                    defaultValue={[0]}
+                    defaultValue={0}
                 />
             );
             const root = screen.getByTestId('accordion-root');
@@ -254,10 +260,10 @@ describe('Accordion accessibility', () => {
         test('controlled value prop syncs with external changes', async() => {
             const user = userEvent.setup();
             const Controlled = () => {
-                const [value, setValue] = React.useState<(number | string)[]>([]);
+                const [value, setValue] = React.useState<string | number | ''>('');
                 return (
                     <>
-                        <button onClick={() => setValue([1])}>Open 2</button>
+                        <button onClick={() => setValue(1)}>Open 2</button>
                         <TestAccordion value={value} onValueChange={setValue} />
                     </>
                 );
@@ -280,7 +286,7 @@ describe('Accordion accessibility', () => {
         });
 
         test('defaultValue opens specified item initially', () => {
-            render(<TestAccordion defaultValue={[2]} />);
+            render(<TestAccordion defaultValue={2} />);
             expect(screen.getByText('Content 3')).toBeInTheDocument();
             const triggers = screen.getAllByRole('button');
             expect(triggers[2]).toHaveAttribute('aria-expanded', 'true');
@@ -326,7 +332,7 @@ describe('Accordion accessibility', () => {
 
         test('axe has no violations with multiple open panels', async() => {
             const user = userEvent.setup();
-            const { container } = render(<TestAccordion openMultiple />);
+            const { container } = render(<TestAccordion type="multiple" />);
 
             const triggers = screen.getAllByRole('button');
             await user.click(triggers[0]);
@@ -398,7 +404,7 @@ describe('Accordion accessibility', () => {
     });
 
     test('renders and hydrates without mismatches', async() => {
-        const markup = renderToString(<TestAccordion defaultValue={[0]} />);
+        const markup = renderToString(<TestAccordion defaultValue={0} />);
         const container = document.createElement('div');
         container.innerHTML = markup;
         document.body.appendChild(container);
@@ -407,7 +413,7 @@ describe('Accordion accessibility', () => {
 
         let root: ReturnType<typeof hydrateRoot>;
         await act(async() => {
-            root = hydrateRoot(container, <TestAccordion defaultValue={[0]} />);
+            root = hydrateRoot(container, <TestAccordion defaultValue={0} />);
         });
         act(() => root.unmount());
 
@@ -425,20 +431,26 @@ describe('Accordion accessibility', () => {
                 { title: 'Item 3', content: <div>Content 3</div> }
             ];
 
-            const DisabledAccordion = (props: Partial<AccordionRootProps>) => (
-                <Accordion.Root collapsible {...props}>
-                    {disabledItems.map((item, index) => (
-                        <Accordion.Item value={index} key={index} disabled={(item as any).disabled}>
-                            <Accordion.Header>
-                                <Accordion.Trigger>{item.title}</Accordion.Trigger>
-                            </Accordion.Header>
-                            <Accordion.Content index={index}>{item.content}</Accordion.Content>
-                        </Accordion.Item>
-                    ))}
-                </Accordion.Root>
-            );
+            const DisabledAccordion = (props: Partial<AccordionRootProps>) => {
+                const rootProps = props.type === 'multiple'
+                    ? ({ collapsible: true, ...props } as AccordionMultipleRootProps)
+                    : ({ collapsible: true, ...props } as AccordionSingleRootProps);
 
-            render(<DisabledAccordion openMultiple />);
+                return (
+                    <Accordion.Root {...rootProps}>
+                        {disabledItems.map((item, index) => (
+                            <Accordion.Item value={index} key={index} disabled={(item as any).disabled}>
+                                <Accordion.Header>
+                                    <Accordion.Trigger>{item.title}</Accordion.Trigger>
+                                </Accordion.Header>
+                                <Accordion.Content index={index}>{item.content}</Accordion.Content>
+                            </Accordion.Item>
+                        ))}
+                    </Accordion.Root>
+                );
+            };
+
+            render(<DisabledAccordion type="multiple" />);
             const triggers = screen.getAllByRole('button');
 
             await user.click(triggers[0]);
@@ -493,7 +505,7 @@ describe('Accordion accessibility', () => {
         });
 
         test('content is properly associated with trigger via aria-controls', () => {
-            render(<TestAccordion defaultValue={[0]} />);
+            render(<TestAccordion defaultValue={0} />);
             const trigger = screen.getByRole('button', { name: 'Item 1' });
             const controlsId = trigger.getAttribute('aria-controls');
             expect(controlsId).toBeTruthy();
@@ -503,7 +515,7 @@ describe('Accordion accessibility', () => {
         });
 
         test('items have proper role="region"', () => {
-            render(<TestAccordion defaultValue={[0, 1, 2]} openMultiple />);
+            render(<TestAccordion type="multiple" defaultValue={[0, 1, 2]} />);
             const regions = screen.getAllByRole('region', { hidden: true });
             expect(regions.length).toBe(3);
             regions.forEach((item) => {
@@ -536,7 +548,7 @@ describe('Accordion accessibility', () => {
         });
 
         test('renders and hydrates without mismatches', async() => {
-            const markup = renderToString(<TestAccordion defaultValue={[0]} />);
+            const markup = renderToString(<TestAccordion defaultValue={0} />);
             const container = document.createElement('div');
             container.innerHTML = markup;
             document.body.appendChild(container);
@@ -545,7 +557,7 @@ describe('Accordion accessibility', () => {
 
             let root: ReturnType<typeof hydrateRoot>;
             await act(async() => {
-                root = hydrateRoot(container, <TestAccordion defaultValue={[0]} />);
+                root = hydrateRoot(container, <TestAccordion defaultValue={0} />);
             });
             act(() => root.unmount());
 

--- a/src/components/ui/Accordion/tests/Accordion.dynamic.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.dynamic.test.tsx
@@ -15,7 +15,7 @@ describe('Accordion Dynamic Content', () => {
             }, []);
 
             return (
-                <Accordion.Root collapsible defaultValue={['item-1']} transitionDuration={300}>
+                <Accordion.Root collapsible defaultValue="item-1" transitionDuration={300}>
                     <Accordion.Item value="item-1">
                         <Accordion.Header>
                             <Accordion.Trigger>Trigger 1</Accordion.Trigger>
@@ -46,5 +46,26 @@ describe('Accordion Dynamic Content', () => {
         expect(screen.getByText('Item 1')).toBeInTheDocument();
         expect(screen.getByText('Item 2')).toBeInTheDocument();
         expect(screen.getByText('Item 3')).toBeInTheDocument();
+    });
+
+    it('publishes Radix-compatible content size CSS variables', () => {
+        render(
+            <Accordion.Root collapsible defaultValue="item-1" transitionDuration={0}>
+                <Accordion.Item value="item-1">
+                    <Accordion.Header>
+                        <Accordion.Trigger>Trigger 1</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content data-testid="content">
+                        <div>Content</div>
+                    </Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>
+        );
+
+        const content = screen.getByTestId('content');
+        expect(content.style.getPropertyValue('--radix-accordion-content-height')).toBe('0px');
+        expect(content.style.getPropertyValue('--radix-accordion-content-width')).toBe('0px');
+        expect(content.style.height).toBe('');
+        expect(content.style.transition).toBe('');
     });
 });

--- a/src/components/ui/Accordion/tests/Accordion.focus.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.focus.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Accordion from '../Accordion';
-import { AccordionRootProps } from '../fragments/AccordionRoot';
+import { AccordionSingleRootProps } from '../fragments/AccordionRoot';
 
 const testItems = [
     { title: 'First', content: <div>Content A</div> },
@@ -11,10 +11,10 @@ const testItems = [
     { title: 'Third', content: <div>Content C</div> }
 ];
 
-const FocusHarness = (props: Partial<AccordionRootProps>) => (
+const FocusHarness = (props: Partial<AccordionSingleRootProps>) => (
     <div>
         <button type="button">Before</button>
-        <Accordion.Root collapsible {...props}>
+        <Accordion.Root {...({ collapsible: true, ...props } as AccordionSingleRootProps)}>
             {testItems.map((item, index) => (
                 <Accordion.Item value={index} key={index}>
                     <Accordion.Header>

--- a/src/components/ui/Accordion/tests/Accordion.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import * as axe from 'axe-core';
 
 import Accordion from '../Accordion';
-import { AccordionRootProps } from '../fragments/AccordionRoot';
+import { AccordionMultipleRootProps, AccordionRootProps, AccordionSingleRootProps } from '../fragments/AccordionRoot';
 import { ACCESSIBILITY_TEST_TAGS } from '~/setupTests';
 import Theme from '../../Theme/Theme';
 
@@ -18,8 +18,12 @@ const testItems = [
 
 // Create a test accordion component using the composable pattern
 const TestAccordion = (props: Partial<AccordionRootProps>) => {
+    const rootProps = props.type === 'multiple'
+        ? ({ collapsible: true, ...props } as AccordionMultipleRootProps)
+        : ({ collapsible: true, ...props } as AccordionSingleRootProps);
+
     return (
-        <Accordion.Root collapsible {...props}>
+        <Accordion.Root {...rootProps}>
             {testItems.map((item, index) => (
                 <Accordion.Item value={index} key={index}>
                     <Accordion.Header>
@@ -52,7 +56,7 @@ describe('Accordion Component', () => {
 
     test('does not generate classes without a theme classNamespace', () => {
         render(
-            <Accordion.Root data-testid="accordion-root" defaultValue={[0]}>
+            <Accordion.Root data-testid="accordion-root" defaultValue={0}>
                 <Accordion.Item data-testid="accordion-item" value={0}>
                     <Accordion.Header data-testid="accordion-header">
                         <Accordion.Trigger data-testid="accordion-trigger">Item 1</Accordion.Trigger>
@@ -77,7 +81,7 @@ describe('Accordion Component', () => {
 
         render(
             <Theme classNamespace="acme">
-                <Accordion.Root data-testid="accordion-root" defaultValue={[0]}>
+                <Accordion.Root data-testid="accordion-root" defaultValue={0}>
                     <Accordion.Item data-testid="accordion-item" value={0}>
                         <Accordion.Header data-testid="accordion-header">
                             <Accordion.Trigger data-testid="accordion-trigger">Item 1</Accordion.Trigger>
@@ -116,7 +120,7 @@ describe('Accordion Component', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
         render(
-            <Accordion.Root ref={rootRef} defaultValue={[0]}>
+            <Accordion.Root ref={rootRef} defaultValue={0}>
                 <Accordion.Item value={0} ref={itemRef}>
                     <Accordion.Header ref={headerRef}>
                         <Accordion.Trigger ref={triggerRef}>Item 1</Accordion.Trigger>
@@ -237,7 +241,7 @@ describe('Accordion Component', () => {
                     <button onClick={() => setValue([])}>Close All</button>
                     <button onClick={() => setValue([1])}>Open 2</button>
                     <button onClick={() => setValue([0, 2])}>Open 1 & 3</button>
-                    <TestAccordion value={value} onValueChange={setValue} openMultiple />
+                    <TestAccordion type="multiple" value={value} onValueChange={setValue} />
                 </>
             );
         };
@@ -268,8 +272,31 @@ describe('Accordion Component', () => {
         expect(screen.queryByText('Content 3')).not.toBeInTheDocument();
     });
 
+    test('single mode exposes scalar controlled values', () => {
+        const handleValueChange = jest.fn();
+
+        render(
+            <Accordion.Root collapsible onValueChange={handleValueChange}>
+                <Accordion.Item value="item-1">
+                    <Accordion.Header>
+                        <Accordion.Trigger>Item 1</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content>Content 1</Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>
+        );
+
+        const trigger = screen.getByRole('button', { name: 'Item 1' });
+
+        fireEvent.click(trigger);
+        expect(handleValueChange).toHaveBeenLastCalledWith('item-1');
+
+        fireEvent.click(trigger);
+        expect(handleValueChange).toHaveBeenLastCalledWith('');
+    });
+
     test('works with defaultValue to show initial item', () => {
-        render(<TestAccordion defaultValue={[2]} />);
+        render(<TestAccordion defaultValue={2} />);
 
         // Item 3 content should be visible initially
         expect(screen.getByText('Content 3')).toBeInTheDocument();
@@ -299,7 +326,7 @@ describe('Accordion Component', () => {
 
     test('Escape on trigger closes panel and syncs aria-expanded (collapsible)', () => {
         render(
-            <Accordion.Root collapsible defaultValue={[0]}>
+            <Accordion.Root collapsible defaultValue={0}>
                 <Accordion.Item value={0}>
                     <Accordion.Header>
                         <Accordion.Trigger>Item 1</Accordion.Trigger>

--- a/src/components/ui/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/ui/Collapsible/tests/Collapsible.test.tsx
@@ -155,4 +155,18 @@ describe('Collapsible.Content Component', () => {
         const content = screen.getByText('Content');
         expect(content).toHaveAttribute('aria-hidden', 'false');
     });
+
+    it('publishes Radix-compatible size variables and skips inline animation styles when disabled', () => {
+        render(
+            <Collapsible.Root defaultOpen transitionDuration={0}>
+                <Collapsible.Content data-testid="content">Content</Collapsible.Content>
+            </Collapsible.Root>
+        );
+
+        const content = screen.getByTestId('content');
+        expect(content.style.getPropertyValue('--radix-collapsible-content-height')).toBe('0px');
+        expect(content.style.getPropertyValue('--radix-collapsible-content-width')).toBe('0px');
+        expect(content.style.height).toBe('');
+        expect(content.style.transition).toBe('');
+    });
 });

--- a/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
+++ b/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
@@ -23,10 +23,37 @@ const CollapsiblePrimitiveContent = React.forwardRef<
 
     const [height, setHeight] = useState<number | undefined>(open ? undefined : 0);
     const heightRef = useRef(height);
+    const [contentSize, setContentSize] = useState({ height: 0, width: 0 });
     const [shouldRender, setShouldRender] = useState(open || forceMount);
     const animationTimeoutRef = useRef<NodeJS.Timeout>();
     const rafRef = useRef<number>();
     const ref = useRef<HTMLDivElement | null>(null);
+
+    useLayoutEffect(() => {
+        if (!ref.current) return;
+
+        const measure = () => {
+            if (!ref.current) return;
+
+            setContentSize({
+                height: ref.current.scrollHeight,
+                width: ref.current.scrollWidth
+            });
+        };
+
+        measure();
+
+        const resizeObserver = new ResizeObserver(() => {
+            measure();
+        });
+
+        resizeObserver.observe(ref.current);
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [children, shouldRender]);
+
     // Track presence for mounting/unmounting
     useEffect(() => {
         if (open || forceMount) {
@@ -68,6 +95,10 @@ const CollapsiblePrimitiveContent = React.forwardRef<
                     if (ref.current) {
                         const contentHeight = ref.current.scrollHeight;
                         setHeight(contentHeight);
+                        setContentSize({
+                            height: contentHeight,
+                            width: ref.current.scrollWidth
+                        });
                     }
                 });
             });
@@ -114,11 +145,15 @@ const CollapsiblePrimitiveContent = React.forwardRef<
     const dynamicStyle: React.CSSProperties = {
         ...style,
         overflow: 'hidden',
-        height: height !== undefined ? `${height}px` : undefined,
+        '--radix-collapsible-content-height': `${contentSize.height}px`,
+        '--radix-collapsible-content-width': `${contentSize.width}px`,
+        '--radix-accordion-content-height': `${contentSize.height}px`,
+        '--radix-accordion-content-width': `${contentSize.width}px`,
+        height: transitionDuration > 0 && height !== undefined ? `${height}px` : undefined,
         ...(transitionDuration > 0
             ? { transition: `height ${transitionDuration}ms ${transitionTimingFunction}` }
             : {})
-    };
+    } as React.CSSProperties;
 
     const shouldUseAsChild = asChild && React.isValidElement(children);
 


### PR DESCRIPTION
## Summary
- align `Accordion.Root` with Radix-style single vs multiple value shapes
- expose Radix-compatible content size CSS variables on collapsible/accordion content
- stop applying inline height/transition styles when `transitionDuration={0}` so consumers can own CSS-driven animations

## Why
Issue #1917 reports two API parity gaps that block drop-in migration from `@radix-ui/react-accordion`:
1. `Accordion.Content` could not participate in Radix-style CSS keyframe animations because the measured size was only used for inline JS transitions.
2. `Accordion.Root` always exposed array-shaped `value`/`defaultValue`/`onValueChange`, even in single mode.

## What changed
- changed `Accordion.Root` public types so `type="single"` uses a scalar value and `type="multiple"` uses an array while keeping the internal array state model
- normalized single-mode `onValueChange` to emit the opened item value or `''` when the accordion closes, matching Radix semantics
- added `--radix-accordion-content-height`, `--radix-accordion-content-width`, `--radix-collapsible-content-height`, and `--radix-collapsible-content-width` to the content element
- only apply inline `height` and `transition` styles when the built-in JS transition path is enabled
- updated Accordion docs, story coverage, and tests around the new value shapes and CSS variable contract

## Validation
- `npx jest src/components/ui/Accordion/tests/Accordion.test.tsx src/components/ui/Accordion/tests/Accordion.a11y.test.tsx src/components/ui/Accordion/tests/Accordion.dynamic.test.tsx src/components/ui/Accordion/tests/Accordion.focus.test.tsx src/components/ui/Collapsible/tests/Collapsible.test.tsx --runInBand`
- `npm run check:types` still fails on pre-existing unrelated repo errors in `DrawerSwipeZone.tsx`, `Popover.stories.tsx`, `ToastRoot.tsx`, and `Clarity.stories.tsx`

## Risks / follow-ups
- the deprecated `openMultiple` runtime alias still works, but the new discriminated typing is centered on `type`, which is the preferred public API going forward
- CSS-variable tests run in jsdom, so they verify the contract and inline-style opt-out rather than browser layout values beyond the mocked `0px` defaults

Closes #1917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Accordion API refactored: single mode now uses scalar values (e.g., `defaultValue={1}`) instead of arrays (e.g., `defaultValue={[1]}`)

* **New Features**
  * Added Radix-compatible CSS variables for Accordion and Collapsible content sizing

* **Improvements**
  * Enhanced type definitions for single vs multiple accordion modes
  * Improved animation handling for zero-duration transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->