### PR TITLE
docs(contributing): add API review checklist for new exports

### DIFF
--- a/docs/app/docs/contributing/api-review-checklist/content.mdx
+++ b/docs/app/docs/contributing/api-review-checklist/content.mdx
@@ -1,0 +1,56 @@
+# API review checklist
+
+Use this checklist before exporting a new public symbol from `@radui/ui` or changing an existing supported export.
+
+The goal is to keep the public surface intentional, documented, and semver-safe.
+
+## When this applies
+
+- Adding a new component entry under `package.json` `exports`
+- Exporting a new type, hook, or utility from a public entrypoint
+- Promoting an internal module to a supported public API
+- Renaming or removing anything consumers may import today
+
+Skip this checklist for purely internal refactors that do not change supported exports.
+
+## Checklist
+
+### Scope and naming
+
+- [ ] The symbol is **truly public**. If it is only needed inside the library, keep it internal.
+- [ ] The name matches existing Rad UI conventions (see [Naming conventions](/docs/contributing/naming-conventions)).
+- [ ] The export path follows the per-component entry pattern (`@radui/ui/ComponentName`) when appropriate.
+- [ ] The API shape is composable and headless — behavior and accessibility live in the library; visual design stays with consumers.
+
+### Semver and compatibility
+
+- [ ] The change is classified as **patch**, **minor**, or **major** before merge.
+- [ ] Breaking removals or signature changes include a **major** changeset and migration notes (see [Changeset quality](/docs/contributing/changeset-quality)).
+- [ ] Deprecated APIs have a documented replacement and a reasonable removal timeline when possible.
+
+### Documentation and examples
+
+- [ ] A docs page exists or is updated for new components and meaningful API changes.
+- [ ] Storybook stories cover primary states and keyboard interaction where relevant.
+- [ ] Public `data-*` attributes and styling hooks are documented when they are part of the supported contract.
+
+### Tests and accessibility
+
+- [ ] Unit or integration tests cover the new export and expected behavior.
+- [ ] Keyboard interaction, focus management, and ARIA roles are verified for interactive APIs.
+- [ ] SSR-safe patterns are used — no `window` / `document` in render paths.
+
+### Release hygiene
+
+- [ ] A changeset is added when the change should appear in release notes.
+- [ ] Generated `dist` types and exports were checked locally with `npm run build:rollup`.
+
+## Reviewer prompts
+
+Reviewers should ask:
+
+1. Would we support this API for multiple major versions?
+2. Can consumers style and extend it without relying on internal DOM structure?
+3. Is there a smaller surface that solves the same problem?
+
+Link the tracking issue in the PR and call out any checklist items that do not apply.

--- a/docs/app/docs/contributing/api-review-checklist/page.tsx
+++ b/docs/app/docs/contributing/api-review-checklist/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/api-review-checklist/seo.ts
+++ b/docs/app/docs/contributing/api-review-checklist/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const apiReviewChecklistMetadata = generateSeoMetadata({
+  title: 'API review checklist | Rad UI',
+  description: 'Checklist for reviewing new public exports and API changes before they ship in @radui/ui.'
+})
+
+export default apiReviewChecklistMetadata

--- a/docs/app/docs/contributing/contributor-checklist/content.mdx
+++ b/docs/app/docs/contributing/contributor-checklist/content.mdx
@@ -21,6 +21,10 @@ Use this checklist before opening a PR. Skip items that clearly do not apply (fo
 - [ ] **Keyboard**: Focus order and focus visibility are reasonable; Escape / arrow keys behave as expected for the pattern.
 - [ ] **Motion**: Respects `prefers-reduced-motion` when adding animation (if applicable).
 
+## Public API changes
+
+- [ ] **New exports**: Followed the [API review checklist](/docs/contributing/api-review-checklist) when adding or changing supported public symbols.
+
 ## Release hygiene
 
 - [ ] **Changeset**: Added a `.changeset` entry when the change should appear in the changelog (see [Changeset quality](/docs/contributing/changeset-quality)).

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -148,6 +148,10 @@ export const docsNavigationSections = [
                 path:"/docs/contributing/contributor-checklist"
             },
             {
+                title:"API Review Checklist",
+                path:"/docs/contributing/api-review-checklist"
+            },
+            {
                 title:"Flaky Test Quarantine",
                 path:"/docs/contributing/flaky-test-quarantine"
             },


### PR DESCRIPTION
## Summary
- Adds a contributing guide with a checklist for reviewing new public exports and API changes.
- Links the checklist from the contributor checklist and docs navigation.

Closes #1833.

## Test plan
- [x] Docs page files follow existing contributing guide structure (`content.mdx`, `page.tsx`, `seo.ts`).
- [ ] Verify the page renders at `/docs/contributing/api-review-checklist` in the docs app.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "API Review Checklist" guide for contributors outlining the review process for new public API additions, covering naming conventions, version compatibility, documentation standards, and testing requirements.
  * Updated the contributor checklist to reference API review requirements when adding or changing supported public exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->