### PR TITLE
test(tooltip): lazy mount behavior (#1847)

### DIFF
--- a/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Tooltip from '../Tooltip';
 
@@ -25,7 +25,11 @@ describe('Tooltip lazy mount', () => {
             </Tooltip.Root>
         );
 
-        await user.hover(screen.getByText('Hover me'));
-        expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+        await act(async() => {
+            await user.hover(screen.getByText('Hover me'));
+        });
+        await waitFor(() => {
+            expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Tooltip from '../Tooltip';
+
+describe('Tooltip lazy mount', () => {
+    test('does not mount tooltip content until opened', () => {
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content data-testid="tooltip-content">Tooltip label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content after hover opens the tooltip', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content>Tooltip label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        await user.hover(screen.getByText('Hover me'));
+        expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds Tooltip lazy mount tests

Related to #1847

## Test plan
- [x] npm test -- --testPathPatterns=Tooltip.lazyMount