### PR TITLE
feat(api): defaultOpen support to dialog root

### DIFF
--- a/.changeset/shiny-dialogs-rest.md
+++ b/.changeset/shiny-dialogs-rest.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+dialog - add `defaultOpen` support to `DialogPrimitive.Root` and the Dialog wrapper API

--- a/docs/app/docs/components/dialog/docs/component_api/root.tsx
+++ b/docs/app/docs/components/dialog/docs/component_api/root.tsx
@@ -51,10 +51,10 @@ const data = {
        {
         prop : {
             name : "defaultOpen",
-            info_tooltips : "Not supported on this wrapper; control initial state by managing open in your own state."
+            info_tooltips : "The initial open state for uncontrolled usage."
         },
-        type : "n/a",
-        default : "--",
+        type : "boolean",
+        default : "false",
        },
        {
         prop : {

--- a/src/components/ui/Dialog/tests/Dialog.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithPortal, assertFocusTrap, assertFocusReturn, assertScrollLock, assertScrollUnlock } from '~/test-utils/portal';
 import Dialog from '../Dialog';
@@ -64,6 +64,50 @@ describe('Dialog', () => {
         );
 
         expect(opened.queryByText('Description')).toBeInTheDocument();
+    });
+
+    test('supports uncontrolled defaultOpen and controlled rerenders', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Dialog.Root defaultOpen>
+                <Dialog.Trigger>Open</Dialog.Trigger>
+                <Dialog.Overlay />
+                <Dialog.Content>
+                    <Dialog.Description>Default open content</Dialog.Description>
+                    <Dialog.Close>Close</Dialog.Close>
+                </Dialog.Content>
+            </Dialog.Root>
+        );
+
+        expect(screen.getByText('Default open content')).toBeInTheDocument();
+
+        await user.click(screen.getByText('Close'));
+        await waitFor(() => expect(screen.queryByText('Default open content')).toBeNull());
+
+        const controlled = render(
+            <Dialog.Root open={false}>
+                <Dialog.Trigger>Open</Dialog.Trigger>
+                <Dialog.Overlay />
+                <Dialog.Content>
+                    <Dialog.Description>Controlled content</Dialog.Description>
+                </Dialog.Content>
+            </Dialog.Root>
+        );
+
+        expect(controlled.queryByText('Controlled content')).toBeNull();
+
+        controlled.rerender(
+            <Dialog.Root open>
+                <Dialog.Trigger>Open</Dialog.Trigger>
+                <Dialog.Overlay />
+                <Dialog.Content>
+                    <Dialog.Description>Controlled content</Dialog.Description>
+                </Dialog.Content>
+            </Dialog.Root>
+        );
+
+        expect(controlled.queryByText('Controlled content')).toBeInTheDocument();
     });
 
     test('renders without warnings', () => {

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveRoot.tsx
@@ -1,11 +1,13 @@
 'use client';
-import React, { forwardRef, useState, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { DialogPrimitiveContext } from '../context/DialogPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
+import { useControllableState } from '~/core/hooks/useControllableState';
 
 export type DialogPrimitiveRootProps = {
     children: React.ReactNode;
     open?: boolean;
+    defaultOpen?: boolean;
     onOpenChange?: (open: boolean) => void;
     onClickOutside?: () => void;
     className?:string;
@@ -15,18 +17,12 @@ export type DialogPrimitiveRootProps = {
 
 const COMPONENT_NAME = 'DialogPrimitive';
 
-const DialogPrimitiveRootInner = forwardRef<HTMLDivElement, DialogPrimitiveRootProps>(({ children, open = false, onOpenChange = () => {}, onClickOutside = () => {}, className, disablePointerDismissal = false, ...props }, ref) => {
-    const [isOpen, setIsOpen] = useState(open);
+const DialogPrimitiveRootInner = forwardRef<HTMLDivElement, DialogPrimitiveRootProps>(({ children, open, defaultOpen = false, onOpenChange, onClickOutside = () => {}, className, disablePointerDismissal = false, ...props }, ref) => {
+    const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, onOpenChange);
     const nodeId = Floater.useFloatingNodeId();
-
-    // Sync internal state with the open prop
-    useEffect(() => {
-        setIsOpen(open);
-    }, [open]);
 
     const handleOpenChange = (open: boolean) => {
         setIsOpen(open);
-        onOpenChange(open);
     };
     const handleOverlayClick = () => {
         if (disablePointerDismissal) return;

--- a/src/core/primitives/Dialog/stories/DialogPrimitive.stories.tsx
+++ b/src/core/primitives/Dialog/stories/DialogPrimitive.stories.tsx
@@ -46,3 +46,23 @@ export const Default = {
         actionButton: <button>Delete</button>
     }
 };
+
+export const DefaultOpen = {
+    render: () => (
+        <SandboxEditor>
+            <DialogPrimitive.Root defaultOpen>
+                <DialogPrimitive.Overlay className="w-screen h-screen opacity-50 bg-[rgba(0,0,0,0.9)]" />
+                <DialogPrimitive.Trigger>
+                    Open Dialog
+                </DialogPrimitive.Trigger>
+                <DialogPrimitive.Portal>
+                    <DialogPrimitive.Content className="p-4 z-50 fixed mx-auto bg-[var(--rad-ui-surface-muted)] top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] rounded-md ">
+                        <DialogPrimitive.Cancel>
+                            Cancel
+                        </DialogPrimitive.Cancel>
+                    </DialogPrimitive.Content>
+                </DialogPrimitive.Portal>
+            </DialogPrimitive.Root>
+        </SandboxEditor>
+    )
+};


### PR DESCRIPTION
## Summary
- add uncontrolled `defaultOpen` support to `DialogPrimitive.Root` via the shared `useControllableState` hook
- add dialog regression coverage for uncontrolled `defaultOpen` and controlled rerenders
- update the Dialog API docs and add a changeset entry for the new supported wrapper behavior

## Why
Issue #1780 calls out inconsistent controlled/uncontrolled support across primitives. `DialogPrimitive.Root` was the outlier in the primitive layer: it exposed `open`/`onOpenChange` but had no `defaultOpen` path, and the Dialog docs explicitly marked `defaultOpen` as unsupported.

## Validation
- `npm test -- --runInBand src/components/ui/Dialog/tests/Dialog.test.tsx src/components/ui/Dialog/tests/Dialog.portal.test.tsx`

## Risks / follow-ups
- I only changed the dialog surface because the core primitive audit in `src/core/primitives` showed this was the remaining real gap; broader component-level consistency work should be handled separately if needed.
- `npx eslint ...` on the touched source files reported the worktree file was ignored by the current ESLint config, so lint did not provide additional signal here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog.Root component now supports the `defaultOpen` prop, allowing you to set an initial open state without requiring controlled state management.

* **Documentation**
  * Updated Dialog component API documentation to document the new `defaultOpen` prop, including its boolean type and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->