### PR TITLE
test: add StrictMode resilience coverage for Theme, Dialog, and Switch

### DIFF
--- a/src/components/ui/Dialog/tests/Dialog.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.test.tsx
@@ -110,4 +110,24 @@ describe('Dialog', () => {
         await waitFor(() => assertScrollUnlock());
         cleanup();
     });
+
+    test('renders under StrictMode without console errors', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const { getByText, unmount } = render(
+            <React.StrictMode>
+                <Dialog.Root open>
+                    <Dialog.Trigger>Open</Dialog.Trigger>
+                    <Dialog.Content>
+                        <Dialog.Title>Title</Dialog.Title>
+                        <Dialog.Close>Close</Dialog.Close>
+                    </Dialog.Content>
+                </Dialog.Root>
+            </React.StrictMode>
+        );
+
+        expect(getByText('Title')).toBeInTheDocument();
+        unmount();
+        expect(errorSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/components/ui/Switch/tests/Switch.test.tsx
+++ b/src/components/ui/Switch/tests/Switch.test.tsx
@@ -250,4 +250,22 @@ describe('Switch Component', () => {
         expect(checkbox).not.toBeChecked();
     });
     */
+
+    test('renders under StrictMode without console errors', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const { unmount } = render(
+            <React.StrictMode>
+                <Switch.Root>
+                    <Switch.Thumb />
+                </Switch.Root>
+            </React.StrictMode>
+        );
+
+        expect(screen.getAllByRole('switch').length).toBeGreaterThan(0);
+        unmount();
+        expect(errorSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
 });

--- a/src/components/ui/Theme/tests/Theme.test.tsx
+++ b/src/components/ui/Theme/tests/Theme.test.tsx
@@ -148,4 +148,19 @@ describe('Theme', () => {
 
         expect(themeDiv).not.toHaveClass('rad-ui-theme');
     });
+
+    test('renders under StrictMode without console errors', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn(), removeEventListener: jest.fn() } as unknown as MediaQueryList);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const { unmount } = render(
+            <React.StrictMode>
+                <Theme appearance="light">content</Theme>
+            </React.StrictMode>
+        );
+
+        expect(screen.getByText('content')).toBeVisible();
+        unmount();
+        expect(errorSpy).not.toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- Adds StrictMode render tests to catch duplicate effect/listener issues during development.

Closes #1824.

## Test plan
- [x] Theme, Dialog, and Switch test suites pass locally.


Made with [Cursor](https://cursor.com)