### PR TITLE
test(AlertDialog): lazy mount dialog content (#1847)

### DIFF
--- a/src/components/ui/AlertDialog/tests/AlertDialog.lazyMount.test.tsx
+++ b/src/components/ui/AlertDialog/tests/AlertDialog.lazyMount.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AlertDialog from '../AlertDialog';
+
+describe('AlertDialog lazy mount', () => {
+    test('does not mount dialog content until opened', () => {
+        render(
+            <AlertDialog.Root>
+                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                <AlertDialog.Content data-testid="alert-content">
+                    <AlertDialog.Title>Title</AlertDialog.Title>
+                    <AlertDialog.Description>Description</AlertDialog.Description>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(screen.queryByTestId('alert-content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content when open', () => {
+        render(
+            <AlertDialog.Root open>
+                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                <AlertDialog.Content>
+                    <AlertDialog.Title>Title</AlertDialog.Title>
+                    <AlertDialog.Description>Description</AlertDialog.Description>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        );
+
+        expect(screen.getByText('Description')).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/AlertDialog/tests/AlertDialog.lazyMount.test.tsx
+++ b/src/components/ui/AlertDialog/tests/AlertDialog.lazyMount.test.tsx
@@ -1,17 +1,36 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import Theme from '~/components/ui/Theme/Theme';
 import AlertDialog from '../AlertDialog';
 
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
 describe('AlertDialog lazy mount', () => {
+    beforeEach(() => mockMatchMedia());
+
     test('does not mount dialog content until opened', () => {
         render(
-            <AlertDialog.Root>
-                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
-                <AlertDialog.Content data-testid="alert-content">
-                    <AlertDialog.Title>Title</AlertDialog.Title>
-                    <AlertDialog.Description>Description</AlertDialog.Description>
-                </AlertDialog.Content>
-            </AlertDialog.Root>
+            <Theme>
+                <AlertDialog.Root>
+                    <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                    <AlertDialog.Portal>
+                        <AlertDialog.Content data-testid="alert-content">
+                            <AlertDialog.Title>Title</AlertDialog.Title>
+                            <AlertDialog.Description>Description</AlertDialog.Description>
+                        </AlertDialog.Content>
+                    </AlertDialog.Portal>
+                </AlertDialog.Root>
+            </Theme>
         );
 
         expect(screen.queryByTestId('alert-content')).not.toBeInTheDocument();
@@ -19,13 +38,17 @@ describe('AlertDialog lazy mount', () => {
 
     test('mounts content when open', () => {
         render(
-            <AlertDialog.Root open>
-                <AlertDialog.Trigger>Open</AlertDialog.Trigger>
-                <AlertDialog.Content>
-                    <AlertDialog.Title>Title</AlertDialog.Title>
-                    <AlertDialog.Description>Description</AlertDialog.Description>
-                </AlertDialog.Content>
-            </AlertDialog.Root>
+            <Theme>
+                <AlertDialog.Root open>
+                    <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+                    <AlertDialog.Portal>
+                        <AlertDialog.Content>
+                            <AlertDialog.Title>Title</AlertDialog.Title>
+                            <AlertDialog.Description>Description</AlertDialog.Description>
+                        </AlertDialog.Content>
+                    </AlertDialog.Portal>
+                </AlertDialog.Root>
+            </Theme>
         );
 
         expect(screen.getByText('Description')).toBeInTheDocument();


### PR DESCRIPTION
Adds tests verifying alert dialog content is not mounted until opened.\n\nRelated to #1847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for dialog lazy-mount behavior.
  * Verified dialog content stays out of the page until opened, and appears when the dialog is open.
  * Stabilized dialog rendering in tests for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->