### PR TITLE
fix(Select): complete Theme portal fallback chain (#1100)

### DIFF
--- a/src/components/ui/Select/fragments/SelectPortal.tsx
+++ b/src/components/ui/Select/fragments/SelectPortal.tsx
@@ -13,7 +13,10 @@ type SelectPortalPrimitiveProps = React.ComponentPropsWithoutRef<typeof Combobox
 
 const SelectPortal = React.forwardRef<SelectPortalElement, SelectPortalPrimitiveProps>(({ children, container, ...props }, forwardedRef) => {
     const themeContext = useContext(ThemeContext);
-    const portalContainer = container ?? themeContext?.portalRootRef.current;
+    const portalContainer = container
+        ?? themeContext?.portalRootRef.current
+        ?? themeContext?.containerRef.current
+        ?? undefined;
 
     return (
         <ComboboxPrimitive.Portal ref={forwardedRef} container={portalContainer} {...props}>

--- a/src/components/ui/Select/tests/Select.portal.test.tsx
+++ b/src/components/ui/Select/tests/Select.portal.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Select from '../Select';
+import Theme from '~/components/ui/Theme/Theme';
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
+describe('Select portal', () => {
+    beforeEach(() => mockMatchMedia());
+
+    test('portals listbox into Theme portal root', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Theme>
+                <Select.Root>
+                    <Select.Trigger />
+                    <Select.Portal>
+                        <Select.Content>
+                            <Select.Item value="apple">Apple</Select.Item>
+                        </Select.Content>
+                    </Select.Portal>
+                </Select.Root>
+            </Theme>
+        );
+
+        const portalRoot = document.querySelector('[data-rad-ui-portal-root]') as HTMLElement;
+        expect(portalRoot).toBeTruthy();
+
+        await user.click(screen.getByRole('combobox'));
+        expect(portalRoot).toContainElement(screen.getByText('Apple'));
+    });
+});


### PR DESCRIPTION
SelectPortal now falls back through portalRootRef, containerRef, and document.body like other overlay components.\n\nCloses #1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Select component's portal container selection logic for better compatibility with different rendering contexts.

* **Tests**
  * Added comprehensive test coverage for Select portal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->