### PR TITLE
fix(menu): portal via ThemeContext refs only (#1100)

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitivePortal.tsx
@@ -1,30 +1,36 @@
 'use client';
-import React, { useContext, useEffect, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
+import React, { useContext, useEffect, useRef, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Floater from '~/core/primitives/Floater';
+import ThemeContext from '~/components/ui/Theme/ThemeContext';
 import MenuPrimitiveRootContext from '../contexts/MenuPrimitiveRootContext';
 
 export type MenuPrimitivePortalElement = HTMLDivElement;
-export type MenuPrimitivePortalProps = { children: React.ReactNode } & ComponentPropsWithoutRef<typeof Floater.Portal>;
+export type MenuPrimitivePortalProps = {
+    children: React.ReactNode;
+    container?: Element | null;
+} & ComponentPropsWithoutRef<typeof Floater.Portal>;
 
 const MenuPrimitivePortal = forwardRef<MenuPrimitivePortalElement, MenuPrimitivePortalProps>(
-    ({ children, ...props }, ref) => {
+    ({ children, container, ...props }, ref) => {
         const context = useContext(MenuPrimitiveRootContext);
-        const [rootElementFound, setRootElementFound] = useState(false);
-        const rootElement = (
-            document.querySelector('#rad-ui-theme-container') || document.body
-        ) as HTMLElement | null;
+        const themeContext = useContext(ThemeContext);
+        const rootElementRef = useRef<HTMLElement | null>(null);
+        const [isMounted, setIsMounted] = useState(false);
 
         useEffect(() => {
-            if (rootElement) {
-                setRootElementFound(true);
-            }
-        }, [rootElement]);
+            rootElementRef.current = (container as HTMLElement | null)
+                ?? themeContext?.portalRootRef.current
+                ?? themeContext?.containerRef.current
+                ?? document.body;
+            setIsMounted(true);
+        }, [container, themeContext]);
 
         if (!context) return null;
         const { isOpen } = context;
-        if (!isOpen || !rootElementFound) return null;
+        if (!isOpen || !isMounted) return null;
+
         return (
-            <Floater.Portal root={rootElement} {...props}>
+            <Floater.Portal root={rootElementRef.current} {...props}>
                 <div ref={ref}>{children}</div>
             </Floater.Portal>
         );

--- a/src/test-utils/portal.ts
+++ b/src/test-utils/portal.ts
@@ -1,17 +1,29 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import Theme from '~/components/ui/Theme/Theme';
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
 
 export function renderWithPortal(ui: React.ReactElement) {
-    const portalRoot = document.createElement('div');
-    portalRoot.setAttribute('id', 'rad-ui-theme-container');
-    document.body.appendChild(portalRoot);
-    const result = render(ui);
+    mockMatchMedia();
+    const result = render(React.createElement(Theme, null, ui));
+    const portalRoot = document.querySelector('[data-rad-ui-portal-root]') as HTMLElement;
     return {
         ...result,
         portalRoot,
         cleanup: () => {
             result.unmount();
-            portalRoot.remove();
         }
     };
 }


### PR DESCRIPTION
## Summary
- Menu portal uses ThemeContext refs with document.body fallback
- Removes querySelector usage
- Updates renderWithPortal test helper to use Theme

Fixes #1100

## Test plan
- [x] npm test -- --testPathPatterns=MenuPrimitive.test
- [x] npm test -- --testPathPatterns=DropdownMenu.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced portal root selection logic to support theme-aware container configuration.
  * Improved test utilities for more robust portal rendering validation in test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->