### PR TITLE
fix(Tooltip): portal inside Theme for themed styles

### DIFF
--- a/src/components/ui/Tooltip/fragments/TooltipContent.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipContent.tsx
@@ -33,11 +33,9 @@ const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentPro
         const { getFloatingProps } = interactions;
 
         const portalRoot = container
-            || themeContext?.portalRootRef.current
-            || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-            || themeContext?.containerRef.current
-            || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
-            || undefined;
+            ?? themeContext?.portalRootRef.current
+            ?? themeContext?.containerRef.current
+            ?? undefined;
 
         return (
             <FloatingPortal root={portalRoot}>

--- a/src/components/ui/Tooltip/tests/Tooltip.portal.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.portal.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Tooltip from '../Tooltip';
+import ThemeContext from '../../Theme/ThemeContext';
+
+describe('Tooltip portal', () => {
+    test('portals content into Theme portalRootRef when provided', async() => {
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content>Tooltip label</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+        expect(portalRoot).toContainElement(screen.getByText('Tooltip label'));
+
+        portalRoot.remove();
+    });
+
+    test('falls back to Theme containerRef when portalRootRef is unset', async() => {
+        const themeContainer = document.createElement('div');
+        document.body.appendChild(themeContainer);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: themeContainer },
+                    portalRootRef: { current: null }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content>Theme container tooltip</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(themeContainer).toContainElement(screen.getByText('Theme container tooltip'));
+
+        themeContainer.remove();
+    });
+
+    test('uses explicit container prop over Theme context', async() => {
+        const explicitContainer = document.createElement('div');
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(explicitContainer);
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content container={explicitContainer}>Custom container</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(explicitContainer).toContainElement(screen.getByText('Custom container'));
+        expect(portalRoot).not.toContainElement(screen.getByText('Custom container'));
+
+        explicitContainer.remove();
+        portalRoot.remove();
+    });
+});


### PR DESCRIPTION
## Summary
- Resolve tooltip portal targets from `ThemeContext` `portalRootRef` and `containerRef` (plus optional `container` prop) so tooltip content stays inside Theme and inherits CSS variables.
- Remove `document.querySelector` fallbacks for portal roots.
- Add portal tests covering Theme context and explicit container override.

Fixes #1657
Fixes #1116

## Test plan
- [x] `npm test -- --testPathPatterns=Tooltip`
- [ ] Verify tooltip appearance inside `Theme` in docs (dark mode / z-index)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tooltip rendering reliability within themed containers.

* **Tests**
  * Added comprehensive test coverage for tooltip portal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->