### PR TITLE
fix(Tooltip): portal via Theme refs without querySelector (#1100)

### DIFF
--- a/src/components/ui/Tooltip/fragments/TooltipContent.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipContent.tsx
@@ -33,11 +33,9 @@ const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentPro
         const { getFloatingProps } = interactions;
 
         const portalRoot = container
-            || themeContext?.portalRootRef.current
-            || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-            || themeContext?.containerRef.current
-            || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
-            || undefined;
+            ?? themeContext?.portalRootRef.current
+            ?? themeContext?.containerRef.current
+            ?? undefined;
 
         return (
             <FloatingPortal root={portalRoot}>

--- a/src/components/ui/Tooltip/tests/Tooltip.portal.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.portal.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Tooltip from '../Tooltip';
+import ThemeContext from '../../Theme/ThemeContext';
+
+describe('Tooltip portal', () => {
+    test('portals content into Theme portalRootRef when provided', async() => {
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content>Tooltip label</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+        expect(portalRoot).toContainElement(screen.getByText('Tooltip label'));
+
+        portalRoot.remove();
+    });
+
+    test('falls back to Theme containerRef when portalRootRef is unset', async() => {
+        const themeContainer = document.createElement('div');
+        document.body.appendChild(themeContainer);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: themeContainer },
+                    portalRootRef: { current: null }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content>Theme container tooltip</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(themeContainer).toContainElement(screen.getByText('Theme container tooltip'));
+
+        themeContainer.remove();
+    });
+
+    test('uses explicit container prop over Theme refs', async() => {
+        const explicitContainer = document.createElement('div');
+        document.body.appendChild(explicitContainer);
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <Tooltip.Root>
+                    <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                    <Tooltip.Content container={explicitContainer}>Explicit container tooltip</Tooltip.Content>
+                </Tooltip.Root>
+            </ThemeContext.Provider>
+        );
+
+        await userEvent.hover(screen.getByText('Hover me'));
+        expect(explicitContainer).toContainElement(screen.getByText('Explicit container tooltip'));
+        expect(portalRoot).not.toContainElement(screen.getByText('Explicit container tooltip'));
+
+        explicitContainer.remove();
+        portalRoot.remove();
+    });
+});


### PR DESCRIPTION
Removes document querySelector fallbacks from TooltipContent portal resolution and adds Theme portal tests.\n\nCloses #1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Tooltip positioning and container resolution logic

* **Tests**
  * Added comprehensive test coverage for Tooltip behavior in different container scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->