### PR TITLE
feat(dx): configurable loop behavior to focus-managed components

### DIFF
--- a/.changeset/green-pigs-repeat.md
+++ b/.changeset/green-pigs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Add configurable `loop` focus-wrapping options for Tabs, Disclosure, Tree, and NavigationMenu, including NavigationMenu content panels.

--- a/docs/app/docs/components/disclosure/docs/component_api/root.tsx
+++ b/docs/app/docs/components/disclosure/docs/component_api/root.tsx
@@ -8,7 +8,8 @@ const data = {
     ],
     data: [
         { prop: { name: "items", info_tooltips: "Array of { title, content } for the convenience wrapper." }, type: "{ title: string, content: ReactNode }[]", default: "--" },
-        { prop: { name: "className", info_tooltips: "Additional CSS classes." }, type: "string", default: '""' }
+        { prop: { name: "className", info_tooltips: "Additional CSS classes." }, type: "string", default: '""' },
+        { prop: { name: "loop", info_tooltips: "Whether arrow key navigation wraps between disclosure triggers." }, type: "boolean", default: "true" }
     ]
 }
 

--- a/docs/app/docs/components/navigation-menu/docs/component_api/root.tsx
+++ b/docs/app/docs/components/navigation-menu/docs/component_api/root.tsx
@@ -8,6 +8,8 @@ const data = {
     ],
     data: [
         { prop: { name: "value", info_tooltips: "Controlled open item value." }, type: "string", default: "--" },
+        { prop: { name: "loop", info_tooltips: "Whether arrow key navigation wraps between top-level triggers." }, type: "boolean", default: "true" },
+        { prop: { name: "contentLoop", info_tooltips: "Default wrap behavior for roving focus inside opened content panels." }, type: "boolean", default: "true" },
         { prop: { name: "orientation", info_tooltips: "Layout orientation of the menu." }, type: "enum", enum_values: ["horizontal", "vertical"], default: "horizontal" },
         { prop: { name: "onValueChange", info_tooltips: "Callback when the active item changes." }, type: "function", default: "--" }
     ]

--- a/docs/app/docs/components/tabs/docs/component_api/root.tsx
+++ b/docs/app/docs/components/tabs/docs/component_api/root.tsx
@@ -92,6 +92,14 @@ const data = {
        },
        {
         prop : {
+            name : "loop",
+            info_tooltips : "Whether arrow key navigation wraps from the last trigger to the first, and from the first to the last."
+        },
+        type : "boolean",
+        default : "true",
+       },
+       {
+        prop : {
             name : "activationMode",
             info_tooltips : "Whether focusing a trigger activates it automatically or only on click/enter/space."
         },

--- a/docs/app/docs/components/tree/docs/codeUsage.js
+++ b/docs/app/docs/components/tree/docs/codeUsage.js
@@ -1,4 +1,5 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import root_api from './component_api/root.tsx';
 import item_api from './component_api/item.tsx';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tree/docs/example_1.tsx');
@@ -13,6 +14,7 @@ export const code = {
 export const anatomy = { code: anatomy_SourceCode };
 
 export const api_documentation = {
+    root: root_api,
     item: item_api
 };
 

--- a/docs/app/docs/components/tree/docs/component_api/root.tsx
+++ b/docs/app/docs/components/tree/docs/component_api/root.tsx
@@ -1,0 +1,16 @@
+const data = {
+    name: "Root",
+    description: "The root Tree component.",
+    columns: [
+        { name: "Prop", id: "prop" },
+        { name: "Type", id: "type" },
+        { name: "Default", id: "default" }
+    ],
+    data: [
+        { prop: { name: "aria-label", info_tooltips: "Accessible label for the tree when no visible label is present." }, type: "string", default: "--" },
+        { prop: { name: "aria-labelledby", info_tooltips: "ID of an element that labels the tree." }, type: "string", default: "--" },
+        { prop: { name: "loop", info_tooltips: "Whether arrow key navigation wraps from the last visible item to the first, and from the first to the last." }, type: "boolean", default: "true" }
+    ]
+}
+
+export default data

--- a/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
@@ -10,9 +10,10 @@ const COMPONENT_NAME = 'Disclosure';
 export type DisclosureRootProps = React.ComponentPropsWithoutRef<'div'> & {
      customRootClass?: string;
      defaultOpen?: number | null;
+     loop?: boolean;
 };
 
-const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, ...props }, forwardedRef) => {
+const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, loop = true, ...props }, forwardedRef) => {
     const disclosureRef = useRef<React.ElementRef<'div'> | null>(null);
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
 
@@ -37,7 +38,7 @@ const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootP
                 disclosureRef
 
             }}>
-            <RovingFocusGroup.Root>
+            <RovingFocusGroup.Root loop={loop}>
                 <RovingFocusGroup.Group className={clsx(rootClass && `${rootClass}-root`)}>
                     <div
                         {...props}

--- a/src/components/ui/Disclosure/tests/Disclosure.test.tsx
+++ b/src/components/ui/Disclosure/tests/Disclosure.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Disclosure from '../Disclosure';
 
 const items = [
@@ -53,6 +54,38 @@ describe('Disclosure', () => {
         render(<Disclosure items={items} aria-label="test" />);
         fireEvent.click(screen.getByText('Item 1'));
         expect(screen.getByText('Content 1')).toBeInTheDocument();
+    });
+
+    test('loop={false} stops focus wrap between triggers', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Disclosure.Root aria-label="test" loop={false}>
+                <Disclosure.Item value={0}>
+                    <Disclosure.Trigger>Item 1</Disclosure.Trigger>
+                    <Disclosure.Content>Content 1</Disclosure.Content>
+                </Disclosure.Item>
+                <Disclosure.Item value={1}>
+                    <Disclosure.Trigger>Item 2</Disclosure.Trigger>
+                    <Disclosure.Content>Content 2</Disclosure.Content>
+                </Disclosure.Item>
+            </Disclosure.Root>
+        );
+
+        const item1 = screen.getByText('Item 1');
+        const item2 = screen.getByText('Item 2');
+
+        await user.tab();
+        expect(item1).toHaveFocus();
+
+        await user.keyboard('{ArrowLeft}');
+        expect(item1).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(item2).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(item2).toHaveFocus();
     });
 
     test('hides content when the same item is clicked again', () => {

--- a/src/components/ui/NavigationMenu/contexts/NavigationMenuRootContext.tsx
+++ b/src/components/ui/NavigationMenu/contexts/NavigationMenuRootContext.tsx
@@ -4,12 +4,14 @@ export interface NavigationMenuRootContextProps {
     isOpen: string;
     setIsOpen: React.Dispatch<React.SetStateAction<string>>;
     rootClass: string;
+    contentLoop: boolean;
 }
 
 const NavigationMenuRootContext = React.createContext<NavigationMenuRootContextProps>({
     isOpen: '',
     setIsOpen: () => {},
-    rootClass: ''
+    rootClass: '',
+    contentLoop: true
 });
 
 export default NavigationMenuRootContext;

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuContent.tsx
@@ -8,13 +8,15 @@ export type NavigationMenuContentElement = React.ElementRef<'div'>;
 
 export interface NavigationMenuContentProps extends React.ComponentPropsWithoutRef<'div'> {
     children: React.ReactNode;
+    loop?: boolean;
 }
 
 const NavigationMenuContent = React.forwardRef<NavigationMenuContentElement, NavigationMenuContentProps>(
-    ({ children, className, ...props }, ref) => {
+    ({ children, className, loop, ...props }, ref) => {
         const { itemOpen } = React.useContext(NavigationMenuItemContext);
-        const { rootClass } = React.useContext(NavigationMenuRootContext);
+        const { rootClass, contentLoop } = React.useContext(NavigationMenuRootContext);
         const contentRef = React.useRef<HTMLDivElement>(null);
+        const resolvedLoop = loop ?? contentLoop;
 
         React.useImperativeHandle(ref, () => contentRef.current as HTMLDivElement);
 
@@ -30,7 +32,7 @@ const NavigationMenuContent = React.forwardRef<NavigationMenuContentElement, Nav
                 data-state={itemOpen ? 'open' : 'closed'}
                 {...props}
             >
-                <RovingFocusGroup.Root>
+                <RovingFocusGroup.Root loop={resolvedLoop}>
                     <RovingFocusGroup.Group>{children}</RovingFocusGroup.Group>
                 </RovingFocusGroup.Root>
             </div>

--- a/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
+++ b/src/components/ui/NavigationMenu/fragments/NavigationMenuRoot.tsx
@@ -15,6 +15,8 @@ export interface NavigationMenuRootProps extends React.ComponentPropsWithoutRef<
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     customRootClass?: string;
+    loop?: boolean;
+    contentLoop?: boolean;
 }
 
 const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, NavigationMenuRootProps>(
@@ -25,6 +27,8 @@ const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, Navigatio
             defaultValue = '',
             onValueChange,
             customRootClass,
+            loop = true,
+            contentLoop = true,
             className,
             ...props
         },
@@ -35,8 +39,8 @@ const NavigationMenuRoot = React.forwardRef<NavigationMenuRootElement, Navigatio
 
         return (
             <div ref={ref} {...props}>
-                <NavigationMenuRootContext.Provider value={{ isOpen, setIsOpen, rootClass }}>
-                    <RovingFocusGroup.Root>
+                <NavigationMenuRootContext.Provider value={{ isOpen, setIsOpen, rootClass, contentLoop }}>
+                    <RovingFocusGroup.Root loop={loop}>
                         <RovingFocusGroup.Group className={clsx(rootClass && `${rootClass}-root`, className)}>
                             {children}
                         </RovingFocusGroup.Group>

--- a/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
+++ b/src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import NavigationMenu from '../NavigationMenu';
 
 describe('NavigationMenu component', () => {
@@ -197,5 +198,70 @@ describe('NavigationMenu component', () => {
 
         errorSpy.mockRestore();
         warnSpy.mockRestore();
+    });
+
+    test('loop={false} stops focus wrap between top-level triggers', async() => {
+        const user = userEvent.setup();
+
+        const { getByText } = render(
+            <NavigationMenu.Root loop={false}>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Menu 1</NavigationMenu.Trigger>
+                </NavigationMenu.Item>
+                <NavigationMenu.Item value="item2">
+                    <NavigationMenu.Trigger>Menu 2</NavigationMenu.Trigger>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        const trigger1 = getByText('Menu 1');
+        const trigger2 = getByText('Menu 2');
+
+        await user.tab();
+        expect(trigger1).toHaveFocus();
+
+        await user.keyboard('{ArrowLeft}');
+        expect(trigger1).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(trigger2).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(trigger2).toHaveFocus();
+    });
+
+    test('content loop={false} stops focus wrap between links', async() => {
+        const user = userEvent.setup();
+
+        const { getByText } = render(
+            <NavigationMenu.Root defaultValue="item1">
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content loop={false}>
+                        <NavigationMenu.Link href="#link-1">Link 1</NavigationMenu.Link>
+                        <NavigationMenu.Link href="#link-2">Link 2</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        const trigger = getByText('Open');
+        const link1 = getByText('Link 1');
+        const link2 = getByText('Link 2');
+
+        await user.tab();
+        expect(trigger).toHaveFocus();
+
+        await user.tab();
+        expect(link1).toHaveFocus();
+
+        await user.keyboard('{ArrowLeft}');
+        expect(link1).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(link2).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(link2).toHaveFocus();
     });
 });

--- a/src/components/ui/Tabs/fragments/TabRoot.tsx
+++ b/src/components/ui/Tabs/fragments/TabRoot.tsx
@@ -19,6 +19,7 @@ export type TabRootProps = React.ComponentPropsWithoutRef<'div'> & {
     onValueChange?: (value: string) => void;
     orientation?: 'horizontal' | 'vertical';
     dir?: 'ltr' | 'rtl';
+    loop?: boolean;
     activationMode?: 'automatic' | 'manual';
     asChild?: boolean;
 };
@@ -33,6 +34,7 @@ const TabRoot = React.forwardRef<React.ElementRef<'div'>, TabRootProps>(({
     color,
     orientation = 'horizontal',
     dir = 'ltr',
+    loop = true,
     activationMode = 'automatic',
     asChild = false,
     ...props
@@ -73,7 +75,7 @@ const TabRoot = React.forwardRef<React.ElementRef<'div'>, TabRootProps>(({
 
     return (
         <TabsRootContext.Provider value={contextValues}>
-            <RovingFocusGroup.Root orientation={orientation} loop dir={dir} asChild>
+            <RovingFocusGroup.Root orientation={orientation} loop={loop} dir={dir} asChild>
                 <Primitive.div
                     ref={forwardedRef}
                     className={clsx(rootClass, className)}

--- a/src/components/ui/Tabs/tests/Tabs.interaction.test.tsx
+++ b/src/components/ui/Tabs/tests/Tabs.interaction.test.tsx
@@ -59,6 +59,37 @@ describe('Tabs interactions', () => {
         expect(tab1).toHaveAttribute('data-state', 'inactive');
     });
 
+    test('loop={false} stops arrow navigation at the ends', async() => {
+        const user = userEvent.setup();
+        render(
+            <Tabs.Root defaultValue="t1" activationMode="manual" loop={false}>
+                <Tabs.List>
+                    <Tabs.Trigger value="t1">Tab 1</Tabs.Trigger>
+                    <Tabs.Trigger value="t2">Tab 2</Tabs.Trigger>
+                    <Tabs.Trigger value="t3">Tab 3</Tabs.Trigger>
+                </Tabs.List>
+                <Tabs.Content value="t1">Panel 1</Tabs.Content>
+                <Tabs.Content value="t2">Panel 2</Tabs.Content>
+                <Tabs.Content value="t3">Panel 3</Tabs.Content>
+            </Tabs.Root>
+        );
+
+        const tab1 = screen.getByText('Tab 1');
+        const tab3 = screen.getByText('Tab 3');
+
+        await user.tab();
+        expect(tab1).toHaveFocus();
+
+        await user.keyboard('{ArrowLeft}');
+        expect(tab1).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}{ArrowRight}');
+        expect(tab3).toHaveFocus();
+
+        await user.keyboard('{ArrowRight}');
+        expect(tab3).toHaveFocus();
+    });
+
     test('data-state attributes sync between trigger and content', async() => {
         const user = userEvent.setup();
         render(

--- a/src/components/ui/Tree/fragments/TreeRoot.tsx
+++ b/src/components/ui/Tree/fragments/TreeRoot.tsx
@@ -15,9 +15,10 @@ export type TreeRootProps = {
     customRootClass?: string;
     'aria-label'?: string;
     'aria-labelledby'?: string;
+    loop?: boolean;
 } & ComponentPropsWithoutRef<typeof Primitive.div>;
 
-const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }, ref) => {
+const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, className = '', customRootClass = '', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, loop = true, ...props }, ref) => {
     const treeRef = useRef<TreeRootElement>(null);
     useImperativeHandle(ref, () => treeRef.current as TreeRootElement);
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
@@ -42,7 +43,7 @@ const TreeRoot = forwardRef<TreeRootElement, TreeRootProps>(({ children, classNa
 
     return (
         <TreeContext.Provider value={treeContextValue}>
-            <RovingFocusGroup.Root orientation='vertical' mode='tree'>
+            <RovingFocusGroup.Root orientation='vertical' mode='tree' loop={loop}>
                 <RovingFocusGroup.Group>
                     <Primitive.div
                         className={clsx(rootClass, className)}

--- a/src/components/ui/Tree/tests/Tree.test.tsx
+++ b/src/components/ui/Tree/tests/Tree.test.tsx
@@ -49,6 +49,33 @@ describe('Tree', () => {
         expect(screen.getByText('Child')).toBeInTheDocument();
     });
 
+    test('loop={false} stops arrow navigation at tree edges', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Tree.Root aria-label='Files' loop={false}>
+                <Tree.Item item={{ label: 'Item 1' }}>Item 1</Tree.Item>
+                <Tree.Item item={{ label: 'Item 2' }}>Item 2</Tree.Item>
+                <Tree.Item item={{ label: 'Item 3' }}>Item 3</Tree.Item>
+            </Tree.Root>
+        );
+
+        const item1 = screen.getByRole('treeitem', { name: 'Item 1' });
+        const item3 = screen.getByRole('treeitem', { name: 'Item 3' });
+
+        await user.tab();
+        expect(item1).toHaveFocus();
+
+        await user.keyboard('{ArrowUp}');
+        expect(item1).toHaveFocus();
+
+        await user.keyboard('{ArrowDown}{ArrowDown}');
+        expect(item3).toHaveFocus();
+
+        await user.keyboard('{ArrowDown}');
+        expect(item3).toHaveFocus();
+    });
+
     test('renders without console errors or warnings', () => {
         const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
         const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- add  props to , , and  so focus wrapping can be disabled consistently
- add  and  controls to  for top-level triggers and content-panel roving focus
- update component API docs, add Tree root API docs, add regression tests, and include a changeset

## Why
- addresses issue #1787 by making focus-wrap behavior configurable across components that currently hardcode or implicitly inherit looping
- preserves existing defaults while giving consumers a consistent opt-out when they need edge-stopping keyboard navigation

## Validation
- 
> @radui/ui@0.5.0 test
> jest --runInBand src/components/ui/Tabs/tests/Tabs.interaction.test.tsx
- 
> @radui/ui@0.5.0 test
> jest --runInBand src/components/ui/Disclosure/tests/Disclosure.test.tsx
- 
> @radui/ui@0.5.0 test
> jest --runInBand src/components/ui/NavigationMenu/tests/NavigationMenu.test.tsx
- 
> @radui/ui@0.5.0 test
> jest --runInBand src/components/ui/Tree/tests/Tree.test.tsx
- 
> @radui/ui@0.5.0 validate:changesets
> node scripts/validate-changesets.mjs

## Risks / Follow-ups
-  now has separate root and content wrap controls; if we want a stricter API later, we may want to unify that naming across other multi-scope components.

Closes #1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `loop` prop to Tabs, Disclosure, Tree, and NavigationMenu components, allowing focus-wrapping in keyboard navigation to be disabled when needed (enabled by default).
  * NavigationMenu Content panels now support `contentLoop` prop for independent control of focus wrapping.

* **Documentation**
  * Component API documentation updated with new `loop` and `contentLoop` properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->