### PR TITLE
fix(floating-ui): merge props through getReferenceProps (#806)

### DIFF
--- a/src/core/primitives/Dialog/context/DialogPrimitiveContext.tsx
+++ b/src/core/primitives/Dialog/context/DialogPrimitiveContext.tsx
@@ -5,9 +5,9 @@ type DialogPrimitiveContextType = {
   isOpen: boolean;
   handleOpenChange: (open: boolean) => void;
   handleOverlayClick: () => void;
-  getItemProps: () => any;
-  getReferenceProps: () => any;
-  getFloatingProps: () => any;
+  getItemProps: (userProps?: Record<string, unknown>) => any;
+  getReferenceProps: (userProps?: Record<string, unknown>) => any;
+  getFloatingProps: (userProps?: Record<string, unknown>) => any;
   refs: {
     setReference: React.RefCallback<any> | (() => void);
     setFloating: React.RefCallback<any> | (() => void);
@@ -22,9 +22,9 @@ export const DialogPrimitiveContext = createContext<DialogPrimitiveContextType>(
     isOpen: false,
     handleOpenChange: () => {},
     handleOverlayClick: () => {},
-    getItemProps: () => {},
-    getReferenceProps: () => {},
-    getFloatingProps: () => {},
+    getItemProps: (userProps = {}) => userProps,
+    getReferenceProps: (userProps = {}) => userProps,
+    getFloatingProps: (userProps = {}) => userProps,
     refs: {
         setReference: () => {},
         setFloating: () => {},

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveAction.tsx
@@ -15,9 +15,10 @@ const DialogPrimitiveAction = forwardRef<HTMLButtonElement, DialogPrimitiveActio
         <ButtonPrimitive
             ref={ref}
             asChild={asChild}
-            onClick={() => handleOpenChange(false)}
-            {...getItemProps()}
-            {...props}
+            {...getItemProps({
+                ...props,
+                onClick: () => handleOpenChange(false)
+            })}
         >
             {children}
         </ButtonPrimitive>

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveCancel.tsx
@@ -16,12 +16,13 @@ const DialogPrimitiveCancel = forwardRef<HTMLButtonElement, DialogPrimitiveCance
         <ButtonPrimitive
             ref={ref}
             asChild={asChild}
-            {...getItemProps()}
-            {...props}
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                onClick?.(e);
-                handleOpenChange(false);
-            }}
+            {...getItemProps({
+                ...props,
+                onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                    onClick?.(e);
+                    handleOpenChange(false);
+                }
+            })}
         >
             {children}
         </ButtonPrimitive>

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
@@ -9,13 +9,15 @@ export type DialogPrimitiveTriggerProps = {
     asChild?: boolean;
     className?: string;
     disabled?: boolean;
-}
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+} & Omit<React.ComponentPropsWithoutRef<'button'>, 'onClick'>;
 
 const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTriggerProps>(({
     children,
     asChild,
     className = '',
     disabled = false,
+    onClick,
     ...props
 }, ref) => {
     const { handleOpenChange, getReferenceProps, refs } = useContext(DialogPrimitiveContext);
@@ -28,9 +30,15 @@ const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTrig
             asChild={asChild}
             className={className}
             disabled={disabled}
-            onClick={disabled ? undefined : () => handleOpenChange(true)}
-            {...getReferenceProps()}
-            {...props}
+            {...getReferenceProps({
+                ...props,
+                onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+                    onClick?.(event);
+                    if (!disabled) {
+                        handleOpenChange(true);
+                    }
+                }
+            })}
         >
             {children}
         </ButtonPrimitive>

--- a/src/core/primitives/Menu/fragments/MenuPrimitiveTrigger.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveTrigger.tsx
@@ -27,9 +27,8 @@ const MenuPrimitiveTrigger = forwardRef<HTMLButtonElement, MenuPrimitiveTriggerP
                 className={className}
                 tabIndex={!isNested ? undefined : activeIndex === index ? 0 : -1}
                 ref={mergedRef}
-                {...getReferenceProps()}
                 asChild={asChild}
-                {...props}
+                {...getReferenceProps(props)}
             >
                 {children}
             </ButtonPrimitive>


### PR DESCRIPTION
## Summary
- Pass user event handlers through Floating UI prop getters on Dialog trigger/action/cancel and Menu trigger

Fixes #806, relates to #1099

## Test plan
- [x] MenuPrimitive and Dialog tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved prop handling in Dialog and Menu primitive components by standardizing how custom properties are passed through context getters, enhancing consistency in prop composition across trigger, action, and cancel components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->