### PR TITLE
fix(Collapsible): CSS-driven accordion height animation (#1917)

### DIFF
--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -31,6 +31,10 @@ const AccordionContent = React.forwardRef<React.ElementRef<'div'>, AccordionCont
                         'var(--radix-collapsible-content-height)',
                     ['--radix-accordion-content-width' as string]:
                         'var(--radix-collapsible-content-width)',
+                    ['--rad-accordion-content-height' as string]:
+                        'var(--radix-collapsible-content-height)',
+                    ['--rad-accordion-content-width' as string]:
+                        'var(--radix-collapsible-content-width)',
                     ...style
                 }}
                 {...props}

--- a/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
+++ b/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
@@ -23,6 +23,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
 
     const [height, setHeight] = useState<number | undefined>(open ? undefined : 0);
     const [isPresent, setIsPresent] = useState(open || forceMount);
+    const [, setCssVarRevision] = useState(0);
     const animationTimeoutRef = useRef<NodeJS.Timeout>();
     const rafRef = useRef<number>();
     const ref = useRef<HTMLDivElement | null>(null);
@@ -87,6 +88,11 @@ const CollapsiblePrimitiveContent = React.forwardRef<
             } else {
                 setIsPresent(true);
             }
+
+            if (open) {
+                setCssVarRevision((revision) => revision + 1);
+            }
+
             return;
         }
 
@@ -147,10 +153,14 @@ const CollapsiblePrimitiveContent = React.forwardRef<
         return null;
     }
 
+    const omitInlineHeightForCssAnimation = transitionDuration === 0 && open;
+
     const dynamicStyle: React.CSSProperties = {
         ...style,
         overflow: 'hidden',
-        height: height !== undefined ? `${height}px` : undefined,
+        ...(!omitInlineHeightForCssAnimation && height !== undefined
+            ? { height: `${height}px` }
+            : {}),
         ['--radix-collapsible-content-height' as string]:
             heightRef.current !== undefined ? `${heightRef.current}px` : undefined,
         ['--radix-collapsible-content-width' as string]:

--- a/src/core/primitives/Collapsible/tests/Collapsible.test.tsx
+++ b/src/core/primitives/Collapsible/tests/Collapsible.test.tsx
@@ -141,4 +141,94 @@ describe('CollapsiblePrimitive', () => {
         expect(content.style.getPropertyValue('--radix-collapsible-content-height')).toBe('120px');
         expect(content.style.getPropertyValue('--radix-collapsible-content-width')).toBe('320px');
     });
+    test('does not set inline height in steady open state when transitionDuration is 0', () => {
+        HTMLElement.prototype.getBoundingClientRect = jest.fn(function(this: HTMLElement) {
+            if (this.dataset.testid === 'content') {
+                return {
+                    width: 320,
+                    height: 120,
+                    top: 0,
+                    left: 0,
+                    right: 320,
+                    bottom: 120,
+                    x: 0,
+                    y: 0,
+                    toJSON: () => ({})
+                } as DOMRect;
+            }
+
+            return {
+                width: 0,
+                height: 0,
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                x: 0,
+                y: 0,
+                toJSON: () => ({})
+            } as DOMRect;
+        });
+
+        render(
+            <CollapsiblePrimitive.Root transitionDuration={0} defaultOpen>
+                <CollapsiblePrimitive.Content data-testid="content">
+                    <div>Measured Content</div>
+                </CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        const content = screen.getByTestId('content');
+
+        expect(content.style.height).toBe('');
+        expect(content.style.getPropertyValue('--radix-collapsible-content-height')).toBe('120px');
+        expect(content.style.getPropertyValue('--radix-collapsible-content-width')).toBe('320px');
+    });
+
+    test('clears inline height after opening with transitionDuration 0', () => {
+        HTMLElement.prototype.getBoundingClientRect = jest.fn(function(this: HTMLElement) {
+            if (this.dataset.testid === 'content') {
+                return {
+                    width: 200,
+                    height: 80,
+                    top: 0,
+                    left: 0,
+                    right: 200,
+                    bottom: 80,
+                    x: 0,
+                    y: 0,
+                    toJSON: () => ({})
+                } as DOMRect;
+            }
+
+            return {
+                width: 0,
+                height: 0,
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                x: 0,
+                y: 0,
+                toJSON: () => ({})
+            } as DOMRect;
+        });
+
+        render(
+            <CollapsiblePrimitive.Root transitionDuration={0}>
+                <CollapsiblePrimitive.Trigger data-testid="trigger">Toggle</CollapsiblePrimitive.Trigger>
+                <CollapsiblePrimitive.Content data-testid="content">
+                    <div>Measured Content</div>
+                </CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        fireEvent.click(screen.getByTestId('trigger'));
+
+        const content = screen.getByTestId('content');
+
+        expect(content).toHaveAttribute('data-state', 'open');
+        expect(content.style.height).toBe('');
+        expect(content.style.getPropertyValue('--radix-collapsible-content-height')).toBe('80px');
+    });
 });


### PR DESCRIPTION
## Summary
- When `transitionDuration={0}`, Collapsible content no longer sets inline `height` in the steady open state so consumers can animate expand/collapse via CSS keyframes on `data-state`.
- Measured dimensions remain available on `--radix-collapsible-content-height` / `--radix-collapsible-content-width`, with a re-render bump so `defaultOpen` exposes correct values.
- `Accordion.Content` forwards `--rad-accordion-content-height` and `--rad-accordion-content-width` aliases for Radix-style migration.

Related to #1917 (CSS animation parity); does not address the `type="single"` value shape gap.

## Test plan
- [x] `npm test -- src/core/primitives/Collapsible/tests/Collapsible.test.tsx`
- [ ] Verify Accordion with `transitionDuration={0}` and CSS keyframes using `var(--rad-accordion-content-height)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsible component behavior when using instant (zero-duration) transitions to properly handle content measurements and display updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->