### PR TITLE
fix(ScrollArea): reset scroll when viewport content changes (#1349)

### DIFF
--- a/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
@@ -56,8 +56,23 @@ const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({
         resizeObserver.observe(viewport);
         Array.from(viewport.children).forEach(child => resizeObserver.observe(child));
 
-        const mutationObserver = new MutationObserver(() => {
+        const mutationObserver = new MutationObserver((mutations) => {
+            const contentSwapped = mutations.some(
+                (mutation) =>
+                    mutation.type === "childList" &&
+                    (mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0)
+            );
+
+            if (contentSwapped) {
+                viewport.scrollTop = 0;
+                viewport.scrollLeft = 0;
+            }
+
             handleResize();
+
+            if (contentSwapped) {
+                handleScroll();
+            }
         });
 
         mutationObserver.observe(viewport, {

--- a/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
+++ b/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import ScrollArea from '../ScrollArea';
 
@@ -175,5 +175,38 @@ describe('ScrollArea', () => {
         fireEvent.mouseEnter(screen.getByTestId('root'));
 
         expect(screen.getByTestId('scrollbar')).toHaveAttribute('data-state', 'visible');
+    });
+
+    test('resets scroll position when viewport children change', async() => {
+        const scrollArea = (content: React.ReactNode) => (
+            <ScrollArea.Root style={{ height: 100 }}>
+                <ScrollArea.Viewport data-testid="viewport" style={{ height: 100, overflow: 'auto' }}>
+                    {content}
+                </ScrollArea.Viewport>
+                <ScrollArea.Scrollbar data-testid="scrollbar" orientation="vertical">
+                    <ScrollArea.Thumb data-testid="thumb" />
+                </ScrollArea.Scrollbar>
+            </ScrollArea.Root>
+        );
+
+        const { rerender } = render(scrollArea(<div key="tab-a" style={{ height: 400 }}>tab a</div>));
+
+        const viewport = screen.getByTestId('viewport');
+        Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 400 });
+        Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 100 });
+
+        act(() => {
+            viewport.scrollTop = 300;
+            fireEvent.scroll(viewport);
+        });
+
+        expect(viewport.scrollTop).toBe(300);
+
+        rerender(scrollArea(<div key="tab-b">tab b</div>));
+
+        await waitFor(() => {
+            expect(viewport.scrollTop).toBe(0);
+            expect(viewport.scrollLeft).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Reset `scrollTop` / `scrollLeft` to 0 when the viewport receives `childList` mutations (e.g. tab content swap) and recalculate thumb sizes/position.
- Adds a regression test that scrolls to the bottom, swaps viewport children, and asserts scroll resets.

Fixes #1349

## Test plan
- [x] `npm test -- src/components/ui/ScrollArea/tests/ScrollArea.test.tsx`
- [ ] Manually: docs site — scroll a long tab to the bottom, switch tabs, confirm scrollbar returns to top