### PR TITLE
build(package): annotate sideEffects for CSS tree-shaking

### DIFF
--- a/docs/app/docs/contributing/side-effects-and-tree-shaking/content.mdx
+++ b/docs/app/docs/contributing/side-effects-and-tree-shaking/content.mdx
@@ -1,0 +1,38 @@
+# Side effects and tree-shaking
+
+Rad UI marks stylesheet modules as side-effectful so bundlers can tree-shake unused JavaScript while still loading CSS when imported.
+
+## Package annotation
+
+`package.json` includes:
+
+```json
+"sideEffects": [
+  "**/*.css",
+  "**/*.scss"
+]
+```
+
+This tells bundlers such as webpack, Rollup, and esbuild that:
+
+- plain component modules are safe to drop when unused
+- theme and component CSS/SCSS files must be retained when imported
+
+## Consumer guidance
+
+- Prefer per-component imports (`@radui/ui/Button`) so unused components are not bundled.
+- Import theme CSS explicitly when you rely on Rad UI styles:
+
+```tsx
+import '@radui/ui/themes/default.css'
+```
+
+- Do not re-export the entire library from a single app barrel if you only need a few components.
+
+## Maintainer checklist
+
+When adding a module with runtime side effects (global registration, polyfills, imperative setup):
+
+1. Confirm it is truly required at import time.
+2. Add a targeted `sideEffects` glob or file path if the module must not be tree-shaken.
+3. Avoid widening `sideEffects` to `true` for the whole package.

--- a/docs/app/docs/contributing/side-effects-and-tree-shaking/page.tsx
+++ b/docs/app/docs/contributing/side-effects-and-tree-shaking/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/side-effects-and-tree-shaking/seo.ts
+++ b/docs/app/docs/contributing/side-effects-and-tree-shaking/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const sideEffectsMetadata = generateSeoMetadata({
+  title: 'Side effects and tree-shaking | Rad UI',
+  description: 'How Rad UI sideEffects annotations help bundlers tree-shake JavaScript while preserving CSS imports.'
+})
+
+export default sideEffectsMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -162,6 +162,10 @@ export const docsNavigationSections = [
             {
                 title:"Changeset Quality",
                 path:"/docs/contributing/changeset-quality"
+            },
+            {
+                title:"Side Effects & Tree-shaking",
+                path:"/docs/contributing/side-effects-and-tree-shaking"
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "",
   "main": "dist",
   "type": "module",
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Adds `sideEffects` for CSS/SCSS so bundlers can tree-shake unused JS while preserving stylesheet imports.
- Documents the annotation and maintainer checklist in contributing docs.

Closes #1846.

## Test plan
- [x] `npm run check:exports` passes on commit.
- [ ] Confirm bundlers retain `@radui/ui/themes/default.css` imports when components are tree-shaken.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on side effects and tree-shaking, covering best practices for component imports, CSS management, avoiding unnecessary re-exports, and a maintainer checklist for handling side-effect modules.

* **Chores**
  * Added sideEffects configuration to mark CSS and SCSS files in package.json.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->