### PR TITLE
test(collapsible): controlled/uncontrolled mode switching (#1825)

### DIFF
--- a/src/components/ui/Collapsible/tests/Collapsible.controlledSwitch.test.tsx
+++ b/src/components/ui/Collapsible/tests/Collapsible.controlledSwitch.test.tsx
@@ -27,15 +27,18 @@ describe('Collapsible controlled switch', () => {
         expect(onOpenChange).toHaveBeenCalledWith(true);
     });
 
-    test('switches from controlled open to uncontrolled defaultOpen', () => {
-        const { rerender } = render(collapsible({ defaultOpen: true }));
+    test('switches from controlled open to uncontrolled defaultOpen', async() => {
+        const user = userEvent.setup();
+
+        const { rerender } = render(collapsible({ open: true, onOpenChange: () => {} }));
 
         expect(screen.getByText('Panel')).toBeVisible();
 
-        rerender(collapsible({ open: false }));
+        rerender(collapsible({ open: false, onOpenChange: () => {} }));
         expect(screen.queryByText('Panel')).not.toBeInTheDocument();
 
         rerender(collapsible({ defaultOpen: true }));
+        await user.click(screen.getByText('Toggle'));
         expect(screen.getByText('Panel')).toBeVisible();
     });
 });

--- a/src/components/ui/Collapsible/tests/Collapsible.controlledSwitch.test.tsx
+++ b/src/components/ui/Collapsible/tests/Collapsible.controlledSwitch.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Collapsible from '../Collapsible';
+
+describe('Collapsible controlled switch', () => {
+    const collapsible = (rootProps: Partial<React.ComponentProps<typeof Collapsible.Root>>) => (
+        <Collapsible.Root {...rootProps}>
+            <Collapsible.Trigger>Toggle</Collapsible.Trigger>
+            <Collapsible.Content>Panel</Collapsible.Content>
+        </Collapsible.Root>
+    );
+
+    test('switches from uncontrolled defaultOpen to controlled open', async() => {
+        const user = userEvent.setup();
+        const onOpenChange = jest.fn();
+
+        const { rerender } = render(collapsible({ defaultOpen: true }));
+
+        expect(screen.getByText('Panel')).toBeVisible();
+
+        rerender(collapsible({ open: false, onOpenChange }));
+
+        expect(screen.queryByText('Panel')).not.toBeInTheDocument();
+
+        await user.click(screen.getByText('Toggle'));
+        expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    test('switches from controlled open to uncontrolled defaultOpen', () => {
+        const { rerender } = render(collapsible({ defaultOpen: true }));
+
+        expect(screen.getByText('Panel')).toBeVisible();
+
+        rerender(collapsible({ open: false }));
+        expect(screen.queryByText('Panel')).not.toBeInTheDocument();
+
+        rerender(collapsible({ defaultOpen: true }));
+        expect(screen.getByText('Panel')).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds Collapsible primitive controlled/uncontrolled switch tests

Related to #1825

## Test plan
- [x] npm test -- --testPathPatterns=Collapsible.controlledSwitch