### PR TITLE
fix(Menu): merge consumer props into getItemProps (#806)

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitiveItem.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveItem.tsx
@@ -47,20 +47,19 @@ const MenuPrimitiveItem = forwardRef<HTMLButtonElement, MenuPrimitiveItemProps>(
                 ref={mergedRef}
                 tabIndex={isActive ? 0 : -1}
                 className={className}
-                {...getItemProps({
-                    onClick(event: React.MouseEvent<HTMLButtonElement>) {
-                        if (disabled) return;
-                        if (onSelect) {
-                            onSelect(event);
-                        } else {
-                            tree?.events.emit('click');
-                        }
+            {...getItemProps({
+                ...props,
+                disabled,
+                onClick(event: React.MouseEvent<HTMLButtonElement>) {
+                    if (disabled) return;
+                    if (onSelect) {
+                        onSelect(event);
+                    } else {
+                        tree?.events.emit('click');
                     }
-
-                })}
-                disabled={disabled}
-                asChild={asChild}
-                {...props}
+                }
+            })}
+            asChild={asChild}
             >
                 {children}
             </Primitive.button>

--- a/src/core/primitives/Menu/fragments/MenuPrimitiveItem.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveItem.tsx
@@ -41,25 +41,31 @@ const MenuPrimitiveItem = forwardRef<HTMLButtonElement, MenuPrimitiveItemProps>(
         if (!context) return null;
         const { activeIndex, getItemProps } = context;
         const isActive = activeIndex === index;
+        const { onClick: consumerOnClick, onKeyDown: consumerOnKeyDown, ...restProps } = props as React.ComponentPropsWithoutRef<'button'>;
 
         return (
             <Primitive.button
                 ref={mergedRef}
                 tabIndex={isActive ? 0 : -1}
                 className={className}
-            {...getItemProps({
-                ...props,
-                disabled,
-                onClick(event: React.MouseEvent<HTMLButtonElement>) {
-                    if (disabled) return;
-                    if (onSelect) {
-                        onSelect(event);
-                    } else {
-                        tree?.events.emit('click');
+                {...getItemProps({
+                    ...restProps,
+                    disabled,
+                    onClick(event: React.MouseEvent<HTMLButtonElement>) {
+                        if (disabled) return;
+                        consumerOnClick?.(event);
+                        if (event.defaultPrevented) return;
+                        if (onSelect) {
+                            onSelect(event);
+                        } else {
+                            tree?.events.emit('click');
+                        }
+                    },
+                    onKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+                        consumerOnKeyDown?.(event);
                     }
-                }
-            })}
-            asChild={asChild}
+                })}
+                asChild={asChild}
             >
                 {children}
             </Primitive.button>


### PR DESCRIPTION
MenuPrimitiveItem now spreads consumer props into getItemProps to preserve custom handlers and attributes.\n\nCloses #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Menu item interaction handling when items are disabled, including consistent keyboard behavior.
* **Refactor**
  * Updated Menu item prop handling to simplify how item event handlers and button properties are wired, while preserving existing click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->