### PR TITLE
test(hover-card): lazy mount behavior (#1847)

### DIFF
--- a/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HoverCard from '../HoverCard';
+
+describe('HoverCard lazy mount', () => {
+    test('does not mount content until opened', () => {
+        render(
+            <HoverCard.Root>
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Portal>
+                    <HoverCard.Content data-testid="hover-content">Hover body</HoverCard.Content>
+                </HoverCard.Portal>
+            </HoverCard.Root>
+        );
+
+        expect(screen.queryByTestId('hover-content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content when open', () => {
+        render(
+            <HoverCard.Root open>
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Portal>
+                    <HoverCard.Content>Hover body</HoverCard.Content>
+                </HoverCard.Portal>
+            </HoverCard.Root>
+        );
+
+        expect(screen.getByText('Hover body')).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
@@ -1,16 +1,33 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import Theme from '~/components/ui/Theme/Theme';
 import HoverCard from '../HoverCard';
 
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
 describe('HoverCard lazy mount', () => {
+    beforeEach(() => mockMatchMedia());
+
     test('does not mount content until opened', () => {
         render(
-            <HoverCard.Root>
-                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
-                <HoverCard.Portal>
-                    <HoverCard.Content data-testid="hover-content">Hover body</HoverCard.Content>
-                </HoverCard.Portal>
-            </HoverCard.Root>
+            <Theme>
+                <HoverCard.Root>
+                    <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                    <HoverCard.Portal>
+                        <HoverCard.Content data-testid="hover-content">Hover body</HoverCard.Content>
+                    </HoverCard.Portal>
+                </HoverCard.Root>
+            </Theme>
         );
 
         expect(screen.queryByTestId('hover-content')).not.toBeInTheDocument();
@@ -18,12 +35,14 @@ describe('HoverCard lazy mount', () => {
 
     test('mounts content when open', () => {
         render(
-            <HoverCard.Root open>
-                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
-                <HoverCard.Portal>
-                    <HoverCard.Content>Hover body</HoverCard.Content>
-                </HoverCard.Portal>
-            </HoverCard.Root>
+            <Theme>
+                <HoverCard.Root open>
+                    <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                    <HoverCard.Portal>
+                        <HoverCard.Content>Hover body</HoverCard.Content>
+                    </HoverCard.Portal>
+                </HoverCard.Root>
+            </Theme>
         );
 
         expect(screen.getByText('Hover body')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Adds HoverCard lazy mount tests

Related to #1847

## Test plan
- [x] npm test -- --testPathPatterns=HoverCard.lazyMount