### PR TITLE
docs(a11y): add focus-visible and non-color affordance guidance

### DIFF
--- a/docs/app/docs/guides/accessibility/content.mdx
+++ b/docs/app/docs/guides/accessibility/content.mdx
@@ -57,6 +57,38 @@ Accessibility is a shared responsibility between the component library and the d
 
 ---
 
+## Focus visible and non-color affordances
+
+Keyboard users must be able to see **which element is focused**. Color alone must never be the only indicator of state, selection, or errors.
+
+### `:focus-visible` guidance
+
+- Style **keyboard focus** with `:focus-visible`, not bare `:focus`, so pointer clicks do not leave a persistent ring on mouse users.
+- Ensure the focus indicator has **sufficient contrast** against adjacent backgrounds (WCAG 2.2 focus appearance guidance).
+- Preserve Rad UI's default focus behavior when wrapping components; do not remove outlines without providing an equivalent visible indicator.
+
+```css
+/* Example app-level focus ring */
+:where(button, [role='menuitem'], [role='tab']):focus-visible {
+  outline: 2px solid var(--focus-ring, #005fcc);
+  outline-offset: 2px;
+}
+```
+
+### Non-color requirements
+
+Pair color with at least one additional cue:
+
+| State | Avoid | Prefer |
+| --- | --- | --- |
+| Error | red border only | red border + `aria-invalid` + text message |
+| Selected | hue change only | selected icon, weight, or `data-state="on"` styling |
+| Disabled | faded color only | `data-disabled` + `aria-disabled` + non-interactive cursor |
+
+When customizing Rad UI themes, test with Windows **High Contrast** mode and forced-colors media queries where possible.
+
+---
+
 ## Focus Management
 
 Correct focus behavior is essential for accessible interfaces.


### PR DESCRIPTION
## Summary
- Extends the accessibility guide with `:focus-visible` styling guidance and non-color affordance requirements for errors, selection, and disabled states.

Closes #1809.

## Test plan
- [ ] Verify updated `/docs/guides/accessibility` content renders.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive accessibility guidance on focus visibility and non-color affordances for keyboard navigation
  * Includes best practices for :focus-visible styling, ARIA attributes for error/selected/disabled states, and contrast requirements
  * Added guidance for testing with Windows High Contrast mode and forced-colors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->