### PR TITLE
fix(popover): merge trigger props through getReferenceProps (#806)

### DIFF
--- a/src/core/primitives/Popover/fragments/PopoverPrimitiveTrigger.tsx
+++ b/src/core/primitives/Popover/fragments/PopoverPrimitiveTrigger.tsx
@@ -37,11 +37,12 @@ const PopoverPrimitiveTrigger = forwardRef<HTMLButtonElement, PopoverPrimitiveTr
             data-state={isOpen ? 'open' : 'closed'}
             data-disabled={disabled ? '' : undefined}
             {...getReferenceProps({
+                ...props,
+                disabled,
                 onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
                     onClick?.(event);
                 }
             })}
-            {...props}
         >
             {children}
         </ButtonPrimitive>


### PR DESCRIPTION
## Summary
- Popover trigger merges consumer props via getReferenceProps

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=Popover.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of component prop handling for the Popover trigger element. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->