### PR TITLE
fix(menu): enable vertical scroll when menu exceeds viewport

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -22,8 +22,17 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
             elementsRef,
             labelsRef,
             isNested,
-            floatingContext
+            floatingContext,
+            maxHeight
         } = context;
+
+        const scrollContainerStyle: React.CSSProperties = {
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            maxHeight: maxHeight !== undefined ? `${maxHeight}px` : undefined,
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain'
+        };
 
         return (
             <>
@@ -41,7 +50,7 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
                         className={className}
                         {...props}
                     >
-                        <div style={{overflowY:"auto", overflowX:"hidden"}}>
+                        <div style={scrollContainerStyle}>
                         {children}
                         </div>
                     </div>

--- a/src/core/primitives/Menu/tests/MenuPrimitive.test.tsx
+++ b/src/core/primitives/Menu/tests/MenuPrimitive.test.tsx
@@ -391,6 +391,25 @@ describe('MenuPrimitive', () => {
             expect(contentElement).toHaveClass('flex', 'flex-col', 'mt-2', 'bg-gray-1000', 'border', 'border-gray-200', 'rounded', 'shadow-lg', 'min-w-[180px]');
         });
 
+        it('should apply scroll styles to the inner content container for overflow menus', () => {
+            act(() => {
+                render(
+                    <MenuPrimitive.Root defaultOpen={true}>
+                        <MenuPrimitive.Content>
+                            <div>Menu Content</div>
+                        </MenuPrimitive.Content>
+                    </MenuPrimitive.Root>
+                );
+            });
+
+            const scrollContainer = screen.getByText('Menu Content').parentElement;
+            expect(scrollContainer).toHaveStyle({
+                overflowY: 'auto',
+                overflowX: 'hidden',
+                overscrollBehavior: 'contain'
+            });
+        });
+
         it('should return null when used outside MenuPrimitive.Root context', () => {
             const { container } = render(
                 <MenuPrimitive.Content>


### PR DESCRIPTION
## Summary
- Applies floating-ui `availableHeight` to the menu content scroll container so long menus scroll vertically on small screens
- Adds regression test for scroll container overflow styles

Fixes #1752

## Test plan
- [x] `npm test -- --testPathPatterns=MenuPrimitive.test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Menu components now support optional height limiting with enhanced overflow and overscroll behavior handling.

* **Tests**
  * Added test coverage verifying scroll-related styling is correctly applied to menu content containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->