### PR TITLE
Harden worktree tooling around Husky and Jest

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,12 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+HUSKY_HELPER="$(dirname -- "$0")/_/husky.sh"
+
+if [ ! -f "$HUSKY_HELPER" ]; then
+  echo "Husky is not bootstrapped in this checkout."
+  echo "Run 'npm install' or 'npm run prepare' from the repository root, then retry the commit."
+  exit 1
+fi
+
+. "$HUSKY_HELPER"
 npm run check:exports
 npm run lint:staged

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ npm install
 npm run sb
 ```
 
+If you create a fresh clone or `git worktree`, run `npm install` before committing so Husky regenerates the local hook helpers under `.husky/_/`.
+
 Run the docs app locally:
 
 ```bash

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,13 @@ const config: Config = {
     verbose: false, // enable to see the full test suite output, console.log, etc.
     testEnvironment: 'jsdom', // enable to use DOM APIs
     setupFilesAfterEnv: ['./src/setupTests.ts'], // enable to use custom setup files
+    testPathIgnorePatterns: [
+        '/node_modules/',
+        '/dist/',
+        '/coverage/',
+        '/docs/',
+        '/\\.worktrees/'
+    ],
     moduleNameMapper: {
         '\\.(css|less|scss)$': 'identity-obj-proxy', // enable to mock CSS imports
         '^~/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
## Summary
- ignore local `.worktrees/*` folders in Jest so repo test runs only execute the canonical workspace tests
- make the Husky pre-commit hook fail with actionable bootstrap guidance when `.husky/_/husky.sh` has not been generated yet
- document the fresh clone / `git worktree` bootstrap expectation in the root README

## Issue audit
- directly addresses #1924 by making the missing Husky bootstrap case explicit instead of failing with a cryptic shell error
- audited #1917, #1916, and #1915 while validating Accordion regressions; the current source tree already includes targeted Accordion parity and hydration coverage for those reports
- reviewed #1912 during the same pass, but that docs presentation change looks like a separate visual follow-up rather than the tooling/worktree fix in this PR

## Verification
- `npm test -- --runInBand --runTestsByPath src/components/ui/Accordion/tests/Accordion.test.tsx src/components/ui/Accordion/tests/Accordion.focus.test.tsx src/core/primitives/Collapsible/tests/Collapsible.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development guide with setup instructions for cloning and git worktree workflows

* **Chores**
  * Enhanced pre-commit hook with improved path resolution and validation
  * Configured Jest test runner to exclude specific directories from test discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->