### PR TITLE
fix(combobox): merge content props through getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Combobox/contexts/ComboboxPrimitiveContext.tsx
+++ b/src/core/primitives/Combobox/contexts/ComboboxPrimitiveContext.tsx
@@ -17,7 +17,7 @@ export type ComboboxPrimitiveContextType = {
     floatingStyles: React.CSSProperties;
     floatingContext: any;
     getReferenceProps: () => any;
-    getFloatingProps: () => any;
+    getFloatingProps: (userProps?: any) => any;
     getItemProps: (userProps?: any) => any;
     activeIndex: number | null;
     setActiveIndex: React.Dispatch<React.SetStateAction<number | null>>;

--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
@@ -56,26 +56,27 @@ const ComboboxPrimitiveContent = React.forwardRef<
                     <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef} >
                         <div
                             ref={mergedRef}
-                            style={{
-                                ...floatingStyles,
-                                ...style,
-                                '--rad-ui-floating-transform-origin': placementState.transformOrigin,
-                                visibility: !isPositioned && shouldHideUntilPositioned
-                                    ? 'hidden'
-                                    : middlewareData.hide?.referenceHidden
+                            {...getFloatingProps({
+                                ...props,
+                                className,
+                                'data-state': isOpen ? 'open' : 'closed',
+                                'data-side': placementState.side,
+                                'data-align': placementState.align,
+                                'data-positioned': isPositioned ? '' : undefined,
+                                style: {
+                                    ...floatingStyles,
+                                    ...style,
+                                    '--rad-ui-floating-transform-origin': placementState.transformOrigin,
+                                    visibility: !isPositioned && shouldHideUntilPositioned
                                         ? 'hidden'
-                                        : (style?.visibility || floatingStyles.visibility),
-                                pointerEvents: middlewareData.hide?.referenceHidden
-                                    ? 'none'
-                                    : style?.pointerEvents
-                            }}
-                            className={className}
-                            data-state={isOpen ? 'open' : 'closed'}
-                            data-side={placementState.side}
-                            data-align={placementState.align}
-                            data-positioned={isPositioned ? '' : undefined}
-                            {...getFloatingProps()}
-                            {...props}
+                                        : middlewareData.hide?.referenceHidden
+                                            ? 'hidden'
+                                            : (style?.visibility || floatingStyles.visibility),
+                                    pointerEvents: middlewareData.hide?.referenceHidden
+                                        ? 'none'
+                                        : style?.pointerEvents
+                                }
+                            })}
                         >
 
                             {children}


### PR DESCRIPTION
## Summary
- Combobox content merges consumer props via getFloatingProps
- Updates context typing for userProps

Fixes #806

## Test plan
- [x] npm test -- --testPathPatterns=Combobox