### PR TITLE
test(collapsible): lazy mount behavior (#1847)

### DIFF
--- a/src/core/primitives/Collapsible/tests/Collapsible.lazyMount.test.tsx
+++ b/src/core/primitives/Collapsible/tests/Collapsible.lazyMount.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CollapsiblePrimitive from '~/core/primitives/Collapsible';
+
+describe('Collapsible lazy mount behavior', () => {
+    test('does not mount content while closed by default', () => {
+        render(
+            <CollapsiblePrimitive.Root open={false}>
+                <CollapsiblePrimitive.Trigger>Toggle</CollapsiblePrimitive.Trigger>
+                <CollapsiblePrimitive.Content>Hidden panel</CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        expect(screen.getByText('Toggle')).toBeInTheDocument();
+        expect(screen.queryByText('Hidden panel')).not.toBeInTheDocument();
+    });
+
+    test('mounts content after opening and unmounts after closing', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <CollapsiblePrimitive.Root defaultOpen={false} transitionDuration={0}>
+                <CollapsiblePrimitive.Trigger>Toggle</CollapsiblePrimitive.Trigger>
+                <CollapsiblePrimitive.Content>Panel</CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        expect(screen.queryByText('Panel')).not.toBeInTheDocument();
+        await user.click(screen.getByText('Toggle'));
+        expect(screen.getByText('Panel')).toBeInTheDocument();
+        await user.click(screen.getByText('Toggle'));
+        expect(screen.queryByText('Panel')).not.toBeInTheDocument();
+    });
+
+    test('forceMount keeps content mounted while closed', () => {
+        render(
+            <CollapsiblePrimitive.Root open={false}>
+                <CollapsiblePrimitive.Trigger>Toggle</CollapsiblePrimitive.Trigger>
+                <CollapsiblePrimitive.Content forceMount>Mounted panel</CollapsiblePrimitive.Content>
+            </CollapsiblePrimitive.Root>
+        );
+
+        expect(screen.getByText('Mounted panel')).toBeInTheDocument();
+        expect(screen.getByText('Mounted panel')).toHaveAttribute('data-state', 'closed');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds lazy mount tests for Collapsible primitive
- Covers forceMount keeping closed content mounted

Related to #1847

## Test plan
- [x] npm test -- --testPathPatterns=Collapsible.lazyMount