### PR TITLE
test(Command): controlled/uncontrolled value switch (#1825)

### DIFF
--- a/src/components/ui/Command/tests/Command.controlledSwitch.test.tsx
+++ b/src/components/ui/Command/tests/Command.controlledSwitch.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Command from '../Command';
+
+describe('Command controlled switch', () => {
+    const command = (rootProps: Partial<React.ComponentProps<typeof Command.Root>>) => (
+        <Command.Root {...rootProps}>
+            <Command.Input placeholder="Search" />
+            <Command.List>
+                <Command.Item value="copy">Copy</Command.Item>
+                <Command.Item value="paste">Paste</Command.Item>
+            </Command.List>
+        </Command.Root>
+    );
+
+    const commandRoot = () => screen.getByRole('combobox').parentElement as HTMLElement;
+
+    test('switches from uncontrolled defaultValue to controlled value', () => {
+        const onValueChange = jest.fn();
+
+        const { rerender } = render(command({ defaultValue: 'copy' }));
+
+        expect(commandRoot()).toHaveAttribute('data-value', 'copy');
+
+        rerender(command({ value: 'paste', onValueChange }));
+
+        expect(commandRoot()).toHaveAttribute('data-value', 'paste');
+        expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    test('switches from controlled value to uncontrolled defaultValue', () => {
+        const { rerender } = render(command({ defaultValue: 'copy' }));
+
+        rerender(command({ value: 'paste' }));
+        expect(commandRoot()).toHaveAttribute('data-value', 'paste');
+
+        rerender(command({ defaultValue: 'copy' }));
+        expect(commandRoot()).toHaveAttribute('data-value', 'copy');
+    });
+});


### PR DESCRIPTION
Adds rerender tests for switching between defaultValue and controlled value on Command.Root.\n\nRelated to #1825