### PR TITLE
fix(hover-card): portal content inside Theme scope (#1100)

### DIFF
--- a/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
@@ -21,9 +21,6 @@ const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>
         const resolvedRoot = explicitRoot
             || themeContext?.portalRootRef.current
             || themeContext?.containerRef.current
-            || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-            || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
-            || document.getElementsByClassName(rootTriggerClass)[0] as HTMLElement | undefined
             || document.body;
 
         setRootElem(resolvedRoot);

--- a/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HoverCard from '../HoverCard';
+import ThemeContext from '../../Theme/ThemeContext';
+
+describe('HoverCard portal', () => {
+    test('portals content into Theme portalRootRef when provided', async() => {
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <HoverCard.Root open>
+                    <HoverCard.Trigger>Hover me</HoverCard.Trigger>
+                    <HoverCard.Portal>
+                        <HoverCard.Content>Hover label</HoverCard.Content>
+                    </HoverCard.Portal>
+                </HoverCard.Root>
+            </ThemeContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(portalRoot).toContainElement(screen.getByText('Hover label'));
+        });
+
+        portalRoot.remove();
+    });
+});


### PR DESCRIPTION
## Summary
- HoverCard portal targets ThemeContext refs instead of DOM queries
- Preserves optional explicit rootElement prop

Fixes #1100

## Test plan
- [x] npm test -- --testPathPatterns=HoverCard.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the Hover Card portal to resolve its root using the theme’s provided portal and container references first, with a simpler fallback to the document body. This improves consistency and reduces reliance on legacy DOM lookups for portal placement.
* **Tests**
  * Added coverage to verify that `HoverCard.Portal` correctly renders its content into the configured theme portal root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->