### PR TITLE
feat(a11y): add LiveRegion utility for announcements (#1810)

### DIFF
--- a/.changeset/live-region-utility.md
+++ b/.changeset/live-region-utility.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": minor
+---
+
+Add LiveRegion utility and useAnnounce hook for accessible screen reader announcements

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,12 @@
 import { customClassSwitcher } from './customClassSwitcher';
 import { composeRefs, mergeProps } from './utils/mergeProps';
+import LiveRegion, { useAnnounce } from './utils/LiveRegion';
 
-export { customClassSwitcher, composeRefs, mergeProps };
+export { customClassSwitcher, composeRefs, mergeProps, LiveRegion, useAnnounce };
+export type {
+    LiveRegionElement,
+    LiveRegionPoliteness,
+    LiveRegionProps,
+    UseAnnounceOptions,
+    UseAnnounceReturn
+} from './utils/LiveRegion';

--- a/src/core/utils/LiveRegion/LiveRegion.tsx
+++ b/src/core/utils/LiveRegion/LiveRegion.tsx
@@ -1,0 +1,34 @@
+'use client';
+import React, { forwardRef, ComponentPropsWithoutRef, ElementRef } from 'react';
+import Primitive from '~/core/primitives/Primitive';
+import { VISUALLY_HIDDEN_STYLES } from './visuallyHiddenStyles';
+
+const COMPONENT_NAME = 'LiveRegion';
+
+export type LiveRegionElement = ElementRef<typeof Primitive.div>;
+export type LiveRegionPoliteness = 'polite' | 'assertive';
+
+export type LiveRegionProps = {
+    politeness?: LiveRegionPoliteness;
+    atomic?: boolean;
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
+
+const LiveRegion = forwardRef<LiveRegionElement, LiveRegionProps>(
+    ({ children, politeness = 'polite', atomic = true, style, ...props }, ref) => {
+        return (
+            <Primitive.div
+                ref={ref}
+                aria-live={politeness}
+                aria-atomic={atomic}
+                style={{ ...VISUALLY_HIDDEN_STYLES, ...style }}
+                {...props}
+            >
+                {children}
+            </Primitive.div>
+        );
+    }
+);
+
+LiveRegion.displayName = COMPONENT_NAME;
+
+export default LiveRegion;

--- a/src/core/utils/LiveRegion/index.tsx
+++ b/src/core/utils/LiveRegion/index.tsx
@@ -1,0 +1,12 @@
+import LiveRegion from './LiveRegion';
+import { useAnnounce } from './useAnnounce';
+
+export type {
+    LiveRegionElement,
+    LiveRegionPoliteness,
+    LiveRegionProps
+} from './LiveRegion';
+export type { UseAnnounceOptions, UseAnnounceReturn } from './useAnnounce';
+
+export { useAnnounce };
+export default LiveRegion;

--- a/src/core/utils/LiveRegion/stories/LiveRegion.stories.tsx
+++ b/src/core/utils/LiveRegion/stories/LiveRegion.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
+import Button from '~/components/ui/Button/Button';
+import LiveRegion from '../LiveRegion';
+import { useAnnounce } from '../useAnnounce';
+
+export default {
+    title: 'Utilities/LiveRegion',
+    component: LiveRegion,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Live regions expose dynamic status to screen readers. Use the declarative LiveRegion component or the useAnnounce hook for programmatic updates.'
+            }
+        }
+    }
+};
+
+export const Declarative = {
+    render: () => (
+        <SandboxEditor>
+            <LiveRegion politeness="polite" atomic>
+                Three items selected
+            </LiveRegion>
+            <p className="text-sm text-gray-600">
+                The selection count above is announced when this story mounts (content is visually hidden).
+            </p>
+        </SandboxEditor>
+    )
+};
+
+function AnnounceDemo() {
+    const { announce, Announcer } = useAnnounce({ politeness: 'polite' });
+
+    return (
+        <SandboxEditor>
+            <div className="flex gap-2">
+                <Button onClick={() => announce('Draft saved')}>Save draft</Button>
+                <Button onClick={() => announce('Item removed from list')}>Remove item</Button>
+            </div>
+            <Announcer />
+            <p className="text-sm text-gray-600 mt-4">
+                Activate a button to hear a polite announcement in supporting assistive technology.
+            </p>
+        </SandboxEditor>
+    );
+}
+
+export const Programmatic = {
+    render: () => <AnnounceDemo />
+};

--- a/src/core/utils/LiveRegion/tests/LiveRegion.test.tsx
+++ b/src/core/utils/LiveRegion/tests/LiveRegion.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import LiveRegion from '../LiveRegion';
+import { useAnnounce } from '../useAnnounce';
+
+describe('LiveRegion', () => {
+    test('defaults to polite, atomic live region with visually hidden styles', () => {
+        render(<LiveRegion>Status updated</LiveRegion>);
+        const region = screen.getByText('Status updated');
+
+        expect(region).toHaveAttribute('aria-live', 'polite');
+        expect(region).toHaveAttribute('aria-atomic', 'true');
+        expect(region).toHaveStyle({
+            position: 'absolute',
+            width: '1px',
+            height: '1px',
+            overflow: 'hidden'
+        });
+    });
+
+    test('supports assertive politeness and aria-atomic=false', () => {
+        render(
+            <LiveRegion politeness="assertive" atomic={false}>
+                Alert
+            </LiveRegion>
+        );
+        const region = screen.getByText('Alert');
+
+        expect(region).toHaveAttribute('aria-live', 'assertive');
+        expect(region).toHaveAttribute('aria-atomic', 'false');
+    });
+
+    test('forwards additional props and ref', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <LiveRegion ref={ref} data-testid="live-region">
+                Message
+            </LiveRegion>
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLElement);
+        expect(screen.getByTestId('live-region')).toBeInTheDocument();
+    });
+});
+
+function AnnounceHarness({ politeness }: { politeness?: 'polite' | 'assertive' }) {
+    const { announce, Announcer } = useAnnounce({ politeness });
+
+    return (
+        <>
+            <button type="button" onClick={() => announce('Saved changes')}>
+                Save
+            </button>
+            <Announcer />
+        </>
+    );
+}
+
+describe('useAnnounce', () => {
+    test('announces messages through the companion live region', async() => {
+        const user = userEvent.setup();
+        render(<AnnounceHarness />);
+
+        await user.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Saved changes')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Saved changes')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    test('re-announces the same message', async() => {
+        const user = userEvent.setup();
+        render(<AnnounceHarness />);
+        const button = screen.getByRole('button', { name: /save/i });
+
+        await user.click(button);
+        await waitFor(() => {
+            expect(screen.getByText('Saved changes')).toBeInTheDocument();
+        });
+
+        await user.click(button);
+        await waitFor(() => {
+            expect(screen.getByText('Saved changes')).toBeInTheDocument();
+        });
+    });
+
+    test('respects assertive politeness option', async() => {
+        const user = userEvent.setup();
+        render(<AnnounceHarness politeness="assertive" />);
+
+        await user.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Saved changes')).toHaveAttribute('aria-live', 'assertive');
+        });
+    });
+});

--- a/src/core/utils/LiveRegion/useAnnounce.tsx
+++ b/src/core/utils/LiveRegion/useAnnounce.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React, { useCallback, useState } from 'react';
+import LiveRegion, { LiveRegionPoliteness } from './LiveRegion';
+
+export type UseAnnounceOptions = {
+    politeness?: LiveRegionPoliteness;
+    atomic?: boolean;
+};
+
+export type UseAnnounceReturn = {
+    announce: (message: string) => void;
+    Announcer: () => React.JSX.Element | null;
+};
+
+/**
+ * Programmatic screen reader announcements via a companion live region.
+ * Render `Announcer` once in the tree (typically near the app root).
+ */
+export function useAnnounce(options: UseAnnounceOptions = {}): UseAnnounceReturn {
+    const { politeness = 'polite', atomic = true } = options;
+    const [message, setMessage] = useState('');
+
+    const announce = useCallback((nextMessage: string) => {
+        setMessage('');
+        queueMicrotask(() => {
+            setMessage(nextMessage);
+        });
+    }, []);
+
+    const Announcer = useCallback(
+        () => (
+            <LiveRegion politeness={politeness} atomic={atomic}>
+                {message}
+            </LiveRegion>
+        ),
+        [message, politeness, atomic]
+    );
+
+    return { announce, Announcer };
+}

--- a/src/core/utils/LiveRegion/visuallyHiddenStyles.ts
+++ b/src/core/utils/LiveRegion/visuallyHiddenStyles.ts
@@ -1,0 +1,20 @@
+import { CSSProperties } from 'react';
+
+/**
+ * Shared visually-hidden styles (same contract as VisuallyHidden).
+ * Keeps live region content available to assistive tech without affecting layout.
+ */
+export const VISUALLY_HIDDEN_STYLES: CSSProperties = {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    margin: '-1px',
+    border: '0',
+    padding: '0',
+    whiteSpace: 'nowrap',
+    clip: 'rect(0 0 0 0)',
+    clipPath: 'inset(50%)',
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    userSelect: 'none'
+} as const;


### PR DESCRIPTION
## Summary
- Adds `LiveRegion` in `src/core/utils/LiveRegion/` with `aria-live` (`polite`/`assertive`) and `aria-atomic`, using the same visually hidden styling contract as `VisuallyHidden`.
- Adds `useAnnounce` for programmatic announcements via a companion `Announcer` render target.
- Includes unit tests, Storybook stories under **Utilities/LiveRegion**, exports from `src/core/index.ts`, and a changeset.

Closes #1810

## Test plan
- [x] `npm test -- --testPathPatterns=LiveRegion`
- [ ] Verify Storybook **Utilities/LiveRegion** declarative and programmatic examples
- [ ] Confirm screen reader announces polite/assertive updates in a real AT setup