### PR TITLE
fix(menu): portal content inside Theme scope (#1100)

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
@@ -1,30 +1,41 @@
 'use client';
-import React, { useContext, useEffect, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import React, { useContext, useLayoutEffect, useRef, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Floater from '~/core/primitives/Floater';
+import ThemeContext from '~/components/ui/Theme/ThemeContext';
 import MenuPrimitiveRootContext from '../contexts/MenuPrimitiveRootContext';
 
 export type MenuPrimitivePortalElement = HTMLDivElement;
-export type MenuPrimitivePortalProps = { children: React.ReactNode } & ComponentPropsWithoutRef<typeof Floater.Portal>;
+export type MenuPrimitivePortalProps = {
+    children: React.ReactNode;
+    container?: Element | null;
+} & ComponentPropsWithoutRef<typeof Floater.Portal>;
 
 const MenuPrimitivePortal = forwardRef<MenuPrimitivePortalElement, MenuPrimitivePortalProps>(
-    ({ children, ...props }, ref) => {
+    ({ children, container, ...props }, ref) => {
         const context = useContext(MenuPrimitiveRootContext);
-        const [rootElementFound, setRootElementFound] = useState(false);
-        const rootElement = (
-            document.querySelector('#rad-ui-theme-container') || document.body
-        ) as HTMLElement | null;
+        const themeContext = useContext(ThemeContext);
+        const rootElementRef = useRef<HTMLElement | null>(null);
+        const [isMounted, setIsMounted] = useState(false);
 
-        useEffect(() => {
-            if (rootElement) {
-                setRootElementFound(true);
+        useLayoutEffect(() => {
+            if (container) {
+                rootElementRef.current = container as HTMLElement;
+            } else {
+                rootElementRef.current = themeContext?.portalRootRef.current
+                    || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
+                    || themeContext?.containerRef.current
+                    || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
+                    || document.body;
             }
-        }, [rootElement]);
+            setIsMounted(true);
+        }, [container, themeContext]);
 
         if (!context) return null;
         const { isOpen } = context;
-        if (!isOpen || !rootElementFound) return null;
+        if (!isOpen || !isMounted) return null;
+
         return (
-            <Floater.Portal root={rootElement} {...props}>
+            <Floater.Portal root={rootElementRef.current} {...props}>
                 <div ref={ref}>{children}</div>
             </Floater.Portal>
         );


### PR DESCRIPTION
## Summary
- Menu portal targets ThemeContext refs with theme container fallbacks
- Keeps optional container prop support

Fixes #1100

## Test plan
- [x] npm test -- --testPathPatterns=MenuPrimitive.test
- [x] npm test -- --testPathPatterns=DropdownMenu.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced menu portal rendering with improved theme context integration and support for flexible container control, ensuring more reliable menu positioning and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->