### PR TITLE
docs(contributing): add snapshot testing policy

### DIFF
--- a/docs/app/docs/contributing/contributor-checklist/content.mdx
+++ b/docs/app/docs/contributing/contributor-checklist/content.mdx
@@ -10,6 +10,7 @@ Use this checklist before opening a PR. Skip items that clearly do not apply (fo
 
 ## Tests
 
+- [ ] **Snapshots**: Followed the [snapshot testing policy](/docs/contributing/snapshot-testing-policy) — prefer semantic assertions over full-tree snapshots.
 - [ ] **Unit / component tests**: Added or updated tests for new behavior and regressions.
 - [ ] **Edge cases**: Covered empty states, controlled vs uncontrolled usage (if applicable), and keyboard interaction where relevant.
 - [ ] **Browser-sensitive changes**: Checked the [browser support matrix](/docs/guides/browser-support) and ran the relevant manual QA when behavior depends on layout, focus, portals, or scrolling.

--- a/docs/app/docs/contributing/snapshot-testing-policy/content.mdx
+++ b/docs/app/docs/contributing/snapshot-testing-policy/content.mdx
@@ -1,0 +1,53 @@
+# Snapshot testing policy
+
+Rad UI tests should prefer **semantic assertions** over large Jest snapshots. Snapshots are allowed only when they carry clear, stable signal.
+
+## Default preference
+
+**Prefer**
+
+```tsx
+expect(button).toHaveAttribute('data-state', 'open')
+expect(button).toHaveAccessibleName('Save')
+await user.keyboard('{ArrowDown}')
+expect(items[1]).toHaveFocus()
+```
+
+**Avoid**
+
+```tsx
+expect(container).toMatchSnapshot()
+```
+
+Full-tree snapshots hide regressions behind noisy diffs and break when unrelated markup changes.
+
+## When snapshots are acceptable
+
+- small, stable strings (serialized server HTML helpers, token maps) with an explicit comment explaining why
+- Storybook or visual regression tooling outside Jest (Chromatic) for intentional visual coverage
+- temporary snapshots during a refactor, deleted before merge unless promoted to a visual test
+
+## Required practices
+
+- Assert **roles**, **labels**, **focus**, and documented **`data-*`** attributes for behavior tests.
+- Use `@testing-library/react` queries oriented on user-visible output.
+- Keep interaction tests (`userEvent`) for keyboard paths documented on component pages.
+- If a snapshot is unavoidable, limit scope to a single element and name the file descriptively.
+
+## Reviewer checklist
+
+- [ ] Does the test fail for the right reason when behavior breaks?
+- [ ] Would a harmless className change cause a false failure?
+- [ ] Are accessibility expectations covered without snapshot-only coverage?
+- [ ] If updating a snapshot, does the PR explain the intentional behavior change?
+
+## Migrating away from snapshots
+
+1. Replace `toMatchSnapshot()` with targeted assertions on public hooks.
+2. Delete obsolete `__snapshots__` files in the same PR.
+3. Add a regression test for the behavior the snapshot was meant to guard.
+
+## Related docs
+
+- [Contributor checklist](/docs/contributing/contributor-checklist)
+- [Flaky test quarantine](/docs/contributing/flaky-test-quarantine)

--- a/docs/app/docs/contributing/snapshot-testing-policy/page.tsx
+++ b/docs/app/docs/contributing/snapshot-testing-policy/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/contributing/snapshot-testing-policy/seo.ts
+++ b/docs/app/docs/contributing/snapshot-testing-policy/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const snapshotPolicyMetadata = generateSeoMetadata({
+  title: 'Snapshot testing policy | Rad UI',
+  description: 'Prefer semantic test assertions over Jest snapshots in Rad UI component tests.'
+})
+
+export default snapshotPolicyMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -152,6 +152,10 @@ export const docsNavigationSections = [
                 path:"/docs/contributing/flaky-test-quarantine"
             },
             {
+                title:"Snapshot Testing Policy",
+                path:"/docs/contributing/snapshot-testing-policy"
+            },
+            {
                 title:"Release Candidate Checklist",
                 path:"/docs/contributing/release-candidate-checklist"
             },


### PR DESCRIPTION
## Summary
- Documents preference for semantic assertions over Jest snapshots, with reviewer checklist and migration notes.
- Links the policy from the contributor checklist.

Closes #1819.

## Test plan
- [ ] Verify `/docs/contributing/snapshot-testing-policy` renders in the docs app.


Made with [Cursor](https://cursor.com)