### PR TITLE
test(toast): aria-live announcement semantics (#1808)

### DIFF
--- a/src/components/ui/Toast/fragments/ToastRoot.tsx
+++ b/src/components/ui/Toast/fragments/ToastRoot.tsx
@@ -148,6 +148,7 @@ const ToastRoot: React.FC<ToastRootProps> = ({ toast, className, children }) => 
 
     // Imperative dismiss — same exit as Close / timer
     useEffect(() => {
+        if (!toastManager) return;
         const unsub = toastManager.subscribeDismiss((id) => {
             if (id === '__all__') return;
             if (id === toast.id) dismissRef.current();

--- a/src/components/ui/Toast/tests/Toast.announcement.test.tsx
+++ b/src/components/ui/Toast/tests/Toast.announcement.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ToastRoot from '../fragments/ToastRoot';
+import { ToastProviderContext, type ToastData } from '../contexts/ToastContext';
+
+function renderToast(toast: ToastData) {
+    const toastManager = {
+        defaultTimeout: 5000,
+        subscribe: () => () => {},
+        subscribeDismiss: () => () => {},
+        subscribeUpdate: () => () => {},
+        create: () => toast.id,
+        update: () => {},
+        dismiss: () => {},
+        dismissAll: () => {},
+        close: () => {}
+    };
+
+    const provider = {
+        rootClass: '',
+        position: 'bottom-right',
+        expand: false,
+        gap: 14,
+        maxToasts: 3,
+        defaultToastTimeout: 5000,
+        toastManager,
+        isHovered: false,
+        setIsHovered: () => {},
+        heights: new Map<string, number>(),
+        updateHeight: () => {},
+        unlinkStackHeight: () => {},
+        removeToast: () => {},
+        toasts: [toast],
+        visibleToasts: [toast]
+    };
+
+    return render(
+        <ToastProviderContext.Provider value={provider}>
+            <ul>
+                <ToastRoot toast={toast}>
+                    <span>{toast.title}</span>
+                </ToastRoot>
+            </ul>
+        </ToastProviderContext.Provider>
+    );
+}
+
+describe('Toast announcement semantics', () => {
+    test('uses polite aria-live by default and assertive for high priority', () => {
+        renderToast({ id: '1', title: 'Saved', priority: 'low', duration: 5000 });
+
+        const polite = screen.getByRole('status');
+        expect(polite).toHaveAttribute('aria-live', 'polite');
+        expect(polite).toHaveAttribute('aria-atomic', 'true');
+
+        renderToast({ id: '2', title: 'Error', priority: 'high', duration: 5000 });
+
+        expect(screen.getByText('Error').closest('[role="status"]')).toHaveAttribute('aria-live', 'assertive');
+    });
+});

--- a/src/components/ui/Toast/tests/Toast.announcement.test.tsx
+++ b/src/components/ui/Toast/tests/Toast.announcement.test.tsx
@@ -46,15 +46,19 @@ function renderToast(toast: ToastData) {
 }
 
 describe('Toast announcement semantics', () => {
-    test('uses polite aria-live by default and assertive for high priority', () => {
+    test('uses polite aria-live by default', () => {
         renderToast({ id: '1', title: 'Saved', priority: 'low', duration: 5000 });
 
         const polite = screen.getByRole('status');
         expect(polite).toHaveAttribute('aria-live', 'polite');
         expect(polite).toHaveAttribute('aria-atomic', 'true');
+    });
 
+    test('uses assertive aria-live for high priority', () => {
         renderToast({ id: '2', title: 'Error', priority: 'high', duration: 5000 });
 
-        expect(screen.getByText('Error').closest('[role="status"]')).toHaveAttribute('aria-live', 'assertive');
+        const assertive = screen.getByText('Error').closest('[role="status"]');
+        expect(assertive).toHaveAttribute('aria-live', 'assertive');
+        expect(assertive).toHaveAttribute('aria-atomic', 'true');
     });
 });


### PR DESCRIPTION
## Summary
- Adds ToastRoot tests for polite vs assertive aria-live based on priority
- Guards imperative dismiss subscription when toastManager is unset

Fixes #1808

## Test plan
- [x] npm test -- --testPathPatterns=Toast.announcement