### PR TITLE
fix(Dialog): merge consumer props into getReferenceProps (#806)

### DIFF
--- a/src/components/ui/Dialog/tests/Dialog.referenceProps.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.referenceProps.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DialogPrimitive from '~/core/primitives/Dialog';
+
+describe('Dialog reference props merge', () => {
+    test('preserves consumer onClick when opening', async() => {
+        const user = userEvent.setup();
+        const onClick = jest.fn();
+
+        render(
+            <DialogPrimitive.Root>
+                <DialogPrimitive.Trigger {...({ onClick } as object)}>Open</DialogPrimitive.Trigger>
+                <DialogPrimitive.Content>Dialog body</DialogPrimitive.Content>
+            </DialogPrimitive.Root>
+        );
+
+        await user.click(screen.getByText('Open'));
+        expect(onClick).toHaveBeenCalled();
+        expect(screen.getByText('Dialog body')).toBeInTheDocument();
+    });
+});

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveTrigger.tsx
@@ -19,6 +19,7 @@ const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTrig
     ...props
 }, ref) => {
     const { handleOpenChange, getReferenceProps, refs } = useContext(DialogPrimitiveContext);
+    const { onClick, ...restProps } = props as React.ComponentPropsWithoutRef<'button'>;
 
     const mergedRef = Floater.useMergeRefs([refs.setReference, ref]);
 
@@ -27,10 +28,17 @@ const DialogPrimitiveTrigger = forwardRef<HTMLButtonElement, DialogPrimitiveTrig
             ref={mergedRef}
             asChild={asChild}
             className={className}
-            disabled={disabled}
-            onClick={disabled ? undefined : () => handleOpenChange(true)}
-            {...getReferenceProps()}
-            {...props}
+            {...(getReferenceProps as (userProps?: Record<string, unknown>) => Record<string, unknown>)({
+                ...restProps,
+                disabled,
+                onClick(event: React.MouseEvent<HTMLButtonElement>) {
+                    if (disabled) return;
+                    onClick?.(event);
+                    if (!event.defaultPrevented) {
+                        handleOpenChange(true);
+                    }
+                }
+            })}
         >
             {children}
         </ButtonPrimitive>


### PR DESCRIPTION
DialogPrimitiveTrigger merges consumer handlers through getReferenceProps.\n\nFixes #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog triggers now respect custom click handlers while still opening the dialog when appropriate.
  * Prevented opening when the trigger is disabled or when a user-provided click handler cancels the event.

* **Tests**
  * Added coverage for dialog trigger prop handling and click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->