### PR TITLE
docs(guides): document styling and customization policy

### DIFF
--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -94,6 +94,10 @@ export const docsNavigationSections = [
                 path:"/docs/guides/accessibility"
             },
             {
+                title:"Styling & Customization",
+                path:"/docs/guides/styling-and-customization"
+            },
+            {
                 title:"Browser Support",
                 path:"/docs/guides/browser-support"
             },

--- a/docs/app/docs/first-steps/usage/content.mdx
+++ b/docs/app/docs/first-steps/usage/content.mdx
@@ -24,7 +24,7 @@ We recommend wrapping Rad UI components with your own abstractions to streamline
 
 
 ## Importing base styles
-Rad UI is headless by default. Components work without built-in visual styles, so you can bring your own design system, utility classes, CSS Modules, SCSS, or any other styling approach.
+Rad UI is headless by default. Components work without built-in visual styles, so you can bring your own design system, utility classes, CSS Modules, SCSS, or any other styling approach. Read [Styling and customization](/docs/guides/styling-and-customization) for supported hooks and what to avoid overriding.
 
 If you want Rad UI's default design system styles, import the default theme stylesheet explicitly:
 

--- a/docs/app/docs/guides/styling-and-customization/content.mdx
+++ b/docs/app/docs/guides/styling-and-customization/content.mdx
@@ -1,0 +1,76 @@
+# Styling and customization policy
+
+How Rad UI expects consumers to customize appearance without coupling to internal implementation details.
+
+## Headless by default
+
+Rad UI owns **behavior**, **accessibility**, and **composition**. Visual design is yours unless you opt into Rad UI's default theme CSS and `Theme classNamespace` classes.
+
+Without `classNamespace` and without importing theme CSS, components render **without library-owned styling classes**.
+
+## Supported customization surfaces
+
+Use these stable hooks when styling:
+
+| Surface | Example | Intended use |
+| --- | --- | --- |
+| `className` on parts | `<Button className="billing-cta" />` | local layout and app-specific styles |
+| `data-*` state attributes | `[data-state="open"]` | state-driven styling in your CSS |
+| `Theme` props | `appearance`, `accentColor`, `radius`, `scaling` | subtree-wide visual context |
+| `Theme classNamespace` | `classNamespace="rad-ui"` | generated part classes that match theme CSS |
+| `customRootClass` | per-component namespace override | incremental migrations |
+| documented CSS variables | `--rad-ui-radius-md` | tokenized styling when theme CSS is loaded |
+
+See [Usage](/docs/first-steps/usage) for `Theme` and `classNamespace` examples.
+
+## What not to rely on
+
+Avoid styling strategies that break when Rad UI refactors internals:
+
+- deep descendant selectors against undocumented DOM nesting
+- overriding private class names that are not part of your `classNamespace`
+- `!important` rules that fight component state styles
+- copying markup from Storybook and assuming incidental wrapper elements are stable
+
+If a style requirement needs a hook that does not exist, open an issue or PR to add a **documented** public attribute rather than targeting internals.
+
+## Default theme vs bring-your-own
+
+**Rad UI default theme**
+
+```tsx
+import '@radui/ui/themes/default.css'
+import Theme from '@radui/ui/Theme'
+
+<Theme classNamespace="rad-ui" appearance="dark">
+  <App />
+</Theme>
+```
+
+**Consumer design system**
+
+- import Rad UI primitives per component
+- map `data-*` attributes and slots to your tokens
+- wrap primitives in your design-system components
+
+Rad UI should not force a specific CSS framework. Tailwind, CSS Modules, SCSS, and CSS-in-JS are all valid as long as they target public hooks.
+
+## Customization decision tree
+
+1. Need one-off spacing or layout? → `className` on the relevant part.
+2. Need state styling (open, checked, disabled)? → documented `data-*` attributes.
+3. Need shared product theme? → `Theme` + optional theme CSS import.
+4. Need a different visual system entirely? → headless usage + your tokens; do not import Rad UI theme CSS.
+
+## Testing custom styles
+
+When you ship custom CSS:
+
+- verify focus rings remain visible
+- test keyboard paths documented on each component page
+- check contrast in both light and dark `Theme` appearances
+- run SSR/hydration smoke tests if styles depend on client-only measurements
+
+## Maintainer alignment
+
+Library changes should preserve documented `data-*` attributes and public anatomy. Undocumented selectors may change in patch releases if they were never part of the supported contract.

--- a/docs/app/docs/guides/styling-and-customization/page.tsx
+++ b/docs/app/docs/guides/styling-and-customization/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/styling-and-customization/seo.ts
+++ b/docs/app/docs/guides/styling-and-customization/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const stylingPolicyMetadata = generateSeoMetadata({
+  title: 'Styling and customization | Rad UI',
+  description: 'Rad UI styling boundaries, supported customization surfaces, and what consumers should not override.'
+})
+
+export default stylingPolicyMetadata


### PR DESCRIPTION
## Summary
- Documents supported styling surfaces (`className`, `data-*`, `Theme`, `classNamespace`, tokens) and anti-patterns consumers should avoid.
- Links the policy from usage docs and guides navigation.

Closes #1862.

## Test plan
- [ ] Verify `/docs/guides/styling-and-customization` renders in the docs app.


Made with [Cursor](https://cursor.com)