### PR TITLE
fix(dialog): portal content inside Theme scope (#1100)

### DIFF
--- a/src/components/ui/Dialog/tests/Dialog.portal.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.portal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import Dialog from '../Dialog';
+import Theme from '~/components/ui/Theme/Theme';
 import { TextEncoder, TextDecoder } from 'util';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder;
@@ -15,6 +16,24 @@ const { act } = require('react-dom/test-utils');
 
 // Helper to flush microtasks
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') {
+        return;
+    }
+
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(query => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn()
+        }))
+    });
+};
 
 describe('Dialog portal and accessibility', () => {
     test('manages focus and data-state, closes on escape and overlay click', async() => {
@@ -206,5 +225,25 @@ describe('Dialog portal and accessibility', () => {
 
         expect(triggerRef.current?.tagName).toBe('A');
         expect(contentRef.current?.tagName).toBe('FORM');
+    });
+
+    test('portals content inside the active theme scope', async() => {
+        mockMatchMedia();
+
+        render(
+            <Theme appearance="dark" classNamespace="rad-ui">
+                <Dialog.Root open>
+                    <Dialog.Trigger>Open</Dialog.Trigger>
+                    <Dialog.Portal>
+                        <Dialog.Overlay />
+                        <Dialog.Content data-testid="dialog-content">Portaled</Dialog.Content>
+                    </Dialog.Portal>
+                </Dialog.Root>
+            </Theme>
+        );
+
+        const content = await screen.findByTestId('dialog-content');
+        expect(content.closest('[data-rad-ui-theme="dark"]')).toBeInTheDocument();
+        expect(content.closest('[data-rad-ui-portal-root]')).toBeInTheDocument();
     });
 });

--- a/src/components/ui/Dialog/tests/Dialog.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.test.tsx
@@ -1,8 +1,27 @@
 import React, { createRef } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithPortal, assertFocusTrap, assertFocusReturn, assertScrollLock, assertScrollUnlock } from '~/test-utils/portal';
+import { assertFocusTrap, assertFocusReturn, assertScrollLock, assertScrollUnlock } from '~/test-utils/portal';
 import Dialog from '../Dialog';
+import Theme from '~/components/ui/Theme/Theme';
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') {
+        return;
+    }
+
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(query => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn()
+        }))
+    });
+};
 
 describe('Dialog', () => {
     test('forwards refs to subcomponents', () => {
@@ -89,18 +108,23 @@ describe('Dialog', () => {
     });
 
     test('mounts in portal, traps focus, returns focus and locks scroll', async() => {
+        mockMatchMedia();
         const user = userEvent.setup();
-        const { getByText, portalRoot, cleanup } = renderWithPortal(
-            <Dialog.Root>
-                <Dialog.Trigger>Trigger</Dialog.Trigger>
-                <Dialog.Portal>
-                    <Dialog.Overlay />
-                    <Dialog.Content>
-                        <Dialog.Close>Close</Dialog.Close>
-                    </Dialog.Content>
-                </Dialog.Portal>
-            </Dialog.Root>
+        const { getByText, unmount } = render(
+            <Theme id="rad-ui-theme-container">
+                <Dialog.Root>
+                    <Dialog.Trigger>Trigger</Dialog.Trigger>
+                    <Dialog.Portal>
+                        <Dialog.Overlay />
+                        <Dialog.Content>
+                            <Dialog.Close>Close</Dialog.Close>
+                        </Dialog.Content>
+                    </Dialog.Portal>
+                </Dialog.Root>
+            </Theme>
         );
+
+        const portalRoot = document.querySelector('[data-rad-ui-portal-root]') as HTMLElement;
 
         await user.click(getByText('Trigger'));
         await waitFor(() => assertScrollLock());
@@ -108,7 +132,7 @@ describe('Dialog', () => {
         await user.click(getByText('Close'));
         assertFocusReturn(getByText('Trigger'));
         await waitFor(() => assertScrollUnlock());
-        cleanup();
+        unmount();
     });
 
     test('renders under StrictMode without console errors', () => {

--- a/src/core/primitives/Dialog/fragments/DialogPrimitivePortal.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitivePortal.tsx
@@ -22,17 +22,13 @@ const DialogPrimitivePortal = ({
     const [isMounted, setIsMounted] = useState(false);
 
     useEffect(() => {
-        // Only run on client side after component mounts
         if (container) {
             rootElementRef.current = container as HTMLElement;
         } else {
-            const themeContainer = themeContext?.portalRootRef.current
-                || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-                || themeContext?.containerRef.current
-                || document.querySelector('#rad-ui-theme-container') as HTMLElement | null;
-            const fallback = document.body;
-            const selectedRoot = themeContainer || fallback;
-            rootElementRef.current = selectedRoot;
+            rootElementRef.current =
+                themeContext?.portalRootRef.current
+                ?? themeContext?.containerRef.current
+                ?? document.body;
         }
         setIsMounted(true);
     }, [container, themeContext]);


### PR DESCRIPTION
## Summary
- Dialog portal targets ThemeContext refs instead of querySelector
- Adds regression test for theme-scoped dialog portaling
- Updates Dialog focus-trap test to render inside Theme

Fixes #1100, relates to #1101

## Test plan
- [x] `npm test -- --testPathPatterns=Dialog`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced dialog portal testing with new verification that portal content mounts correctly within the active theme scope.
  * Updated test utilities and setup for improved portal, focus trap, and scroll lock verification.

* **Refactor**
  * Optimized dialog portal mounting to leverage theme context references more directly, improving reliability of portal placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->