### PR TITLE
fix(RovingFocusGroup): recompute focus items on add/remove (#981)

### DIFF
--- a/src/core/utils/RovingFocusGroup/fragments/RovingFocusGroup.tsx
+++ b/src/core/utils/RovingFocusGroup/fragments/RovingFocusGroup.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState, useId, useRef, useContext } from 'react';
+import React, { useEffect, useState, useId, useRef } from 'react';
 import Primitive from '~/core/primitives/Primitive';
 
 import { RovingFocusGroupContext } from '../context/RovingFocusGroupContext';
-import { RovingFocusRootContext } from '../context/RovingFocusRootContext';
 
 /**
  * Props for the RovingFocusGroup component
@@ -35,7 +34,6 @@ const RovingFocusGroup = ({
     'aria-labelledby': ariaLabelledBy,
     ...props
 }: RovingFocusGroupProps) => {
-    const { mode } = useContext(RovingFocusRootContext);
     const groupRef = useRef<HTMLDivElement>(null);
     const [focusItems, setFocusItems] = useState<string[]>([]);
     const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
@@ -50,8 +48,6 @@ const RovingFocusGroup = ({
             return itemRef?.current?.getAttribute('data-child-disabled') !== 'true';
         }) ?? null;
     }, []);
-
-    const SHOULD_RECOMPUTE_FOCUS_ITEMS = mode === 'tree';
     
     /**
      * Registers an item's ref in the registry
@@ -70,18 +66,16 @@ const RovingFocusGroup = ({
         itemRefsMap.current.delete(id);
         
         // Remove from focusItems to avoid stale IDs
-        if (SHOULD_RECOMPUTE_FOCUS_ITEMS) {
-            setFocusItems((prev) => prev.filter((itemId) => itemId !== id));
-        }
-    }, [SHOULD_RECOMPUTE_FOCUS_ITEMS]);
+        setFocusItems((prev) => prev.filter((itemId) => itemId !== id));
+    }, []);
 
     /**
      * Adds a new focusable item to the group
      * @param id - Unique identifier for the item
      */
     const addFocusItem = React.useCallback((id: string) => {
-        // For tree mode, recompute items from registered refs in DOM order
-        if (SHOULD_RECOMPUTE_FOCUS_ITEMS && typeof window !== 'undefined') {
+        // Recompute items from registered refs in DOM order
+        if (typeof window !== 'undefined') {
             setFocusItems((prevItems) => {
                 // Only recompute if the item isn't already in the list
                 if (prevItems.includes(id)) {
@@ -132,7 +126,7 @@ const RovingFocusGroup = ({
             if (prev.includes(id)) return prev;
             return [...prev, id];
         });
-    }, [SHOULD_RECOMPUTE_FOCUS_ITEMS]);
+    }, []);
 
     // Keep the roving entry point on an enabled item so the group remains tabbable.
     useEffect(() => {

--- a/src/core/utils/RovingFocusGroup/tests/RovingFocusGroup.behavior.test.tsx
+++ b/src/core/utils/RovingFocusGroup/tests/RovingFocusGroup.behavior.test.tsx
@@ -152,6 +152,51 @@ describe('RovingFocusGroup behavior', () => {
         expect(itemA).toHaveFocus();
     });
 
+    test('supports dynamic item add and remove in default mode', async() => {
+        const user = userEvent.setup();
+        const DynamicGroup = () => {
+            const [items, setItems] = React.useState(['A', 'B']);
+            return (
+                <>
+                    <button onClick={() => setItems([...items, `Item${items.length + 1}`])} data-testid="add">Add</button>
+                    <button onClick={() => setItems(items.slice(0, -1))} data-testid="remove">Remove</button>
+                    <RovingFocusGroup.Root orientation="horizontal" loop>
+                        <RovingFocusGroup.Group>
+                            {items.map((label) => (
+                                <RovingFocusGroup.Item key={label}>
+                                    <button>{label}</button>
+                                </RovingFocusGroup.Item>
+                            ))}
+                        </RovingFocusGroup.Group>
+                    </RovingFocusGroup.Root>
+                </>
+            );
+        };
+        render(<DynamicGroup />);
+
+        const itemA = screen.getByText('A');
+        const addBtn = screen.getByTestId('add');
+        const removeBtn = screen.getByTestId('remove');
+
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        expect(itemA).toHaveFocus();
+
+        await user.click(addBtn);
+        const item3 = screen.getByText('Item3');
+        itemA.focus();
+        await user.keyboard('{ArrowRight}');
+        await user.keyboard('{ArrowRight}');
+        expect(item3).toHaveFocus();
+
+        await user.click(removeBtn);
+        const itemB = screen.getByText('B');
+        itemB.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(itemA).toHaveFocus();
+    });
+
     test('handles multiple groups independently', async() => {
         const user = userEvent.setup();
         render(


### PR DESCRIPTION
## Summary
- Recompute `focusItems` from registered refs in DOM order whenever items are added, in all modes (not only `tree`).
- Always remove unregistered item IDs from `focusItems` to avoid stale entries.
- Add behavior test for dynamic add/remove in default (non-tree) mode.

Fixes #981

## Test plan
- [x] `npm test -- --testPathPatterns=RovingFocusGroup.behavior` (8 tests pass)
- [ ] Manual: dynamic menu/list with default roving focus — arrow keys reach newly added items and skip removed ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and optimized focus management logic in core roving focus components for improved efficiency and more reliable handling of dynamic content changes

* **Tests**
  * Added comprehensive test coverage for dynamic item addition and removal in focus group navigation scenarios to ensure robust behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->