### PR TITLE
ci(compat): add consumer coverage and support guidance

### DIFF
--- a/.github/workflows/consumer-compat.yml
+++ b/.github/workflows/consumer-compat.yml
@@ -1,0 +1,113 @@
+name: Consumer Compatibility
+
+on:
+  pull_request:
+    branches: [ main, security-fixes ]
+    paths:
+      - 'src/**'
+      - 'styles/**'
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/**'
+      - 'rollup.config.cjs'
+      - 'rollup-css.config.js'
+      - 'rollup-tokens.config.js'
+      - 'tsconfig.json'
+      - '.github/workflows/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'styles/**'
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/**'
+      - 'rollup.config.cjs'
+      - 'rollup-css.config.js'
+      - 'rollup-tokens.config.js'
+      - 'tsconfig.json'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  node-smoke:
+    name: Node ESM/CJS smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build:rollup
+
+      - name: Pack package
+        run: |
+          mkdir -p .tmp/consumer-compat
+          npm pack --pack-destination .tmp/consumer-compat
+
+      - name: Run node consumer smoke tests
+        run: |
+          TARBALL=$(find .tmp/consumer-compat -maxdepth 1 -name '*.tgz' -print -quit)
+          node scripts/consumer-compat/run-node-smoke.mjs "$TARBALL"
+
+  next-app-router:
+    name: Next.js App Router consumer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build:rollup
+
+      - name: Pack package
+        run: |
+          mkdir -p .tmp/consumer-compat
+          npm pack --pack-destination .tmp/consumer-compat
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup docs cache
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install docs dependencies
+        run: pnpm --dir docs install --frozen-lockfile
+
+      - name: Install local package tarball into docs app
+        run: |
+          TARBALL=$(find .tmp/consumer-compat -maxdepth 1 -name '*.tgz' -print -quit)
+          pnpm --dir docs add "../$TARBALL"
+
+      - name: Build docs app
+        run: pnpm --dir docs build

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -98,6 +98,10 @@ export const docsNavigationSections = [
                 path:"/docs/guides/browser-support"
             },
             {
+                title:"React Support",
+                path:"/docs/guides/react-support"
+            },
+            {
                 title:"Date, Time & Timezones",
                 path:"/docs/guides/date-time-and-timezones"
             },

--- a/docs/app/docs/guides/browser-support/content.mdx
+++ b/docs/app/docs/guides/browser-support/content.mdx
@@ -39,6 +39,7 @@ If one of these APIs is missing, the environment is outside the library's guaran
 - **No legacy IE / pre-Chromium Edge support**: those environments are outside the project baseline.
 - **Reduced motion**: components should respect `prefers-reduced-motion` when motion is introduced.
 - **Mobile Safari**: verify touch, scrolling, viewport, and keyboard behavior for overlays and form-heavy components.
+- **React baseline**: framework-level support and version strategy are documented separately in [React Support](/docs/guides/react-support).
 - **SSR**: hydration-sensitive primitives should keep server and client markup aligned. See [SSR & No-JS Fallback](/docs/guides/ssr-and-no-js-fallback).
 
 ## Validation policy

--- a/docs/app/docs/guides/react-support/content.mdx
+++ b/docs/app/docs/guides/react-support/content.mdx
@@ -1,0 +1,53 @@
+# React support
+
+Rad UI is built first for stable React applications, then validated against newer React releases before the public support contract expands.
+
+## Current support matrix
+
+| Environment | Status | What it means |
+| --- | --- | --- |
+| React `18.2.x` | Official | This is the primary peer dependency target and the main unit-test baseline for the library. |
+| React `19.x` | Compatibility smoke-tested | The docs app runs on React 19 with Next.js App Router, which gives maintainers an integration signal, but the package peer dependency and full test matrix are not widened yet. |
+| Earlier React 18 minors | Best effort | They may work, but the project baseline is `18.2.x` rather than every earlier 18.x release. |
+| React 17 and older | Unsupported | These versions are outside the current maintenance target. |
+
+## Why the matrix is split
+
+Rad UI has two different validation layers:
+
+- **Library validation**: Jest and component tests run against the root library environment and enforce the primary support contract.
+- **Consumer validation**: the docs app is a real Next.js App Router consumer and exercises the package in a modern React 19 application.
+
+That split is intentional. It lets maintainers catch integration regressions early without claiming full React 19 support before the peer dependency range, release process, and regression matrix all match that promise.
+
+## React 19 strategy
+
+The current strategy is:
+
+1. Keep the published peer dependency baseline on React `18.2.x`.
+2. Continuously smoke-test Rad UI inside the docs app on React `19.x` and Next.js App Router.
+3. Expand the peer dependency range only after targeted validation shows that core primitives, hydration behavior, and packaging all behave consistently on React 19.
+
+Before the package officially claims React 19 support, maintainers should verify:
+
+- component tests pass on a React 19 library test matrix
+- hydration-sensitive components do not emit new warnings
+- consumer builds still succeed in Next.js App Router and other supported bundlers
+- any React 19 behavior changes are documented in release notes and migration guidance
+
+## App Router and Server Components
+
+Rad UI is a client-side interaction library. In Next.js App Router and other React Server Component environments:
+
+- keep interactive Rad UI usage inside `"use client"` components
+- pass only serializable data across the server-to-client boundary
+- render static layout or content wrappers on the server when that improves first paint or SEO
+
+If your page must remain useful without client hydration, pair this guide with [SSR & No-JS Fallback](/docs/guides/ssr-and-no-js-fallback).
+
+## Practical recommendation
+
+For production apps today:
+
+- choose React `18.2.x` if you want the narrowest, officially supported path
+- use React `19.x` only if your team is comfortable operating on the compatibility-smoke-tested path while the support contract catches up

--- a/docs/app/docs/guides/react-support/seo.ts
+++ b/docs/app/docs/guides/react-support/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const reactSupportMetadata = generateSeoMetadata({
+  title: 'React Support | Rad UI',
+  description: 'React version support policy, compatibility strategy, and App Router guidance for Rad UI.'
+})
+
+export default reactSupportMetadata

--- a/docs/app/docs/guides/ssr-and-no-js-fallback/content.mdx
+++ b/docs/app/docs/guides/ssr-and-no-js-fallback/content.mdx
@@ -15,6 +15,28 @@ Without JavaScript, **interactive components will not function**. Recommended pa
 - **Progressive enhancement**: Ship meaningful **HTML** in the SSR output (headings, links, forms that can post without JS where applicable).
 - **Fallback content**: For critical UI, provide a **noscript** or server-rendered alternative for **read-only** views (for example, a static table instead of a sortable grid).
 
+## Component fallback matrix
+
+The important question is not whether a component can render on the server. Most of them can. The real question is whether the SSR output stays useful before hydration and with JavaScript disabled.
+
+| Category | Examples | SSR output | No-JS behavior | Recommended fallback |
+| --- | --- | --- | --- | --- |
+| Static content and layout primitives | `Text`, `Heading`, `Badge`, `BlockQuote`, `Code`, `Em`, `Kbd`, `Separator`, `Strong`, `Table`, `VisuallyHidden` | Useful semantic markup | Usually still useful | No special fallback needed beyond normal semantic HTML. |
+| Simple presentational wrappers | `AspectRatio`, `Avatar`, `AvatarGroup`, `Callout`, `Card`, `Quote` | Useful structure and content | Usually still readable | Prefer meaningful text and alt content so the server render carries the essential information. |
+| Stateful disclosure and selection patterns | `Accordion`, `Collapsible`, `Disclosure`, `Tabs`, `Toggle`, `ToggleGroup`, `Tree` | Initial state can render correctly | The initial state is visible, but users cannot change it without hydration | When no-JS matters, prefer server-rendered summaries or native elements such as `<details>` for critical disclosures. |
+| Form-adjacent controls with richer interaction | `Checkbox`, `CheckboxGroup`, `NumberField`, `Radio`, `RadioGroup`, `Slider`, `Switch`, `TextArea` | Markup can render, labels can remain visible | Enhanced keyboard, pointer, or state syncing behavior depends on hydration | For critical workflows, prefer native HTML controls or server-postable forms as the baseline. |
+| Overlay, popup, and command surfaces | `AlertDialog`, `Combobox`, `ContextMenu`, `Dialog`, `DropdownMenu`, `HoverCard`, `Menubar`, `NavigationMenu`, `Select`, `Toast`, `Tooltip` | Trigger markup may render, but the interactive surface relies on client behavior | Usually non-functional without JavaScript | Use always-visible server content, native alternatives, or dedicated no-JS navigation paths when the interaction is essential. |
+
+## What to document in product code
+
+If you build product abstractions on top of Rad UI, document three states for critical flows:
+
+- what the page renders during SSR
+- what the user can do before hydration completes
+- what still works when JavaScript is disabled entirely
+
+That framing is more useful than a generic "SSR supported" claim because it matches the actual experience users see.
+
 ## Frameworks
 
 - **Next.js App Router**: Follow React Server Components boundaries; keep client-only Rad UI in `"use client"` components when required.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prerelease:exit": "changeset pre exit",
     "prepublishOnly": "npm run build:rollup",
     "test:shard": "jest --shard=$JEST_SHARD",
+    "test:consumer:node": "node scripts/consumer-compat/run-node-smoke.mjs",
     "test:watch": "jest --watch",
     "clean": "rimraf dist",
     "chromatic": "chromatic --exit-zero-on-changes",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,307 @@
     },
     "./themes/default.css": "./dist/themes/default.css",
     "./themes/baremetal.css": "./dist/themes/baremetal.css",
-    "./themes/tailwind-presets/default.js": "./dist/themes/tailwind-presets/default.js"
+    "./themes/tailwind-presets/default.js": "./dist/themes/tailwind-presets/default.js",
+    "./Accordion": {
+      "import": "./dist/components/Accordion.js",
+      "require": "./dist/components/Accordion.cjs",
+      "types": "./dist/components/Accordion.d.ts"
+    },
+    "./AlertDialog": {
+      "import": "./dist/components/AlertDialog.js",
+      "require": "./dist/components/AlertDialog.cjs",
+      "types": "./dist/components/AlertDialog.d.ts"
+    },
+    "./AspectRatio": {
+      "import": "./dist/components/AspectRatio.js",
+      "require": "./dist/components/AspectRatio.cjs",
+      "types": "./dist/components/AspectRatio.d.ts"
+    },
+    "./Avatar": {
+      "import": "./dist/components/Avatar.js",
+      "require": "./dist/components/Avatar.cjs",
+      "types": "./dist/components/Avatar.d.ts"
+    },
+    "./AvatarGroup": {
+      "import": "./dist/components/AvatarGroup.js",
+      "require": "./dist/components/AvatarGroup.cjs",
+      "types": "./dist/components/AvatarGroup.d.ts"
+    },
+    "./Badge": {
+      "import": "./dist/components/Badge.js",
+      "require": "./dist/components/Badge.cjs",
+      "types": "./dist/components/Badge.d.ts"
+    },
+    "./BlockQuote": {
+      "import": "./dist/components/BlockQuote.js",
+      "require": "./dist/components/BlockQuote.cjs",
+      "types": "./dist/components/BlockQuote.d.ts"
+    },
+    "./Button": {
+      "import": "./dist/components/Button.js",
+      "require": "./dist/components/Button.cjs",
+      "types": "./dist/components/Button.d.ts"
+    },
+    "./Callout": {
+      "import": "./dist/components/Callout.js",
+      "require": "./dist/components/Callout.cjs",
+      "types": "./dist/components/Callout.d.ts"
+    },
+    "./Card": {
+      "import": "./dist/components/Card.js",
+      "require": "./dist/components/Card.cjs",
+      "types": "./dist/components/Card.d.ts"
+    },
+    "./Checkbox": {
+      "import": "./dist/components/Checkbox.js",
+      "require": "./dist/components/Checkbox.cjs",
+      "types": "./dist/components/Checkbox.d.ts"
+    },
+    "./CheckboxCards": {
+      "import": "./dist/components/CheckboxCards.js",
+      "require": "./dist/components/CheckboxCards.cjs",
+      "types": "./dist/components/CheckboxCards.d.ts"
+    },
+    "./CheckboxGroup": {
+      "import": "./dist/components/CheckboxGroup.js",
+      "require": "./dist/components/CheckboxGroup.cjs",
+      "types": "./dist/components/CheckboxGroup.d.ts"
+    },
+    "./Code": {
+      "import": "./dist/components/Code.js",
+      "require": "./dist/components/Code.cjs",
+      "types": "./dist/components/Code.d.ts"
+    },
+    "./Collapsible": {
+      "import": "./dist/components/Collapsible.js",
+      "require": "./dist/components/Collapsible.cjs",
+      "types": "./dist/components/Collapsible.d.ts"
+    },
+    "./Combobox": {
+      "import": "./dist/components/Combobox.js",
+      "require": "./dist/components/Combobox.cjs",
+      "types": "./dist/components/Combobox.d.ts"
+    },
+    "./Command": {
+      "import": "./dist/components/Command.js",
+      "require": "./dist/components/Command.cjs",
+      "types": "./dist/components/Command.d.ts"
+    },
+    "./ContextMenu": {
+      "import": "./dist/components/ContextMenu.js",
+      "require": "./dist/components/ContextMenu.cjs",
+      "types": "./dist/components/ContextMenu.d.ts"
+    },
+    "./DataList": {
+      "import": "./dist/components/DataList.js",
+      "require": "./dist/components/DataList.cjs",
+      "types": "./dist/components/DataList.d.ts"
+    },
+    "./Dialog": {
+      "import": "./dist/components/Dialog.js",
+      "require": "./dist/components/Dialog.cjs",
+      "types": "./dist/components/Dialog.d.ts"
+    },
+    "./Disclosure": {
+      "import": "./dist/components/Disclosure.js",
+      "require": "./dist/components/Disclosure.cjs",
+      "types": "./dist/components/Disclosure.d.ts"
+    },
+    "./Drawer": {
+      "import": "./dist/components/Drawer.js",
+      "require": "./dist/components/Drawer.cjs",
+      "types": "./dist/components/Drawer.d.ts"
+    },
+    "./DropdownMenu": {
+      "import": "./dist/components/DropdownMenu.js",
+      "require": "./dist/components/DropdownMenu.cjs",
+      "types": "./dist/components/DropdownMenu.d.ts"
+    },
+    "./Em": {
+      "import": "./dist/components/Em.js",
+      "require": "./dist/components/Em.cjs",
+      "types": "./dist/components/Em.d.ts"
+    },
+    "./Heading": {
+      "import": "./dist/components/Heading.js",
+      "require": "./dist/components/Heading.cjs",
+      "types": "./dist/components/Heading.d.ts"
+    },
+    "./HoverCard": {
+      "import": "./dist/components/HoverCard.js",
+      "require": "./dist/components/HoverCard.cjs",
+      "types": "./dist/components/HoverCard.d.ts"
+    },
+    "./Kbd": {
+      "import": "./dist/components/Kbd.js",
+      "require": "./dist/components/Kbd.cjs",
+      "types": "./dist/components/Kbd.d.ts"
+    },
+    "./Link": {
+      "import": "./dist/components/Link.js",
+      "require": "./dist/components/Link.cjs",
+      "types": "./dist/components/Link.d.ts"
+    },
+    "./Menubar": {
+      "import": "./dist/components/Menubar.js",
+      "require": "./dist/components/Menubar.cjs",
+      "types": "./dist/components/Menubar.d.ts"
+    },
+    "./Minimap": {
+      "import": "./dist/components/Minimap.js",
+      "require": "./dist/components/Minimap.cjs",
+      "types": "./dist/components/Minimap.d.ts"
+    },
+    "./NavigationMenu": {
+      "import": "./dist/components/NavigationMenu.js",
+      "require": "./dist/components/NavigationMenu.cjs",
+      "types": "./dist/components/NavigationMenu.d.ts"
+    },
+    "./NumberField": {
+      "import": "./dist/components/NumberField.js",
+      "require": "./dist/components/NumberField.cjs",
+      "types": "./dist/components/NumberField.d.ts"
+    },
+    "./Popover": {
+      "import": "./dist/components/Popover.js",
+      "require": "./dist/components/Popover.cjs",
+      "types": "./dist/components/Popover.d.ts"
+    },
+    "./Progress": {
+      "import": "./dist/components/Progress.js",
+      "require": "./dist/components/Progress.cjs",
+      "types": "./dist/components/Progress.d.ts"
+    },
+    "./Quote": {
+      "import": "./dist/components/Quote.js",
+      "require": "./dist/components/Quote.cjs",
+      "types": "./dist/components/Quote.d.ts"
+    },
+    "./Radio": {
+      "import": "./dist/components/Radio.js",
+      "require": "./dist/components/Radio.cjs",
+      "types": "./dist/components/Radio.d.ts"
+    },
+    "./RadioCards": {
+      "import": "./dist/components/RadioCards.js",
+      "require": "./dist/components/RadioCards.cjs",
+      "types": "./dist/components/RadioCards.d.ts"
+    },
+    "./RadioGroup": {
+      "import": "./dist/components/RadioGroup.js",
+      "require": "./dist/components/RadioGroup.cjs",
+      "types": "./dist/components/RadioGroup.d.ts"
+    },
+    "./ScrollArea": {
+      "import": "./dist/components/ScrollArea.js",
+      "require": "./dist/components/ScrollArea.cjs",
+      "types": "./dist/components/ScrollArea.d.ts"
+    },
+    "./Select": {
+      "import": "./dist/components/Select.js",
+      "require": "./dist/components/Select.cjs",
+      "types": "./dist/components/Select.d.ts"
+    },
+    "./Separator": {
+      "import": "./dist/components/Separator.js",
+      "require": "./dist/components/Separator.cjs",
+      "types": "./dist/components/Separator.d.ts"
+    },
+    "./Skeleton": {
+      "import": "./dist/components/Skeleton.js",
+      "require": "./dist/components/Skeleton.cjs",
+      "types": "./dist/components/Skeleton.d.ts"
+    },
+    "./Slider": {
+      "import": "./dist/components/Slider.js",
+      "require": "./dist/components/Slider.cjs",
+      "types": "./dist/components/Slider.d.ts"
+    },
+    "./Spinner": {
+      "import": "./dist/components/Spinner.js",
+      "require": "./dist/components/Spinner.cjs",
+      "types": "./dist/components/Spinner.d.ts"
+    },
+    "./Splitter": {
+      "import": "./dist/components/Splitter.js",
+      "require": "./dist/components/Splitter.cjs",
+      "types": "./dist/components/Splitter.d.ts"
+    },
+    "./Steps": {
+      "import": "./dist/components/Steps.js",
+      "require": "./dist/components/Steps.cjs",
+      "types": "./dist/components/Steps.d.ts"
+    },
+    "./Strong": {
+      "import": "./dist/components/Strong.js",
+      "require": "./dist/components/Strong.cjs",
+      "types": "./dist/components/Strong.d.ts"
+    },
+    "./Switch": {
+      "import": "./dist/components/Switch.js",
+      "require": "./dist/components/Switch.cjs",
+      "types": "./dist/components/Switch.d.ts"
+    },
+    "./TabNav": {
+      "import": "./dist/components/TabNav.js",
+      "require": "./dist/components/TabNav.cjs",
+      "types": "./dist/components/TabNav.d.ts"
+    },
+    "./Table": {
+      "import": "./dist/components/Table.js",
+      "require": "./dist/components/Table.cjs",
+      "types": "./dist/components/Table.d.ts"
+    },
+    "./Tabs": {
+      "import": "./dist/components/Tabs.js",
+      "require": "./dist/components/Tabs.cjs",
+      "types": "./dist/components/Tabs.d.ts"
+    },
+    "./Text": {
+      "import": "./dist/components/Text.js",
+      "require": "./dist/components/Text.cjs",
+      "types": "./dist/components/Text.d.ts"
+    },
+    "./TextArea": {
+      "import": "./dist/components/TextArea.js",
+      "require": "./dist/components/TextArea.cjs",
+      "types": "./dist/components/TextArea.d.ts"
+    },
+    "./Theme": {
+      "import": "./dist/components/Theme.js",
+      "require": "./dist/components/Theme.cjs",
+      "types": "./dist/components/Theme.d.ts"
+    },
+    "./Toggle": {
+      "import": "./dist/components/Toggle.js",
+      "require": "./dist/components/Toggle.cjs",
+      "types": "./dist/components/Toggle.d.ts"
+    },
+    "./ToggleGroup": {
+      "import": "./dist/components/ToggleGroup.js",
+      "require": "./dist/components/ToggleGroup.cjs",
+      "types": "./dist/components/ToggleGroup.d.ts"
+    },
+    "./Toolbar": {
+      "import": "./dist/components/Toolbar.js",
+      "require": "./dist/components/Toolbar.cjs",
+      "types": "./dist/components/Toolbar.d.ts"
+    },
+    "./Tooltip": {
+      "import": "./dist/components/Tooltip.js",
+      "require": "./dist/components/Tooltip.cjs",
+      "types": "./dist/components/Tooltip.d.ts"
+    },
+    "./Tree": {
+      "import": "./dist/components/Tree.js",
+      "require": "./dist/components/Tree.cjs",
+      "types": "./dist/components/Tree.d.ts"
+    },
+    "./VisuallyHidden": {
+      "import": "./dist/components/VisuallyHidden.js",
+      "require": "./dist/components/VisuallyHidden.cjs",
+      "types": "./dist/components/VisuallyHidden.d.ts"
+    }
   },
   "files": [
     "dist",
@@ -53,7 +353,7 @@
     "build:css": "npm run generate-tokens && npm run bundle-tokens && npm run build-css",
     "build:components": "npm run compile-components && npm run process-components",
     "build:rollup": "NODE_OPTIONS='--max-old-space-size=8192' npm run build:rollup:process",
-    "build:rollup:process": "npm run clean && (npm run build:css & npm run build:components & wait) && npm run build:generate-exports",
+    "build:rollup:process": "node scripts/build-rollup-process.cjs",
     "compile-components:esbuild": "node build-components.cjs",
     "check:types": "tsc --noEmit",
     "check:exports": "node scripts/generate-exports.cjs --check",

--- a/scripts/build-rollup-process.cjs
+++ b/scripts/build-rollup-process.cjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const componentsPath = path.join(repoRoot, 'dist', 'components');
+
+function run(command, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd: repoRoot,
+            stdio: 'inherit',
+            shell: true,
+            ...options
+        });
+
+        child.on('error', reject);
+        child.on('exit', (code, signal) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+
+            if (signal) {
+                reject(new Error(`${command} ${args.join(' ')} terminated with signal ${signal}`));
+                return;
+            }
+
+            reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+        });
+    });
+}
+
+async function runParallel(commands) {
+    const running = commands.map(([command, args]) => run(command, args));
+    await Promise.all(running);
+}
+
+async function main() {
+    await run('npm', ['run', 'clean']);
+    await runParallel([
+        ['npm', ['run', 'build:css']],
+        ['npm', ['run', 'build:components']]
+    ]);
+
+    if (!fs.existsSync(componentsPath)) {
+        throw new Error(`Expected built components at ${componentsPath}, but the directory was not created.`);
+    }
+
+    const componentFiles = fs.readdirSync(componentsPath).filter((file) => file.endsWith('.js'));
+    if (componentFiles.length === 0) {
+        throw new Error(`Expected component bundles in ${componentsPath}, but no .js files were found.`);
+    }
+
+    await run('npm', ['run', 'build:generate-exports']);
+}
+
+main().catch((error) => {
+    console.error(`❌ build:rollup:process failed: ${error.message}`);
+    process.exit(1);
+});

--- a/scripts/consumer-compat/run-node-smoke.mjs
+++ b/scripts/consumer-compat/run-node-smoke.mjs
@@ -1,0 +1,64 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const tarballArg = process.argv[2];
+
+if (!tarballArg) {
+    console.error('Usage: node scripts/consumer-compat/run-node-smoke.mjs <package-tarball>');
+    process.exit(1);
+}
+
+const tarballPath = resolve(tarballArg);
+const workspace = mkdtempSync(join(tmpdir(), 'rad-ui-consumer-smoke-'));
+
+const run = (command, args, options = {}) => execFileSync(command, args, {
+    cwd: workspace,
+    stdio: 'inherit',
+    ...options
+});
+
+try {
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({
+        name: 'rad-ui-consumer-smoke',
+        private: true,
+        type: 'module'
+    }, null, 2));
+
+    writeFileSync(join(workspace, 'esm-smoke.mjs'), `import { Button } from '@radui/ui';
+import ButtonSubpath from '@radui/ui/Button';
+
+if (typeof Button !== 'function') {
+  throw new Error('Expected named Button export to resolve as a function.');
+}
+
+if (typeof ButtonSubpath !== 'function') {
+  throw new Error('Expected Button subpath export to resolve as a function.');
+}
+
+console.log('esm-smoke-ok');
+`);
+
+    writeFileSync(join(workspace, 'cjs-smoke.cjs'), `const { Button } = require('@radui/ui');
+const ButtonSubpath = require('@radui/ui/Button');
+
+if (typeof Button !== 'function') {
+  throw new Error('Expected named Button export to resolve as a function.');
+}
+
+const resolvedSubpath = ButtonSubpath && ButtonSubpath.default ? ButtonSubpath.default : ButtonSubpath;
+
+if (typeof resolvedSubpath !== 'function') {
+  throw new Error('Expected Button subpath export to resolve as a function.');
+}
+
+console.log('cjs-smoke-ok');
+`);
+
+    run('npm', ['install', '--no-package-lock', tarballPath]);
+    run('node', ['esm-smoke.mjs']);
+    run('node', ['cjs-smoke.cjs']);
+} finally {
+    rmSync(workspace, { recursive:true, force:true });
+}

--- a/scripts/generate-exports.cjs
+++ b/scripts/generate-exports.cjs
@@ -48,8 +48,8 @@ let files = [];
 try {
     files = fs.readdirSync(distPath);
 } catch (error) {
-    console.warn(`Warning: ${distPath} not found. No components will be exported.`);
-    files = [];
+    console.error(`❌ ${distPath} not found. Build components before generating exports.`);
+    process.exit(1);
 }
 
 const exportsMap = {};
@@ -86,6 +86,12 @@ files.forEach(file => {
         };
     }
 });
+
+const releasedComponentExports = Object.keys(exportsMap).filter((key) => key.startsWith('./') && !key.startsWith('./themes/'));
+if (releasedComponentExports.length === 0) {
+    console.error(`❌ No released component exports were generated from ${distPath}. Refusing to rewrite package.json exports.`);
+    process.exit(1);
+}
 
 if (notReleasedComponents.length > 0) {
     console.log(`Not released components: ${notReleasedComponents.join(', ')}`);


### PR DESCRIPTION
## Summary
- add a dedicated consumer-compat workflow that packs the local library, smoke-tests ESM/CJS consumers, and builds the Next.js App Router docs app against the tarball
- publish a new React support guide that explains the current React 18 baseline, the React 19 compatibility strategy, and App Router client-boundary expectations
- expand SSR/no-JS guidance with a component fallback matrix and link the React support policy from browser support

## Issues
Closes #1866
Closes #1867
Closes #1868
Closes #1869

## Verification
- `node --check scripts/consumer-compat/run-node-smoke.mjs`
- local `npm run build:rollup` was not fully reliable in this sandbox because the existing build uses environment-sensitive tooling (`tsx` IPC permissions here, plus prior local memory pressure), so the new GitHub Actions workflow is the primary verification path for the consumer checks

## Notes
- left unrelated local changes in `README.md`, `.husky/pre-commit`, and `jest.config.ts` untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive React support guide, updated browser-compat notes, and expanded SSR/no-JS fallback guidance.

* **Tests**
  * Added consumer-compatibility checks including Node and Next consumer smoke tests to validate real-world installs and builds.

* **Chores**
  * Improved package export map and packaging scripts; tightened build/export safeguards and streamlined the build orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->