### PR TITLE
fix(menu): merge content props through getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -36,10 +36,11 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
                 >         
                     <div
                         ref={mergedRef}
-                        style={floatingStyles}
-                        {...getFloatingProps()}
-                        className={className}
-                        {...props}
+                        {...getFloatingProps({
+                            ...props,
+                            className,
+                            style: floatingStyles
+                        })}
                     >
                         <div style={{overflowY:"auto", overflowX:"hidden"}}>
                         {children}


### PR DESCRIPTION
## Summary
- Menu content merges consumer props via getFloatingProps

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=MenuPrimitive.test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal property handling in the Menu component for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->