### PR TITLE
fix(Dialog): merge consumer props into getFloatingProps (#806)

### DIFF
--- a/src/components/ui/Dialog/tests/Dialog.floatingProps.test.tsx
+++ b/src/components/ui/Dialog/tests/Dialog.floatingProps.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DialogPrimitive from '~/core/primitives/Dialog';
+
+describe('Dialog floating props merge', () => {
+    test('preserves consumer onKeyDown on content', async() => {
+        const user = userEvent.setup();
+        const onKeyDown = jest.fn();
+
+        render(
+            <DialogPrimitive.Root open>
+                <DialogPrimitive.Trigger>Open</DialogPrimitive.Trigger>
+                <DialogPrimitive.Content onKeyDown={onKeyDown} data-testid="content">
+                    Dialog body
+                </DialogPrimitive.Content>
+            </DialogPrimitive.Root>
+        );
+
+        const content = screen.getByTestId('content');
+        content.focus();
+        await user.keyboard('{Escape}');
+        expect(onKeyDown).toHaveBeenCalled();
+    });
+});

--- a/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
+++ b/src/core/primitives/Dialog/fragments/DialogPrimitiveContent.tsx
@@ -101,19 +101,23 @@ const DialogPrimitiveContent = forwardRef<HTMLDivElement, DialogPrimitiveContent
 
         return result;
     }, [initialFocus]);
+    const consumerStyle = (props as React.HTMLAttributes<HTMLDivElement>).style;
+    const restProps = { ...props } as Record<string, unknown>;
+    delete restProps.style;
     const content = (
         <Primitive.div
             ref={mergedRef}
             asChild={asChild}
-            {...getFloatingProps()}
-            style={{ outline: 'none', ...styleProp }}
-            role={role}
-            aria-hidden={!isOpen ? 'true' : undefined}
-            aria-labelledby={isOpen ? ariaLabelledBy : undefined}
-            aria-describedby={isOpen ? ariaDescribedBy : undefined}
-            data-state={dataState}
-            aria-modal={ariaModal}
-            {...props}
+            {...(getFloatingProps as (userProps?: Record<string, unknown>) => Record<string, unknown>)({
+                ...restProps,
+                style: { outline: 'none', ...styleProp, ...consumerStyle },
+                role,
+                'aria-hidden': !isOpen ? 'true' : undefined,
+                'aria-labelledby': isOpen ? ariaLabelledBy : undefined,
+                'aria-describedby': isOpen ? ariaDescribedBy : undefined,
+                'data-state': dataState,
+                'aria-modal': ariaModal
+            })}
         >
             {children}
         </Primitive.div>


### PR DESCRIPTION
DialogPrimitiveContent merges consumer handlers through getFloatingProps.\n\nFixes #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog behavior so consumer-provided keyboard handlers are preserved and still run as expected.
  * Fixed dialog prop merging to better combine custom styles and accessibility attributes without overwriting user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->