### PR TITLE
feat(dx): standardize portal container/forceMount APIs across overlay primitives

### DIFF
--- a/.changeset/fresh-portals-align.md
+++ b/.changeset/fresh-portals-align.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+standardize overlay portal `container` and `forceMount` APIs across menu, combobox, and hover card primitives

--- a/src/components/ui/Combobox/fragments/ComboboxPortal.tsx
+++ b/src/components/ui/Combobox/fragments/ComboboxPortal.tsx
@@ -1,18 +1,20 @@
 'use client';
 import React from 'react';
 import ComboboxPrimitive from '~/core/primitives/Combobox/ComboboxPrimitive';
+import type { ComboboxPrimitivePortalProps } from '~/core/primitives/Combobox/fragments/ComboboxPrimitivePortal';
 
 export type ComboboxPortalProps = {
   children: React.ReactNode;
   container?: HTMLElement | null;
+  forceMount?: boolean;
 };
 
 type ComboboxPortalElement = React.ElementRef<typeof ComboboxPrimitive.Portal>;
-type ComboboxPortalPrimitiveProps = React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Portal> & ComboboxPortalProps;
+type ComboboxPortalPrimitiveProps = Omit<ComboboxPrimitivePortalProps, 'children'> & ComboboxPortalProps;
 
-const ComboboxPortal = React.forwardRef<ComboboxPortalElement, ComboboxPortalPrimitiveProps>(({ children, container, ...props }, forwardedRef) => {
+const ComboboxPortal = React.forwardRef<ComboboxPortalElement, ComboboxPortalPrimitiveProps>(({ children, container, forceMount, ...props }, forwardedRef) => {
     return (
-        <ComboboxPrimitive.Portal ref={forwardedRef} container={container} {...props}>
+        <ComboboxPrimitive.Portal ref={forwardedRef} container={container} forceMount={forceMount} {...props}>
             {children}
         </ComboboxPrimitive.Portal>
 

--- a/src/components/ui/Combobox/tests/Combobox.full.test.tsx
+++ b/src/components/ui/Combobox/tests/Combobox.full.test.tsx
@@ -141,6 +141,23 @@ describe('Combobox full behavior', () => {
         expect(document.activeElement).toBe(trigger);
     });
 
+    test('portal forceMount keeps content mounted while closed', () => {
+        render(
+            <Combobox.Root>
+                <Combobox.Trigger>open</Combobox.Trigger>
+                <Combobox.Portal forceMount>
+                    <Combobox.Content>
+                        <Combobox.Group>
+                            <Combobox.Item value="one">One</Combobox.Item>
+                        </Combobox.Group>
+                    </Combobox.Content>
+                </Combobox.Portal>
+            </Combobox.Root>
+        );
+
+        expect(screen.getByRole('listbox', { hidden: true })).toHaveAttribute('data-state', 'closed');
+    });
+
     test('axe: no violations and aria attributes set', async() => {
         const { container } = render(
             <div>

--- a/src/components/ui/ContextMenu/stories/ContextMenu.stories.tsx
+++ b/src/components/ui/ContextMenu/stories/ContextMenu.stories.tsx
@@ -161,7 +161,7 @@ export const ScrollCollisionVisualTest: Story = {
                         <ContextMenu.Trigger className="flex h-[180px] w-[320px] items-center justify-center rounded border border-[var(--rad-ui-border-default)] text-[var(--rad-ui-text-primary)]">
                             Right click
                         </ContextMenu.Trigger>
-                        <ContextMenu.Portal root={container}>
+                        <ContextMenu.Portal container={container}>
                             <ContextMenu.Content>
                                 <MenuItems />
                             </ContextMenu.Content>

--- a/src/components/ui/DropdownMenu/stories/DropdownMenu.stories.tsx
+++ b/src/components/ui/DropdownMenu/stories/DropdownMenu.stories.tsx
@@ -65,7 +65,7 @@ export const ScrollCollisionVisualTest: Story = {
                     <div className="h-[280px]" />
                     <DropdownMenu.Root customRootClass="" open={open} onOpenChange={setOpen} collisionBoundary={container}>
                         <DropdownMenu.Trigger><Hamburger /></DropdownMenu.Trigger>
-                        <DropdownMenu.Portal root={container}>
+                        <DropdownMenu.Portal container={container}>
                             <DropdownMenu.Content>
                                 <DropdownMenu.Item label="Profile">Profile</DropdownMenu.Item>
                                 <DropdownMenu.Item label="Settings">Settings</DropdownMenu.Item>

--- a/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
+++ b/src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx
@@ -89,4 +89,24 @@ describe('DropdownMenu', () => {
         assertFocusReturn(getByText('Menu'));
         cleanup();
     });
+
+    it('supports a custom portal container', async() => {
+        const user = userEvent.setup();
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        render(
+            <DropdownMenu.Root>
+                <DropdownMenu.Trigger>Menu</DropdownMenu.Trigger>
+                <DropdownMenu.Portal container={container}>
+                    <DropdownMenu.Content>
+                        <DropdownMenu.Item label="Profile">Profile</DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+        );
+
+        await user.click(screen.getByText('Menu'));
+        expect(container).toContainElement(screen.getByText('Profile'));
+    });
 });

--- a/src/components/ui/HoverCard/contexts/HoverCardPortalContext.tsx
+++ b/src/components/ui/HoverCard/contexts/HoverCardPortalContext.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export const HoverCardPortalContext = React.createContext({
+    forceMount: false
+});

--- a/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
@@ -3,13 +3,15 @@ import clsx from 'clsx';
 import HoverCardContext from '../contexts/HoverCardContext';
 import Floater from '~/core/primitives/Floater';
 import { createDataAttributes } from '~/core/hooks/createDataAttribute';
+import { HoverCardPortalContext } from '../contexts/HoverCardPortalContext';
 
 export type HoverCardContentElement = ElementRef<'div'>;
 export type HoverCardContentProps = ComponentPropsWithoutRef<'div'> & {
     size?: string;
+    forceMount?: boolean;
 };
 
-const HoverCardContent = forwardRef<HoverCardContentElement, HoverCardContentProps>(({ children, className, size = '', ...props }, ref) => {
+const HoverCardContent = forwardRef<HoverCardContentElement, HoverCardContentProps>(({ children, className, forceMount = false, size = '', ...props }, ref) => {
     const {
         isOpen,
         floatingRefs,
@@ -20,6 +22,7 @@ const HoverCardContent = forwardRef<HoverCardContentElement, HoverCardContentPro
         openWithDelay,
         closeWithoutDelay
     } = useContext(HoverCardContext);
+    const { forceMount: portalForceMount } = useContext(HoverCardPortalContext);
 
     useEffect(() => {
         const handleScroll = () => closeWithoutDelay();
@@ -33,12 +36,18 @@ const HoverCardContent = forwardRef<HoverCardContentElement, HoverCardContentPro
     const mergedRef = Floater.useMergeRefs([floatingRefs.setFloating, ref]);
     const dataAttributes = createDataAttributes('hover-card', { size });
 
-    if (!isOpen) return null;
+    if (!isOpen && !forceMount && !portalForceMount) return null;
 
     return <div
         className={clsx(rootClass, className)}
         ref={mergedRef}
-        style={floatingStyles}
+        data-state={isOpen ? 'open' : 'closed'}
+        aria-hidden={!isOpen ? 'true' : undefined}
+        style={{
+            ...floatingStyles,
+            visibility: isOpen ? undefined : 'hidden',
+            pointerEvents: isOpen ? undefined : 'none'
+        }}
         {...dataAttributes}
         {...getFloatingProps({
             onPointerEnter: openWithDelay,

--- a/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
@@ -2,23 +2,28 @@ import React, { useContext, useEffect, useState, forwardRef, ElementRef, Compone
 import Floater from '~/core/primitives/Floater';
 import HoverCardContext from '../contexts/HoverCardContext';
 import ThemeContext from '~/components/ui/Theme/ThemeContext';
+import { HoverCardPortalContext } from '../contexts/HoverCardPortalContext';
 
 export type HoverCardPortalElement = ElementRef<typeof Floater.Portal>;
-export type HoverCardPortalProps = ComponentPropsWithoutRef<typeof Floater.Portal> & {
+export type HoverCardPortalProps = Omit<ComponentPropsWithoutRef<typeof Floater.Portal>, 'root'> & {
+    container?: HTMLElement | null;
+    forceMount?: boolean;
+    /** @deprecated Use `container` instead. */
     rootElement?: HTMLElement | React.MutableRefObject<HTMLElement | null>;
 };
 
-const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>(({ children, rootElement, ...props }, ref) => {
-    const { rootTriggerClass } = useContext(HoverCardContext);
+const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>(({ children, container, forceMount = false, rootElement, ...props }, ref) => {
+    const { rootTriggerClass, isOpen } = useContext(HoverCardContext);
     const themeContext = useContext(ThemeContext);
     const [rootElem, setRootElem] = useState<HTMLElement | null>(null);
 
     useEffect(() => {
-        const explicitRoot = rootElement && 'current' in rootElement
+        const legacyRoot = rootElement && 'current' in rootElement
             ? rootElement.current
             : rootElement;
 
-        const resolvedRoot = explicitRoot
+        const resolvedRoot = container
+            || legacyRoot
             || themeContext?.portalRootRef.current
             || themeContext?.containerRef.current
             || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
@@ -27,16 +32,26 @@ const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>
             || document.body;
 
         setRootElem(resolvedRoot);
-    }, [rootElement, rootTriggerClass, themeContext]);
+    }, [container, rootElement, rootTriggerClass, themeContext]);
 
     if (!rootElem) {
         return null;
     }
 
-    return <Floater.Portal
-        root={rootElem}
-        {...props}
-    >{children}</Floater.Portal>;
+    if (!isOpen && !forceMount) {
+        return null;
+    }
+
+    return (
+        <HoverCardPortalContext.Provider value={{ forceMount }}>
+            <Floater.Portal
+                root={rootElem}
+                {...props}
+            >
+                {children}
+            </Floater.Portal>
+        </HoverCardPortalContext.Provider>
+    );
 });
 
 HoverCardPortal.displayName = 'HoverCardPortal';

--- a/src/components/ui/HoverCard/stories/HoverCard.stories.tsx
+++ b/src/components/ui/HoverCard/stories/HoverCard.stories.tsx
@@ -149,7 +149,7 @@ export const ScrollCollisionVisualTest = () => {
                         Hover card anchor
                     </button>
                 </HoverCard.Trigger>
-                <HoverCard.Portal rootElement={container ?? undefined}>
+                <HoverCard.Portal container={container}>
                     <HoverCard.Content>
                         <div className="w-[18rem]">
                             <CardBody />

--- a/src/components/ui/HoverCard/tests/HoverCard.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.test.tsx
@@ -101,6 +101,25 @@ describe('HoverCard', () => {
         expect(content.closest('[data-rad-ui-portal-root]')).toBeInTheDocument();
     });
 
+    test('supports a custom portal container and portal forceMount', async() => {
+        mockMatchMedia();
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        render(
+            <HoverCard.Root open={false} onOpenChange={() => {}} customRootClass="rad-ui">
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Portal container={container} forceMount>
+                    <HoverCard.Content>Content</HoverCard.Content>
+                </HoverCard.Portal>
+            </HoverCard.Root>
+        );
+
+        const content = await screen.findByRole('dialog', { hidden: true });
+        expect(container).toContainElement(content);
+        expect(content).toHaveAttribute('data-state', 'closed');
+    });
+
     test('renders without warnings and toggles on hover', async() => {
         const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const unexpectedErrors: unknown[][] = [];

--- a/src/components/ui/Menubar/stories/Menubar.stories.tsx
+++ b/src/components/ui/Menubar/stories/Menubar.stories.tsx
@@ -87,7 +87,7 @@ export const ScrollCollisionVisualTest: Story = {
                     <Menubar.Root>
                         <Menubar.Menu collisionBoundary={container}>
                             <Menubar.Trigger>Trigger</Menubar.Trigger>
-                            <Menubar.Portal root={container}>
+                            <Menubar.Portal container={container}>
                                 <Menubar.Content>
                                     <Menubar.Item label="Profile">Profile</Menubar.Item>
                                     <Menubar.Item label="Settings">Settings</Menubar.Item>

--- a/src/components/ui/Select/fragments/SelectPortal.tsx
+++ b/src/components/ui/Select/fragments/SelectPortal.tsx
@@ -2,21 +2,23 @@
 import React, { useContext } from 'react';
 import ComboboxPrimitive from '~/core/primitives/Combobox/ComboboxPrimitive';
 import ThemeContext from '~/components/ui/Theme/ThemeContext';
+import type { ComboboxPrimitivePortalProps } from '~/core/primitives/Combobox/fragments/ComboboxPrimitivePortal';
 
 export type SelectPortalProps = {
   children: React.ReactNode;
   container?: HTMLElement | null;
+  forceMount?: boolean;
 };
 
 type SelectPortalElement = React.ElementRef<typeof ComboboxPrimitive.Portal>;
-type SelectPortalPrimitiveProps = React.ComponentPropsWithoutRef<typeof ComboboxPrimitive.Portal> & SelectPortalProps;
+type SelectPortalPrimitiveProps = Omit<ComboboxPrimitivePortalProps, 'children'> & SelectPortalProps;
 
-const SelectPortal = React.forwardRef<SelectPortalElement, SelectPortalPrimitiveProps>(({ children, container, ...props }, forwardedRef) => {
+const SelectPortal = React.forwardRef<SelectPortalElement, SelectPortalPrimitiveProps>(({ children, container, forceMount, ...props }, forwardedRef) => {
     const themeContext = useContext(ThemeContext);
     const portalContainer = container ?? themeContext?.portalRootRef.current;
 
     return (
-        <ComboboxPrimitive.Portal ref={forwardedRef} container={portalContainer} {...props}>
+        <ComboboxPrimitive.Portal ref={forwardedRef} container={portalContainer} forceMount={forceMount} {...props}>
             {children}
         </ComboboxPrimitive.Portal>
 

--- a/src/core/primitives/Combobox/contexts/ComboboxPrimitivePortalContext.tsx
+++ b/src/core/primitives/Combobox/contexts/ComboboxPrimitivePortalContext.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export const ComboboxPrimitivePortalContext = React.createContext({
+    forceMount: false
+});

--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
@@ -2,11 +2,13 @@
 import React, { useContext } from 'react';
 import { ComboboxPrimitiveContext } from '../contexts/ComboboxPrimitiveContext';
 import Floater from '~/core/primitives/Floater';
+import { ComboboxPrimitivePortalContext } from '../contexts/ComboboxPrimitivePortalContext';
 
 export type ComboboxPrimitiveContentProps = {
     children: React.ReactNode;
     className?: string;
     position?: string;
+    forceMount?: boolean;
     [key: string]: any;
 }
 
@@ -32,7 +34,8 @@ function getPlacementState(placement: string) {
 const ComboboxPrimitiveContent = React.forwardRef<
     React.ElementRef<'div'>,
     ComboboxPrimitiveContentProps & React.ComponentPropsWithoutRef<'div'>
->(({ children, className, style, ...props }, forwardedRef) => {
+>(({ children, className, forceMount = false, style, ...props }, forwardedRef) => {
+    const { forceMount: portalForceMount } = useContext(ComboboxPrimitivePortalContext);
     const {
         isOpen,
         elementsRef,
@@ -48,44 +51,59 @@ const ComboboxPrimitiveContent = React.forwardRef<
     const mergedRef = Floater.useMergeRefs([refs.setFloating, forwardedRef]);
     const shouldHideUntilPositioned = typeof navigator === 'undefined' || !/jsdom/i.test(navigator.userAgent);
     const placementState = getPlacementState(placedPlacement);
+    const shouldRender = isOpen || forceMount || portalForceMount;
+
+    if (!shouldRender) {
+        return null;
+    }
+
+    const content = (
+        <div
+            ref={mergedRef}
+            style={{
+                ...floatingStyles,
+                ...style,
+                '--rad-ui-floating-transform-origin': placementState.transformOrigin,
+                visibility: !isOpen
+                    ? 'hidden'
+                    : !isPositioned && shouldHideUntilPositioned
+                        ? 'hidden'
+                        : middlewareData.hide?.referenceHidden
+                            ? 'hidden'
+                            : (style?.visibility || floatingStyles.visibility),
+                pointerEvents: !isOpen
+                    ? 'none'
+                    : middlewareData.hide?.referenceHidden
+                        ? 'none'
+                        : style?.pointerEvents
+            }}
+            className={className}
+            data-state={isOpen ? 'open' : 'closed'}
+            data-side={placementState.side}
+            data-align={placementState.align}
+            data-positioned={isPositioned ? '' : undefined}
+            aria-hidden={!isOpen ? 'true' : undefined}
+            {...getFloatingProps()}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+
+    if (!isOpen) {
+        return (
+            <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
+                {content}
+            </Floater.FloatingList>
+        );
+    }
 
     return (
-        <>
-            {isOpen && (
-                <Floater.FocusManager context={floatingContext}>
-                    <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef} >
-                        <div
-                            ref={mergedRef}
-                            style={{
-                                ...floatingStyles,
-                                ...style,
-                                '--rad-ui-floating-transform-origin': placementState.transformOrigin,
-                                visibility: !isPositioned && shouldHideUntilPositioned
-                                    ? 'hidden'
-                                    : middlewareData.hide?.referenceHidden
-                                        ? 'hidden'
-                                        : (style?.visibility || floatingStyles.visibility),
-                                pointerEvents: middlewareData.hide?.referenceHidden
-                                    ? 'none'
-                                    : style?.pointerEvents
-                            }}
-                            className={className}
-                            data-state={isOpen ? 'open' : 'closed'}
-                            data-side={placementState.side}
-                            data-align={placementState.align}
-                            data-positioned={isPositioned ? '' : undefined}
-                            {...getFloatingProps()}
-                            {...props}
-                        >
-
-                            {children}
-
-                        </div>
-                    </Floater.FloatingList>
-                </Floater.FocusManager>
-            )}
-        </>
-
+        <Floater.FocusManager context={floatingContext}>
+            <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef} >
+                {content}
+            </Floater.FloatingList>
+        </Floater.FocusManager>
     );
 });
 

--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitivePortal.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitivePortal.tsx
@@ -1,28 +1,51 @@
 'use client';
 import React, { useContext, useEffect, useState } from 'react';
 import Floater from '~/core/primitives/Floater';
+import ThemeContext from '~/components/ui/Theme/ThemeContext';
 import { ComboboxPrimitiveContext } from '../contexts/ComboboxPrimitiveContext';
+import { ComboboxPrimitivePortalContext } from '../contexts/ComboboxPrimitivePortalContext';
+
+export type ComboboxPrimitivePortalProps = Omit<React.ComponentPropsWithoutRef<typeof Floater.Portal>, 'root'> & {
+    children: React.ReactNode;
+    container?: HTMLElement | null;
+    forceMount?: boolean;
+    /** @deprecated Use `container` instead. */
+    root?: HTMLElement | null;
+};
 
 const ComboboxPrimitivePortal = React.forwardRef<
     React.ElementRef<typeof Floater.Portal>,
-    { children: React.ReactNode; container?: HTMLElement | null } & React.ComponentPropsWithoutRef<typeof Floater.Portal>
->(({ children, container, ...props }, _forwardedRef) => {
+    ComboboxPrimitivePortalProps
+>(({ children, container, forceMount = false, root, ...props }, _forwardedRef) => {
     const { isOpen } = useContext(ComboboxPrimitiveContext);
+    const themeContext = useContext(ThemeContext);
     const [rootElementFound, setRootElementFound] = useState(false);
-    const rootElement = (container || document.querySelector('#rad-ui-theme-container') || document.body) as HTMLElement | null;
+    const [rootElement, setRootElement] = useState<HTMLElement | null>(null);
 
     useEffect(() => {
-        if (rootElement) {
+        const resolvedRoot = container
+            ?? root
+            ?? themeContext?.portalRootRef.current
+            ?? document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
+            ?? themeContext?.containerRef.current
+            ?? document.querySelector('#rad-ui-theme-container') as HTMLElement | null
+            ?? document.body;
+
+        setRootElement(resolvedRoot);
+
+        if (resolvedRoot) {
             setRootElementFound(true);
         }
-    }, [rootElement]);
+    }, [container, root, themeContext]);
 
-    if (!isOpen || !rootElementFound) return null;
+    if ((!isOpen && !forceMount) || !rootElementFound || !rootElement) return null;
 
     return (
-        <Floater.Portal root={rootElement} {...props}>
-            {children}
-        </Floater.Portal>
+        <ComboboxPrimitivePortalContext.Provider value={{ forceMount }}>
+            <Floater.Portal root={rootElement} {...props}>
+                {children}
+            </Floater.Portal>
+        </ComboboxPrimitivePortalContext.Provider>
     );
 });
 

--- a/src/core/primitives/Menu/contexts/MenuPrimitivePortalContext.tsx
+++ b/src/core/primitives/Menu/contexts/MenuPrimitivePortalContext.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export const MenuPrimitivePortalContext = React.createContext({
+    forceMount: false
+});

--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -2,21 +2,25 @@ import React, { useContext, forwardRef } from 'react';
 
 import Floater from '~/core/primitives/Floater';
 import MenuPrimitiveRootContext from '../contexts/MenuPrimitiveRootContext';
+import { MenuPrimitivePortalContext } from '../contexts/MenuPrimitivePortalContext';
 
 export type MenuPrimitiveContentProps = {
     children: React.ReactNode;
     className?: string;
+    forceMount?: boolean;
 };
 
 const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProps>(
-    ({ children, className, ...props }, propRef) => {
+    ({ children, className, forceMount = false, ...props }, propRef) => {
         const context = useContext(MenuPrimitiveRootContext);
+        const { forceMount: portalForceMount } = useContext(MenuPrimitivePortalContext);
         const mergedRef = Floater.useMergeRefs([
             context?.refs.setFloating,
             propRef
         ]);
-        if (!context || !context.isOpen) return null;
+        if (!context) return null;
         const {
+            isOpen,
             floatingStyles,
             getFloatingProps,
             elementsRef,
@@ -24,30 +28,48 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
             isNested,
             floatingContext
         } = context;
+        const shouldRender = isOpen || forceMount || portalForceMount;
+
+        if (!shouldRender) return null;
+
+        const content = (
+            <div
+                ref={mergedRef}
+                style={{
+                    ...floatingStyles,
+                    visibility: isOpen ? undefined : 'hidden',
+                    pointerEvents: isOpen ? undefined : 'none'
+                }}
+                data-state={isOpen ? 'open' : 'closed'}
+                {...getFloatingProps()}
+                className={className}
+                {...props}
+            >
+                <div style={{ overflowY: 'auto', overflowX: 'hidden' }}>
+                    {children}
+                </div>
+            </div>
+        );
+
+        if (!isOpen) {
+            return (
+                <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
+                    {content}
+                </Floater.FloatingList>
+            );
+        }
 
         return (
-            <>
             <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
                 <Floater.FocusManager
                     context={floatingContext}
                     modal={false}
                     initialFocus={isNested ? -1 : 0}
                     returnFocus={!isNested}
-                >         
-                    <div
-                        ref={mergedRef}
-                        style={floatingStyles}
-                        {...getFloatingProps()}
-                        className={className}
-                        {...props}
-                    >
-                        <div style={{overflowY:"auto", overflowX:"hidden"}}>
-                        {children}
-                        </div>
-                    </div>
+                >
+                    {content}
                 </Floater.FocusManager>
             </Floater.FloatingList>
-             </>
         );
     }
 );

--- a/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
@@ -1,32 +1,52 @@
 'use client';
-import React, { useContext, useEffect, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import React, { useContext, useEffect, useState, forwardRef } from 'react';
 import Floater from '~/core/primitives/Floater';
+import ThemeContext from '~/components/ui/Theme/ThemeContext';
 import MenuPrimitiveRootContext from '../contexts/MenuPrimitiveRootContext';
+import { MenuPrimitivePortalContext } from '../contexts/MenuPrimitivePortalContext';
 
 export type MenuPrimitivePortalElement = HTMLDivElement;
-export type MenuPrimitivePortalProps = { children: React.ReactNode } & ComponentPropsWithoutRef<typeof Floater.Portal>;
+export type MenuPrimitivePortalProps = Omit<React.ComponentPropsWithoutRef<typeof Floater.Portal>, 'root'> & {
+    children: React.ReactNode;
+    container?: HTMLElement | null;
+    forceMount?: boolean;
+    /** @deprecated Use `container` instead. */
+    root?: HTMLElement | null;
+};
 
 const MenuPrimitivePortal = forwardRef<MenuPrimitivePortalElement, MenuPrimitivePortalProps>(
-    ({ children, ...props }, ref) => {
+    ({ children, container, forceMount = false, root, ...props }, ref) => {
         const context = useContext(MenuPrimitiveRootContext);
+        const themeContext = useContext(ThemeContext);
         const [rootElementFound, setRootElementFound] = useState(false);
-        const rootElement = (
-            document.querySelector('#rad-ui-theme-container') || document.body
-        ) as HTMLElement | null;
+        const [rootElement, setRootElement] = useState<HTMLElement | null>(null);
 
         useEffect(() => {
-            if (rootElement) {
+            const resolvedRoot = container
+                ?? root
+                ?? themeContext?.portalRootRef.current
+                ?? document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
+                ?? themeContext?.containerRef.current
+                ?? document.querySelector('#rad-ui-theme-container') as HTMLElement | null
+                ?? document.body;
+
+            setRootElement(resolvedRoot);
+
+            if (resolvedRoot) {
                 setRootElementFound(true);
             }
-        }, [rootElement]);
+        }, [container, root, themeContext]);
 
         if (!context) return null;
-        const { isOpen } = context;
-        if (!isOpen || !rootElementFound) return null;
+        const shouldRender = context.isOpen || forceMount;
+
+        if (!shouldRender || !rootElementFound || !rootElement) return null;
         return (
-            <Floater.Portal root={rootElement} {...props}>
-                <div ref={ref}>{children}</div>
-            </Floater.Portal>
+            <MenuPrimitivePortalContext.Provider value={{ forceMount }}>
+                <Floater.Portal root={rootElement} {...props}>
+                    <div ref={ref}>{children}</div>
+                </Floater.Portal>
+            </MenuPrimitivePortalContext.Provider>
         );
     }
 );

--- a/src/core/primitives/Menu/tests/MenuPrimitive.test.tsx
+++ b/src/core/primitives/Menu/tests/MenuPrimitive.test.tsx
@@ -484,6 +484,33 @@ describe('MenuPrimitive', () => {
             expect(screen.queryByText('Portal Content')).not.toBeInTheDocument();
         });
 
+        it('should render portal content into a custom container', () => {
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+
+            render(
+                <MenuPrimitive.Root defaultOpen={true}>
+                    <MenuPrimitive.Portal container={container}>
+                        <div>Portal Content</div>
+                    </MenuPrimitive.Portal>
+                </MenuPrimitive.Root>
+            );
+
+            expect(container).toContainElement(screen.getByText('Portal Content'));
+        });
+
+        it('should keep content mounted when forceMount is enabled', () => {
+            render(
+                <MenuPrimitive.Root defaultOpen={false}>
+                    <MenuPrimitive.Portal forceMount>
+                        <MenuPrimitive.Content>Portal Content</MenuPrimitive.Content>
+                    </MenuPrimitive.Portal>
+                </MenuPrimitive.Root>
+            );
+
+            expect(screen.getByText('Portal Content').closest('[data-state]')).toHaveAttribute('data-state', 'closed');
+        });
+
         it('should return null when used outside MenuPrimitive.Root context', () => {
             const { container } = render(
                 <MenuPrimitive.Portal>


### PR DESCRIPTION
Closes #1783.

## What changed
- standardized menu, combobox, and hover-card portal APIs around `container` and `forceMount`
- added portal context plumbing so `forceMount` can keep menu, combobox, and hover-card content mounted in the closed state
- updated developer-facing stories to use `container` instead of legacy `root`/`rootElement`
- added a patch changeset for the user-facing portal API alignment

## Why
- overlay primitives were exposing inconsistent portal mount props (`container`, `root`, `rootElement`) and uneven `forceMount` support
- this blocked parity across the overlay surface and made internal/developer examples inconsistent

## Tests / validation
- `npm test -- --runInBand src/core/primitives/Menu/tests/MenuPrimitive.test.tsx src/components/ui/Combobox/tests/Combobox.full.test.tsx src/components/ui/DropdownMenu/tests/DropdownMenu.test.tsx src/components/ui/HoverCard/tests/HoverCard.test.tsx`
- `npm test -- --runInBand src/components/ui/Menubar/tests/Menubar.test.tsx src/components/ui/ContextMenu/tests/ContextMenu.test.tsx`
- `npm run check:types` still fails on unrelated pre-existing issues in `DrawerSwipeZone`, `Popover.stories`, `ToastRoot`, and `Clarity.stories`

## Risks / follow-ups
- legacy `root` / `rootElement` aliases are still accepted for compatibility, but stories now point developers to `container`
- full repo typecheck remains noisy due to unrelated existing failures, so this PR relies on targeted validation for the touched overlay surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `forceMount` prop to menu, combobox, hover card, and select portal components, enabling overlay content to remain mounted in the DOM while closed
  * Added `container` prop to portal components for specifying custom DOM mount targets

* **Tests**
  * Added tests for `forceMount` and `container` portal functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->