### PR TITLE
test(hover-card): controlled/uncontrolled mode switching (#1825)

### DIFF
--- a/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HoverCard from '../HoverCard';
+
+describe('HoverCard controlled switch', () => {
+    const hoverCard = (rootProps: Partial<React.ComponentProps<typeof HoverCard.Root>>) => (
+        <HoverCard.Root {...rootProps}>
+            <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+            <HoverCard.Content>Hover content</HoverCard.Content>
+        </HoverCard.Root>
+    );
+
+    test('switches from uncontrolled to controlled open', () => {
+        const onOpenChange = jest.fn();
+
+        const { rerender } = render(hoverCard({ open: true }));
+
+        expect(screen.getByText('Hover content')).toBeInTheDocument();
+
+        rerender(hoverCard({ open: false, onOpenChange }));
+        expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+    });
+
+    test('switches from controlled open to uncontrolled', () => {
+        const { rerender } = render(hoverCard({ open: true }));
+
+        expect(screen.getByText('Hover content')).toBeInTheDocument();
+
+        rerender(hoverCard({}));
+        expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
@@ -1,32 +1,47 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import HoverCard from '../HoverCard';
 
 describe('HoverCard controlled switch', () => {
     const hoverCard = (rootProps: Partial<React.ComponentProps<typeof HoverCard.Root>>) => (
-        <HoverCard.Root {...rootProps}>
+        <HoverCard.Root openDelay={0} closeDelay={0} {...rootProps}>
             <HoverCard.Trigger>Trigger</HoverCard.Trigger>
             <HoverCard.Content>Hover content</HoverCard.Content>
         </HoverCard.Root>
     );
 
-    test('switches from uncontrolled to controlled open', () => {
+    test('switches from uncontrolled to controlled open', async() => {
+        const user = userEvent.setup();
         const onOpenChange = jest.fn();
 
-        const { rerender } = render(hoverCard({ open: true }));
+        const { rerender } = render(hoverCard({}));
 
-        expect(screen.getByText('Hover content')).toBeInTheDocument();
+        await user.hover(screen.getByText('Trigger'));
+        await waitFor(() => {
+            expect(screen.getByText('Hover content')).toBeInTheDocument();
+        });
 
         rerender(hoverCard({ open: false, onOpenChange }));
         expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+
+        await user.hover(screen.getByText('Trigger'));
+        expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
     });
 
-    test('switches from controlled open to uncontrolled', () => {
+    test('switches from controlled open to uncontrolled', async() => {
+        const user = userEvent.setup();
+
         const { rerender } = render(hoverCard({ open: true }));
 
         expect(screen.getByText('Hover content')).toBeInTheDocument();
 
         rerender(hoverCard({}));
         expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+
+        await user.hover(screen.getByText('Trigger'));
+        await waitFor(() => {
+            expect(screen.getByText('Hover content')).toBeInTheDocument();
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Adds HoverCard controlled/uncontrolled switch tests

Related to #1825

## Test plan
- [x] npm test -- --testPathPatterns=HoverCard.controlledSwitch