### PR TITLE
fix(popover): portal content inside Theme scope (#1100)

### DIFF
--- a/src/core/primitives/Popover/fragments/PopoverPrimitivePortal.tsx
+++ b/src/core/primitives/Popover/fragments/PopoverPrimitivePortal.tsx
@@ -21,12 +21,10 @@ const PopoverPrimitivePortal = ({
     const [isMounted, setIsMounted] = React.useState(false);
 
     React.useEffect(() => {
-        rootElementRef.current = (container as HTMLElement | null) ||
-            themeContext?.portalRootRef.current ||
-            document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null ||
-            themeContext?.containerRef.current ||
-            document.querySelector('#rad-ui-theme-container') as HTMLElement | null ||
-            document.body;
+        rootElementRef.current = (container as HTMLElement | null)
+            ?? themeContext?.portalRootRef.current
+            ?? themeContext?.containerRef.current
+            ?? document.body;
         setIsMounted(true);
     }, [container, themeContext]);
 


### PR DESCRIPTION
## Summary
- Popover portal targets ThemeContext refs instead of querySelector
- Keeps optional container prop support

Fixes #1100

## Test plan
- [x] npm test -- --testPathPatterns=Popover.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal portal element selection logic for Popover components, reducing complexity and improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->