### PR TITLE
docs(contributing): document barrel export policy

### DIFF
--- a/docs/app/docs/contributing/barrel-export-policy/content.mdx
+++ b/docs/app/docs/contributing/barrel-export-policy/content.mdx
@@ -1,0 +1,44 @@
+# Barrel export policy
+
+Rad UI avoids a single mega-barrel that re-exports every component. Consumers should import the components they need from dedicated entrypoints.
+
+## Policy
+
+**Preferred**
+
+```tsx
+import Button from '@radui/ui/Button'
+import Dialog from '@radui/ui/Dialog'
+```
+
+**Avoid in application code**
+
+```tsx
+import { Button, Dialog, Select } from '@radui/ui'
+```
+
+The root `@radui/ui` entry exists for compatibility, but per-component paths are the supported default because they:
+
+- reduce accidental bundle bloat in apps that only use a few primitives
+- avoid import waterfalls in some bundlers and test runners
+- keep public API growth visible in dependency graphs
+
+## When a barrel is acceptable
+
+- short-lived prototypes where bundle size is not a concern
+- internal storybook or docs fixtures that intentionally exercise many components
+- codemods or migration scripts that rewrite imports in bulk
+
+Even in those cases, migrate to per-component imports before shipping production UI.
+
+## Maintainer guidance
+
+- Add new components to `scripts/RELEASED_COMPONENTS.cjs` and generated per-component exports.
+- Do not add new symbols to the root barrel unless they are core utilities with broad reuse.
+- Document new components on their own docs page with `@radui/ui/ComponentName` import examples.
+- Run `npm run check:exports` and `npm run check:api-surface` before merging export changes.
+
+## Related docs
+
+- [Contributor checklist](/docs/contributing/contributor-checklist) before opening export changes
+- [Usage](/docs/first-steps/usage) for recommended import patterns

--- a/docs/app/docs/contributing/barrel-export-policy/page.tsx
+++ b/docs/app/docs/contributing/barrel-export-policy/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/barrel-export-policy/seo.ts
+++ b/docs/app/docs/contributing/barrel-export-policy/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const barrelExportPolicyMetadata = generateSeoMetadata({
+  title: 'Barrel export policy | Rad UI',
+  description: 'When to use per-component imports instead of root barrel exports in Rad UI.'
+})
+
+export default barrelExportPolicyMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -140,6 +140,10 @@ export const docsNavigationSections = [
                 path:"/docs/contributing/naming-conventions"
             },
             {
+                title:"Barrel Export Policy",
+                path:"/docs/contributing/barrel-export-policy"
+            },
+            {
                 title:"Security & Dependency SLA",
                 path:"/docs/contributing/security-dependency-sla"
             },

--- a/docs/app/docs/first-steps/usage/content.mdx
+++ b/docs/app/docs/first-steps/usage/content.mdx
@@ -3,11 +3,13 @@
 ## Importing components
 Integrating Rad UI into your project is straightforward. Whether you're looking for a headless library with full flexibility or a quick way to prototype with a default theme, Rad UI has you covered. Here’s how you can get started.
 
-To use Rad UI components, you need to import them from the "@radui/ui" package.
+To use Rad UI components, import them from per-component entrypoints:
 
 ```tsx
 import Button from "@radui/ui/Button";
 ```
+
+See [Barrel export policy](/docs/contributing/barrel-export-policy) for why root barrel imports are discouraged in application code.
 
 ## Using components
 Once you've imported the components you need, you can start using them right away. Here's an example of how to integrate Rad UI’s Button component into your app:


### PR DESCRIPTION
## Summary
- Documents why Rad UI prefers per-component imports over root barrel usage.
- Links the policy from usage docs and contributing navigation.

Closes #1832.

## Test plan
- [ ] Verify `/docs/contributing/barrel-export-policy` renders in the docs app.


Made with [Cursor](https://cursor.com)