### PR TITLE
fix(Combobox): merge consumer props into getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
+++ b/src/core/primitives/Combobox/fragments/ComboboxPrimitiveContent.tsx
@@ -56,26 +56,27 @@ const ComboboxPrimitiveContent = React.forwardRef<
                     <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef} >
                         <div
                             ref={mergedRef}
-                            style={{
-                                ...floatingStyles,
-                                ...style,
-                                '--rad-ui-floating-transform-origin': placementState.transformOrigin,
-                                visibility: !isPositioned && shouldHideUntilPositioned
-                                    ? 'hidden'
-                                    : middlewareData.hide?.referenceHidden
+                            {...(getFloatingProps as (userProps?: Record<string, unknown>) => Record<string, unknown>)({
+                                ...props,
+                                className,
+                                style: {
+                                    ...floatingStyles,
+                                    ...style,
+                                    '--rad-ui-floating-transform-origin': placementState.transformOrigin,
+                                    visibility: !isPositioned && shouldHideUntilPositioned
                                         ? 'hidden'
-                                        : (style?.visibility || floatingStyles.visibility),
-                                pointerEvents: middlewareData.hide?.referenceHidden
-                                    ? 'none'
-                                    : style?.pointerEvents
-                            }}
-                            className={className}
-                            data-state={isOpen ? 'open' : 'closed'}
-                            data-side={placementState.side}
-                            data-align={placementState.align}
-                            data-positioned={isPositioned ? '' : undefined}
-                            {...getFloatingProps()}
-                            {...props}
+                                        : middlewareData.hide?.referenceHidden
+                                            ? 'hidden'
+                                            : (style?.visibility || floatingStyles.visibility),
+                                    pointerEvents: middlewareData.hide?.referenceHidden
+                                        ? 'none'
+                                        : style?.pointerEvents
+                                },
+                                'data-state': isOpen ? 'open' : 'closed',
+                                'data-side': placementState.side,
+                                'data-align': placementState.align,
+                                'data-positioned': isPositioned ? '' : undefined
+                            })}
                         >
 
                             {children}

--- a/src/core/primitives/Combobox/tests/ComboboxPrimitive.floatingProps.test.tsx
+++ b/src/core/primitives/Combobox/tests/ComboboxPrimitive.floatingProps.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Combobox from '~/components/ui/Combobox/Combobox';
+
+describe('Combobox floating props merge', () => {
+    test('preserves consumer data-testid on content', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Combobox.Root>
+                <Combobox.Trigger>Choose</Combobox.Trigger>
+                <Combobox.Portal>
+                    <Combobox.Content data-testid="combobox-content">
+                        <Combobox.Group>
+                            <Combobox.Item value="apple">Apple</Combobox.Item>
+                        </Combobox.Group>
+                    </Combobox.Content>
+                </Combobox.Portal>
+            </Combobox.Root>
+        );
+
+        await user.click(screen.getByText('Choose'));
+        expect(screen.getByTestId('combobox-content')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
ComboboxPrimitiveContent merges consumer props through getFloatingProps.\n\nFixes #806