### PR TITLE
fix(popover): merge content props through getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Popover/fragments/PopoverPrimitiveContent.tsx
+++ b/src/core/primitives/Popover/fragments/PopoverPrimitiveContent.tsx
@@ -172,27 +172,28 @@ const PopoverPrimitiveContent = forwardRef<HTMLDivElement, PopoverPrimitiveConte
         return null;
     }
 
-    const floatingProps = getFloatingProps();
+    const floatingProps = getFloatingProps({
+        ...props,
+        id: contentId,
+        role,
+        'data-state': isOpen ? 'open' : 'closed',
+        'data-side': side,
+        'data-align': align,
+        'aria-hidden': !isOpen ? 'true' : undefined,
+        style: {
+            ...floatingStyles,
+            outline: 'none',
+            visibility: isOpen && !isPositioned ? 'hidden' : undefined,
+            pointerEvents: isOpen && !isPositioned ? 'none' : undefined,
+            ...style
+        }
+    });
 
     const content = (
         <Primitive.div
             ref={mergedRef}
             asChild={asChild}
-            id={contentId}
-            role={role}
-            data-state={isOpen ? 'open' : 'closed'}
-            data-side={side}
-            data-align={align}
-            aria-hidden={!isOpen ? 'true' : undefined}
-            style={{
-                ...floatingStyles,
-                outline: 'none',
-                visibility: isOpen && !isPositioned ? 'hidden' : undefined,
-                pointerEvents: isOpen && !isPositioned ? 'none' : undefined,
-                ...style
-            }}
             {...floatingProps}
-            {...props}
         >
             {children}
         </Primitive.div>


### PR DESCRIPTION
## Summary
- Popover content merges consumer props via getFloatingProps

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=Popover.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Popover component's handling of styling and attribute precedence to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->