### PR TITLE
fix(ScrollArea): reset scroll only on direct viewport child swaps (#1349)

### DIFF
--- a/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
@@ -53,8 +53,17 @@ const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({
         };
 
         const resizeObserver = new ResizeObserver(() => handleResize());
-        resizeObserver.observe(viewport);
-        Array.from(viewport.children).forEach(child => resizeObserver.observe(child));
+        const syncResizeObservers = () => {
+            resizeObserver.disconnect();
+            resizeObserver.observe(viewport);
+            Array.from(viewport.children).forEach(child => {
+                if (child instanceof Element) {
+                    resizeObserver.observe(child);
+                }
+            });
+        };
+
+        syncResizeObservers();
 
         const mutationObserver = new MutationObserver((mutations) => {
             const directChildSwap = mutations.some(
@@ -67,6 +76,7 @@ const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({
             if (directChildSwap) {
                 viewport.scrollTop = 0;
                 viewport.scrollLeft = 0;
+                syncResizeObservers();
             }
 
             handleResize();

--- a/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
+++ b/src/components/ui/ScrollArea/fragments/ScrollAreaRoot.tsx
@@ -56,13 +56,29 @@ const ScrollAreaRoot = forwardRef<ScrollAreaRootElement, ScrollAreaRootProps>(({
         resizeObserver.observe(viewport);
         Array.from(viewport.children).forEach(child => resizeObserver.observe(child));
 
-        const mutationObserver = new MutationObserver(() => {
+        const mutationObserver = new MutationObserver((mutations) => {
+            const directChildSwap = mutations.some(
+                (mutation) =>
+                    mutation.type === 'childList'
+                    && mutation.target === viewport
+                    && (mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0)
+            );
+
+            if (directChildSwap) {
+                viewport.scrollTop = 0;
+                viewport.scrollLeft = 0;
+            }
+
             handleResize();
+
+            if (directChildSwap) {
+                handleScroll();
+            }
         });
 
         mutationObserver.observe(viewport, {
             childList: true,
-            subtree: true
+            subtree: false
         });
 
         window.addEventListener('resize', handleResize);

--- a/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
+++ b/src/components/ui/ScrollArea/tests/ScrollArea.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import ScrollArea from '../ScrollArea';
 
@@ -175,5 +175,43 @@ describe('ScrollArea', () => {
         fireEvent.mouseEnter(screen.getByTestId('root'));
 
         expect(screen.getByTestId('scrollbar')).toHaveAttribute('data-state', 'visible');
+    });
+
+    test('resets scroll when direct viewport child is swapped, not on nested mutations', async() => {
+        const { rerender } = render(
+            <ScrollArea.Root style={{ height: 100 }}>
+                <ScrollArea.Viewport data-testid="viewport" style={{ height: 100, overflow: 'auto' }}>
+                    <div key="panel-a" data-testid="panel-a" style={{ height: 400 }}>Panel A</div>
+                </ScrollArea.Viewport>
+            </ScrollArea.Root>
+        );
+
+        const viewport = screen.getByTestId('viewport') as HTMLDivElement;
+        viewport.scrollTop = 120;
+
+        act(() => {
+            const nested = document.createElement('span');
+            nested.textContent = 'nested';
+            screen.getByTestId('panel-a').appendChild(nested);
+        });
+
+        expect(viewport.scrollTop).toBe(120);
+
+        rerender(
+            <ScrollArea.Root style={{ height: 100 }}>
+                <ScrollArea.Viewport data-testid="viewport" style={{ height: 100, overflow: 'auto' }}>
+                    <div key="panel-b" data-testid="panel-b" style={{ height: 400 }}>Panel B</div>
+                </ScrollArea.Viewport>
+            </ScrollArea.Root>
+        );
+
+        await act(async() => {
+            await Promise.resolve();
+        });
+
+        const nextViewport = screen.getByTestId('viewport') as HTMLDivElement;
+        await waitFor(() => {
+            expect(nextViewport.scrollTop).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
Scopes MutationObserver to viewport direct children (subtree: false) and resets scroll on panel swaps.\n\nCloses #1349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scroll areas now reset correctly when their main content is replaced, keeping scroll position and scrollbar behavior in sync.
  * Nested content updates no longer unexpectedly jump or reset the scroll position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->