### PR TITLE
fix(combobox): merge consumer props through getReferenceProps (#806)

### DIFF
--- a/src/core/primitives/Combobox/contexts/ComboboxPrimitiveContext.tsx
+++ b/src/core/primitives/Combobox/contexts/ComboboxPrimitiveContext.tsx
@@ -16,7 +16,7 @@ export type ComboboxPrimitiveContextType = {
     placedPlacement: string;
     floatingStyles: React.CSSProperties;
     floatingContext: any;
-    getReferenceProps: () => any;
+    getReferenceProps: (userProps?: any) => any;
     getFloatingProps: () => any;
     getItemProps: (userProps?: any) => any;
     activeIndex: number | null;

--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitiveSearch.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitiveSearch.tsx
@@ -39,8 +39,13 @@ const ComboboxPrimitiveSearch = React.forwardRef<
         };
     }, [setHasSearch, setActiveIndex, setSearch]);
 
-    // Get the reference props from Floating UI
-    const referenceProps = getReferenceProps();
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (activeIndex !== null && event.key === KEYBOARD_KEYS.ENTER) {
+            event.preventDefault();
+            handleSelect(activeIndex);
+        }
+        props.onKeyDown?.(event);
+    };
 
     return (
         <Primitive.input
@@ -49,20 +54,13 @@ const ComboboxPrimitiveSearch = React.forwardRef<
             className={className}
             placeholder="Search..."
             ref={Floater.useMergeRefs([inputRef, forwardedRef])}
-            value={search}
             aria-activedescendant={virtualItemRef.current?.id || (activeIndex !== null && valuesRef.current[activeIndex] ? valuesRef.current[activeIndex] : undefined)}
-            // @ts-ignore
-            onChange={(e) => setSearch(e.target.value)}
-            {...referenceProps}
-            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
-                if (activeIndex !== null) {
-                    if (event.key === KEYBOARD_KEYS.ENTER) {
-                        event.preventDefault();
-                        handleSelect(activeIndex);
-                    }
-                }
-            }}
-            {...props}
+            {...getReferenceProps({
+                ...props,
+                value: search,
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value),
+                onKeyDown: handleKeyDown
+            })}
         />
     );
 });

--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitiveTrigger.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitiveTrigger.tsx
@@ -17,15 +17,9 @@ const ComboboxPrimitiveTrigger = React.forwardRef<
     React.ElementRef<typeof Primitive.button>,
     ComboboxPrimitiveTriggerProps & React.ComponentPropsWithoutRef<typeof Primitive.button>
 >(({ children, className, disabled, asChild, onClick, renderValue, ...props }, forwardedRef) => {
-    const { isOpen, setIsOpen, selectedLabel, selectedValue, refs, getReferenceProps } = useContext(ComboboxPrimitiveContext);
+    const { isOpen, selectedLabel, selectedValue, refs, getReferenceProps } = useContext(ComboboxPrimitiveContext);
 
-    const { onClick: _refOnClick, ...refProps } = getReferenceProps();
-
-    const handleClick = composeEventHandlers(onClick, () => {
-        if (!disabled) {
-            setIsOpen(prev => !prev);
-        }
-    });
+    const handleClick = composeEventHandlers(onClick);
     const hasSelectedValue = Boolean(selectedLabel || selectedValue);
     const renderedValue = hasSelectedValue
         ? renderValue?.(selectedValue, selectedLabel || selectedValue)
@@ -42,9 +36,11 @@ const ComboboxPrimitiveTrigger = React.forwardRef<
             ref={Floater.useMergeRefs([refs.setReference, forwardedRef])}
             role='combobox'
             asChild={asChild}
-            onClick={handleClick}
-            {...refProps}
-            {...props}
+            {...getReferenceProps({
+                ...props,
+                onClick: handleClick,
+                disabled
+            })}
         >
             {renderedValue ?? (selectedLabel || selectedValue || children)}
         </Primitive.button>


### PR DESCRIPTION
## Summary
- Combobox trigger/search merge user props via getReferenceProps
- Avoid double-toggle by letting useClick own open state
- Update context typing for userProps parameter

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=Combobox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated combobox primitive component's event handling and props management to centralize Enter-key behavior in the search input and streamline click handling in the trigger component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->