### PR TITLE
fix(accordion): add --rad-accordion-content CSS variable aliases (#1917)

### DIFF
--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -31,6 +31,10 @@ const AccordionContent = React.forwardRef<React.ElementRef<'div'>, AccordionCont
                         'var(--radix-collapsible-content-height)',
                     ['--radix-accordion-content-width' as string]:
                         'var(--radix-collapsible-content-width)',
+                    ['--rad-accordion-content-height' as string]:
+                        'var(--rad-collapsible-content-height)',
+                    ['--rad-accordion-content-width' as string]:
+                        'var(--rad-collapsible-content-width)',
                     ...style
                 }}
                 {...props}

--- a/src/components/ui/Accordion/tests/Accordion.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.test.tsx
@@ -118,6 +118,12 @@ describe('Accordion Component', () => {
         expect(content.style.getPropertyValue('--radix-accordion-content-width')).toBe(
             'var(--radix-collapsible-content-width)'
         );
+        expect(content.style.getPropertyValue('--rad-accordion-content-height')).toBe(
+            'var(--rad-collapsible-content-height)'
+        );
+        expect(content.style.getPropertyValue('--rad-accordion-content-width')).toBe(
+            'var(--rad-collapsible-content-width)'
+        );
     });
 
     test('focus-visible styles use centralized focus ring aliases', () => {

--- a/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
+++ b/src/core/primitives/Collapsible/fragments/CollapsiblePrimitiveContent.tsx
@@ -155,6 +155,10 @@ const CollapsiblePrimitiveContent = React.forwardRef<
             heightRef.current !== undefined ? `${heightRef.current}px` : undefined,
         ['--radix-collapsible-content-width' as string]:
             widthRef.current !== undefined ? `${widthRef.current}px` : undefined,
+        ['--rad-collapsible-content-height' as string]:
+            heightRef.current !== undefined ? `${heightRef.current}px` : undefined,
+        ['--rad-collapsible-content-width' as string]:
+            widthRef.current !== undefined ? `${widthRef.current}px` : undefined,
         ...(transitionDuration > 0
             ? { transition: `height ${transitionDuration}ms ${transitionTimingFunction}` }
             : {})


### PR DESCRIPTION
## Summary
- Exposes --rad-collapsible-content-* on Collapsible primitive
- Adds --rad-accordion-content-* aliases on Accordion.Content
- Updates Accordion tests

Fixes #1917

## Test plan
- [x] npm test -- --testPathPatterns=Accordion.test