### PR TITLE
fix(Menu): merge consumer props into getFloatingProps (#806)

### DIFF
--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -25,6 +25,10 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
             floatingContext
         } = context;
 
+        const consumerStyle = (props as React.HTMLAttributes<HTMLDivElement>).style;
+        const restProps = { ...props } as Record<string, unknown>;
+        delete restProps.style;
+
         return (
             <>
             <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
@@ -37,9 +41,9 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
                     <div
                         ref={mergedRef}
                         {...(getFloatingProps as (userProps?: Record<string, unknown>) => Record<string, unknown>)({
-                            ...props,
+                            ...restProps,
                             className,
-                            style: floatingStyles
+                            style: { ...consumerStyle, ...floatingStyles }
                         })}
                     >
                         <div style={{overflowY:"auto", overflowX:"hidden"}}>

--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -36,10 +36,11 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
                 >         
                     <div
                         ref={mergedRef}
-                        style={floatingStyles}
-                        {...getFloatingProps()}
-                        className={className}
-                        {...props}
+                        {...(getFloatingProps as (userProps?: Record<string, unknown>) => Record<string, unknown>)({
+                            ...props,
+                            className,
+                            style: floatingStyles
+                        })}
                     >
                         <div style={{overflowY:"auto", overflowX:"hidden"}}>
                         {children}

--- a/src/core/primitives/Menu/tests/MenuPrimitive.floatingProps.test.tsx
+++ b/src/core/primitives/Menu/tests/MenuPrimitive.floatingProps.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MenuPrimitive from '~/core/primitives/Menu/MenuPrimitive';
+
+describe('Menu floating props merge', () => {
+    test('preserves consumer onKeyDown on menu content', async() => {
+        const user = userEvent.setup();
+        const onKeyDown = jest.fn();
+
+        render(
+            <MenuPrimitive.Root defaultOpen>
+                <MenuPrimitive.Trigger>Open</MenuPrimitive.Trigger>
+                <MenuPrimitive.Portal>
+                    <MenuPrimitive.Content {...({ onKeyDown, 'data-testid': 'menu-content' } as object)}>
+                        <MenuPrimitive.Item label="Profile">Profile</MenuPrimitive.Item>
+                    </MenuPrimitive.Content>
+                </MenuPrimitive.Portal>
+            </MenuPrimitive.Root>
+        );
+
+        const content = screen.getByTestId('menu-content');
+        content.focus();
+        await user.keyboard('{ArrowDown}');
+        expect(onKeyDown).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
MenuPrimitiveContent merges consumer props through getFloatingProps.\n\nFixes #806