### PR TITLE
docs(guides): define canonical design token contract

### DIFF
--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -98,6 +98,10 @@ export const docsNavigationSections = [
                 path:"/docs/guides/browser-support"
             },
             {
+                title:"Design Token Contract",
+                path:"/docs/guides/design-token-contract"
+            },
+            {
                 title:"Date, Time & Timezones",
                 path:"/docs/guides/date-time-and-timezones"
             },

--- a/docs/app/docs/guides/design-token-contract/content.mdx
+++ b/docs/app/docs/guides/design-token-contract/content.mdx
@@ -1,0 +1,67 @@
+# Design token contract
+
+Canonical `--rad-ui-*` tokens for Rad UI's styled layers. The headless component core does **not** require these variables; they apply when you import theme CSS or use Clarity/baremetal styles.
+
+Source of truth in the repository:
+
+- `styles/cssTokens/` — CSS custom property definitions
+- `styles/jsTokens/` — JS token maps referencing CSS variables
+- `src/tokenGen/` — generation pipeline
+
+## Naming convention
+
+All public theme variables use the prefix `--rad-ui-` with kebab-case segments:
+
+```txt
+--rad-ui-<category>-<name>
+--rad-ui-color-gray-100
+--rad-ui-radius-md
+--rad-ui-spacing-4
+```
+
+Semantic accent tokens are scoped by `Theme` attributes such as `data-rad-ui-accent-color`.
+
+## Token families
+
+| Family | Examples | Used for |
+| --- | --- | --- |
+| Color scales | `--rad-ui-color-gray-100`, `--rad-ui-color-indigo-9` | surfaces, borders, text |
+| Radius | `--rad-ui-radius-sm` … `--rad-ui-radius-full` | corners |
+| Spacing | `--rad-ui-spacing-1` … `--rad-ui-spacing-12` | padding, gaps |
+| Typography | `--rad-ui-font-sans`, `--rad-ui-font-size-3` | text styles |
+| Shadows | `--rad-ui-shadow-sm`, `--rad-ui-shadow-md` | elevation |
+| Motion | `--rad-ui-motion-duration-fast`, `--rad-ui-motion-easing-standard` | transitions |
+| Z-index | `--rad-ui-z-index-overlay`, `--rad-ui-z-index-portal` | stacking |
+
+## Component expectations
+
+Styled Rad UI layers should:
+
+1. Read layout and color from token variables, not hard-coded hex in component SCSS.
+2. Use semantic `data-*` attributes for state; tokens supply the values in CSS.
+3. Respect `Theme` appearance (`data-rad-ui-theme`) for light/dark palettes.
+4. Keep motion on tokenized durations/easings so `prefers-reduced-motion` can be applied consistently.
+
+## Consumer contract
+
+When importing `@radui/ui/themes/default.css`:
+
+- You may rely on documented `--rad-ui-*` names in your own CSS.
+- Override tokens on `Theme` containers or `:root` for product branding.
+- Do not depend on undocumented internal class selectors.
+
+When using Rad UI headlessly:
+
+- Tokens are optional; bring your own design tokens and map them in wrappers.
+
+## Adding or changing tokens
+
+1. Update `styles/cssTokens/` and regenerate via `npm run generate-tokens`.
+2. Mirror changes in `styles/jsTokens/` when Tailwind/JS consumers need the name.
+3. Document new public variables if components expose them as styling hooks.
+4. Run visual review on Clarity components affected by the token change.
+
+## Related docs
+
+- [Usage](/docs/first-steps/usage) for `Theme` and optional theme CSS import
+- [Clarity design system](https://github.com/rad-ui/ui/blob/main/knowledge/design_system/clarity_design_system.md) in the repository knowledge docs

--- a/docs/app/docs/guides/design-token-contract/page.tsx
+++ b/docs/app/docs/guides/design-token-contract/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/guides/design-token-contract/seo.ts
+++ b/docs/app/docs/guides/design-token-contract/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const designTokenContractMetadata = generateSeoMetadata({
+  title: 'Design token contract | Rad UI',
+  description: 'Canonical --rad-ui-* token families and expectations for styled Rad UI layers.'
+})
+
+export default designTokenContractMetadata


### PR DESCRIPTION
## Summary
- Documents the `--rad-ui-*` token naming convention, families, and component/consumer expectations.
- Points to cssTokens/jsTokens sources in the repository.

Closes #1855.

## Test plan
- [ ] Verify `/docs/guides/design-token-contract` renders in the docs app.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Design Token Contract" guide documenting CSS custom properties, including naming conventions, token families (color, radius, spacing, typography, shadows, motion, z-index), component integration expectations, and consumer contracts for theme implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->