### PR TITLE
fix(dialog): merge content props through getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Dialog/context/DialogPrimitiveContext.tsx
+++ b/src/core/primitives/Dialog/context/DialogPrimitiveContext.tsx
@@ -7,7 +7,7 @@ type DialogPrimitiveContextType = {
   handleOverlayClick: () => void;
   getItemProps: () => any;
   getReferenceProps: () => any;
-  getFloatingProps: () => any;
+  getFloatingProps: (userProps?: any) => any;
   refs: {
     setReference: React.RefCallback<any> | (() => void);
     setFloating: React.RefCallback<any> | (() => void);

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
@@ -105,15 +105,16 @@ const DialogPrimitiveContent = forwardRef<HTMLDivElement, DialogPrimitiveContent
         <Primitive.div
             ref={mergedRef}
             asChild={asChild}
-            {...getFloatingProps()}
-            style={{ outline: 'none', ...styleProp }}
-            role={role}
-            aria-hidden={!isOpen ? 'true' : undefined}
-            aria-labelledby={isOpen ? ariaLabelledBy : undefined}
-            aria-describedby={isOpen ? ariaDescribedBy : undefined}
-            data-state={dataState}
-            aria-modal={ariaModal}
-            {...props}
+            {...getFloatingProps({
+                ...props,
+                style: { outline: 'none', ...styleProp },
+                role,
+                'aria-hidden': !isOpen ? 'true' : undefined,
+                'aria-labelledby': isOpen ? ariaLabelledBy : undefined,
+                'aria-describedby': isOpen ? ariaDescribedBy : undefined,
+                'data-state': dataState,
+                'aria-modal': ariaModal
+            })}
         >
             {children}
         </Primitive.div>


### PR DESCRIPTION
## Summary
- Dialog content merges consumer props via getFloatingProps
- Updates context typing for userProps

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=Dialog.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to dialog component implementation for better prop handling and context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->