### PR TITLE
test(RadioCards): controlled/uncontrolled value switch (#1825)

### DIFF
--- a/src/components/ui/RadioCards/tests/RadioCards.controlledSwitch.test.tsx
+++ b/src/components/ui/RadioCards/tests/RadioCards.controlledSwitch.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import RadioCards from '../RadioCards';
+
+describe('RadioCards controlled switch', () => {
+    const radioCards = (rootProps: Partial<React.ComponentProps<typeof RadioCards.Root>>) => (
+        <RadioCards.Root name="plan" {...rootProps}>
+            <RadioCards.Item value="basic" data-testid="basic">Basic</RadioCards.Item>
+            <RadioCards.Item value="pro" data-testid="pro">Pro</RadioCards.Item>
+        </RadioCards.Root>
+    );
+
+    test('switches from uncontrolled defaultValue to controlled value', () => {
+        const onValueChange = jest.fn();
+
+        const { rerender } = render(radioCards({ defaultValue: 'basic' }));
+
+        expect(screen.getByTestId('basic')).toHaveAttribute('aria-checked', 'true');
+
+        rerender(radioCards({ value: 'pro', onValueChange }));
+
+        expect(screen.getByTestId('pro')).toHaveAttribute('aria-checked', 'true');
+
+        fireEvent.click(screen.getByTestId('basic'));
+        expect(onValueChange).toHaveBeenCalledWith('basic');
+    });
+
+    test('switches from controlled value to uncontrolled defaultValue', () => {
+        const { rerender } = render(radioCards({ defaultValue: 'basic' }));
+
+        rerender(radioCards({ value: 'pro' }));
+        expect(screen.getByTestId('pro')).toHaveAttribute('aria-checked', 'true');
+
+        rerender(radioCards({ defaultValue: 'basic' }));
+        expect(screen.getByTestId('basic')).toHaveAttribute('aria-checked', 'true');
+    });
+});


### PR DESCRIPTION
Adds rerender tests for switching between defaultValue and controlled value.\n\nRelated to #1825