### PR TITLE
feat(#1807): prefers-reduced-motion defaults for Collapsible transitions

### DIFF
--- a/.changeset/prefers-reduced-motion-collapsible.md
+++ b/.changeset/prefers-reduced-motion-collapsible.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Collapsible primitives disable height transitions by default when prefers-reduced-motion: reduce is enabled, unless transitionDuration is set explicitly.

--- a/src/core/hooks/usePrefersReducedMotion/index.ts
+++ b/src/core/hooks/usePrefersReducedMotion/index.ts
@@ -1,0 +1,1 @@
+export { usePrefersReducedMotion, default } from './usePrefersReducedMotion';

--- a/src/core/hooks/usePrefersReducedMotion/usePrefersReducedMotion.test.tsx
+++ b/src/core/hooks/usePrefersReducedMotion/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+
+describe('usePrefersReducedMotion', () => {
+    const originalMatchMedia = window.matchMedia;
+
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia;
+    });
+
+    it('reflects prefers-reduced-motion after mount', () => {
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: true,
+            media: '(prefers-reduced-motion: reduce)',
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        } as unknown as MediaQueryList);
+
+        const { result } = renderHook(() => usePrefersReducedMotion());
+
+        act(() => {});
+
+        expect(result.current).toBe(true);
+    });
+
+    it('updates when the media query changes', () => {
+        let changeHandler: (event: MediaQueryListEvent) => void = () => {};
+
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: false,
+            media: '(prefers-reduced-motion: reduce)',
+            addEventListener: jest.fn((_event, handler) => {
+                changeHandler = handler;
+            }),
+            removeEventListener: jest.fn()
+        } as unknown as MediaQueryList);
+
+        const { result } = renderHook(() => usePrefersReducedMotion());
+
+        act(() => {});
+
+        expect(result.current).toBe(false);
+
+        act(() => {
+            changeHandler({ matches: true } as MediaQueryListEvent);
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returns false when matchMedia is unavailable', () => {
+        const matchMedia = window.matchMedia;
+
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: undefined
+        });
+
+        const { result } = renderHook(() => usePrefersReducedMotion());
+
+        act(() => {});
+
+        expect(result.current).toBe(false);
+
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: matchMedia
+        });
+    });
+
+    it('cleans up the media query listener on unmount', () => {
+        const removeEventListener = jest.fn();
+
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: false,
+            media: '(prefers-reduced-motion: reduce)',
+            addEventListener: jest.fn(),
+            removeEventListener
+        } as unknown as MediaQueryList);
+
+        const { unmount } = renderHook(() => usePrefersReducedMotion());
+
+        act(() => {});
+
+        unmount();
+
+        expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+});

--- a/src/core/hooks/usePrefersReducedMotion/usePrefersReducedMotion.ts
+++ b/src/core/hooks/usePrefersReducedMotion/usePrefersReducedMotion.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Returns whether the user has enabled prefers-reduced-motion in their OS settings.
+ * SSR-safe: returns false until mounted on the client, then reflects the media query.
+ */
+export function usePrefersReducedMotion(): boolean {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+
+        const mediaQueryList = window.matchMedia(QUERY);
+
+        const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+            setPrefersReducedMotion(event.matches);
+        };
+
+        handleChange(mediaQueryList);
+
+        if (typeof mediaQueryList.addEventListener === 'function') {
+            mediaQueryList.addEventListener('change', handleChange);
+            return () => mediaQueryList.removeEventListener('change', handleChange);
+        }
+
+        mediaQueryList.addListener(handleChange);
+        return () => mediaQueryList.removeListener(handleChange);
+    }, []);
+
+    return prefersReducedMotion;
+}
+
+export default usePrefersReducedMotion;

--- a/src/core/primitives/Collapsible/contexts/CollapsiblePrimitiveContext.tsx
+++ b/src/core/primitives/Collapsible/contexts/CollapsiblePrimitiveContext.tsx
@@ -26,9 +26,10 @@ export type CollapsiblePrimitiveContextValue = {
    */
   contentId: string;
   /**
-   * Duration of the height transition animation in milliseconds
+   * Duration of the height transition animation in milliseconds.
+   * When omitted, primitives apply defaults (including prefers-reduced-motion).
    */
-  transitionDuration: number;
+  transitionDuration?: number;
   /**
    * CSS timing function for the transition
    */

--- a/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
+++ b/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
@@ -1,7 +1,10 @@
-import React, { useState, useRef, useEffect, useLayoutEffect } from 'react';
-import Primitive from '~/core/primitives/Primitive';
-import { useCollapsiblePrimitiveContext } from '../contexts/CollapsiblePrimitiveContext';
-import { composeRefs } from '~/core/utils/mergeProps';
+import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
+import Primitive from "~/core/primitives/Primitive";
+import { useCollapsiblePrimitiveContext } from "../contexts/CollapsiblePrimitiveContext";
+import { composeRefs } from "~/core/utils/mergeProps";
+import { usePrefersReducedMotion } from "~/core/hooks/usePrefersReducedMotion";
+
+const DEFAULT_TRANSITION_DURATION = 300;
 
 type CollapsiblePrimitiveContentElement = React.ElementRef<typeof Primitive.div>;
 export type CollapsiblePrimitiveContentProps = React.ComponentPropsWithoutRef<
@@ -20,6 +23,14 @@ const CollapsiblePrimitiveContent = React.forwardRef<
         transitionDuration,
         transitionTimingFunction
     } = useCollapsiblePrimitiveContext();
+
+    const prefersReducedMotion = usePrefersReducedMotion();
+    const resolvedTransitionDuration =
+        transitionDuration !== undefined
+            ? transitionDuration
+            : prefersReducedMotion
+                ? 0
+                : DEFAULT_TRANSITION_DURATION;
 
     const [height, setHeight] = useState<number | undefined>(open ? undefined : 0);
     const [isPresent, setIsPresent] = useState(open || forceMount);
@@ -62,9 +73,8 @@ const CollapsiblePrimitiveContent = React.forwardRef<
             transitionTimingFunction: node.style.transitionTimingFunction
         };
 
-        // Measure the content at its natural size before the browser paints.
-        node.style.transitionDuration = '0s';
-        node.style.transitionProperty = 'none';
+        node.style.transitionDuration = "0s";
+        node.style.transitionProperty = "none";
 
         const rect = node.getBoundingClientRect();
         const measuredHeight = rect.height || node.scrollHeight;
@@ -79,7 +89,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
             node.style.transitionTimingFunction = originalStylesRef.current.transitionTimingFunction;
         }
 
-        if (transitionDuration === 0) {
+        if (resolvedTransitionDuration === 0) {
             setHeight(open ? undefined : 0);
 
             if (!open && !forceMount) {
@@ -112,7 +122,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
 
             animationTimeoutRef.current = setTimeout(() => {
                 setHeight(undefined);
-            }, transitionDuration);
+            }, resolvedTransitionDuration);
         } else {
             setHeight(heightRef.current ?? node.scrollHeight);
 
@@ -128,7 +138,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
                 if (!forceMount) {
                     setIsPresent(false);
                 }
-            }, transitionDuration);
+            }, resolvedTransitionDuration);
         }
 
         return () => {
@@ -139,7 +149,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
                 cancelAnimationFrame(rafRef.current);
             }
         };
-    }, [open, transitionDuration, forceMount, children]);
+    }, [open, resolvedTransitionDuration, forceMount, children]);
 
     const shouldRender = open || isPresent || forceMount;
 
@@ -149,14 +159,14 @@ const CollapsiblePrimitiveContent = React.forwardRef<
 
     const dynamicStyle: React.CSSProperties = {
         ...style,
-        overflow: 'hidden',
+        overflow: "hidden",
         height: height !== undefined ? `${height}px` : undefined,
-        ['--radix-collapsible-content-height' as string]:
+        ["--radix-collapsible-content-height" as string]:
             heightRef.current !== undefined ? `${heightRef.current}px` : undefined,
-        ['--radix-collapsible-content-width' as string]:
+        ["--radix-collapsible-content-width" as string]:
             widthRef.current !== undefined ? `${widthRef.current}px` : undefined,
-        ...(transitionDuration > 0
-            ? { transition: `height ${transitionDuration}ms ${transitionTimingFunction}` }
+        ...(resolvedTransitionDuration > 0
+            ? { transition: `height ${resolvedTransitionDuration}ms ${transitionTimingFunction}` }
             : {})
     };
 
@@ -167,7 +177,7 @@ const CollapsiblePrimitiveContent = React.forwardRef<
             id={contentId}
             ref={composeRefs(forwardedRef, ref)}
             aria-hidden={!open}
-            data-state={open ? 'open' : 'closed'}
+            data-state={open ? "open" : "closed"}
             className={className}
             style={dynamicStyle}
             asChild={shouldUseAsChild}
@@ -178,6 +188,6 @@ const CollapsiblePrimitiveContent = React.forwardRef<
     );
 });
 
-CollapsiblePrimitiveContent.displayName = 'CollapsiblePrimitiveContent';
+CollapsiblePrimitiveContent.displayName = "CollapsiblePrimitiveContent";
 
 export default CollapsiblePrimitiveContent;

--- a/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveRoot.tsx
+++ b/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveRoot.tsx
@@ -41,7 +41,7 @@ const CollapsiblePrimitiveRoot = React.forwardRef<
     open,
     onOpenChange,
     disabled = false,
-    transitionDuration = 300,
+    transitionDuration,
     transitionTimingFunction = 'linear',
     ...props
 }, forwardedRef) => {

--- a/src/core/primitives/Collapsible/stories/Collapsible.stories.tsx
+++ b/src/core/primitives/Collapsible/stories/Collapsible.stories.tsx
@@ -6,7 +6,13 @@ const meta: Meta<typeof CollapsiblePrimitive> = {
     title: 'Primitives/Collapsible',
     component: CollapsiblePrimitive,
     parameters: {
-        layout: 'centered'
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'Collapsible content animates height over 300ms by default. When transitionDuration is omitted and the user has prefers-reduced-motion enabled, transitions are disabled automatically. Set transitionDuration explicitly to keep a custom duration.'
+            }
+        }
     }
 };
 

--- a/src/core/primitives/Collapsible/tests/Collapsible.test.tsx
+++ b/src/core/primitives/Collapsible/tests/Collapsible.test.tsx
@@ -142,3 +142,57 @@ describe('CollapsiblePrimitive', () => {
         expect(content.style.getPropertyValue('--radix-collapsible-content-width')).toBe('320px');
     });
 });
+
+describe('prefers-reduced-motion', () => {
+    const originalMatchMedia = window.matchMedia;
+
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia;
+    });
+
+    test('disables transitions when reduced motion is preferred and duration is not set', () => {
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: true,
+            media: '(prefers-reduced-motion: reduce)',
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn()
+        } as unknown as MediaQueryList);
+
+        render(
+            <CollapsiblePrimitive.Root defaultOpen>
+                <CollapsiblePrimitive.Content data-testid="content">
+                    Content
+                </CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        expect(screen.getByTestId('content')).not.toHaveStyle({ transition: expect.stringContaining('ms') });
+    });
+
+    test('keeps explicit transition duration when reduced motion is preferred', () => {
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: true,
+            media: '(prefers-reduced-motion: reduce)',
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn()
+        } as unknown as MediaQueryList);
+
+        render(
+            <CollapsiblePrimitive.Root defaultOpen transitionDuration={200}>
+                <CollapsiblePrimitive.Content data-testid="content">
+                    Content
+                </CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        expect(screen.getByTestId('content')).toHaveStyle({ transition: 'height 200ms linear' });
+    });
+});


### PR DESCRIPTION
## Summary
- Add SSR-safe `usePrefersReducedMotion` hook with tests.
- Collapsible content uses zero transition duration by default when `prefers-reduced-motion: reduce` is enabled and `transitionDuration` is omitted.
- Document default behavior in Collapsible Storybook and add a changeset.

## Test plan
- [x] `npm test -- --testPathPatterns=usePrefersReducedMotion|Collapsible/tests/Collapsible.test`
- [ ] Verify Collapsible open/close in Storybook with reduced motion enabled in OS/browser settings

Closes #1807