### PR TITLE
fix(HoverCard): portal via Theme refs without querySelector (#1100)

### DIFF
--- a/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
@@ -21,9 +21,6 @@ const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>
         const resolvedRoot = explicitRoot
             || themeContext?.portalRootRef.current
             || themeContext?.containerRef.current
-            || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-            || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
-            || document.getElementsByClassName(rootTriggerClass)[0] as HTMLElement | undefined
             || document.body;
 
         setRootElem(resolvedRoot);

--- a/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HoverCard from '../HoverCard';
+import ThemeContext from '../../Theme/ThemeContext';
+
+describe('HoverCard portal', () => {
+    test('portals content into Theme portalRootRef when provided', async() => {
+        const portalRoot = document.createElement('div');
+        document.body.appendChild(portalRoot);
+
+        render(
+            <ThemeContext.Provider
+                value={{
+                    containerRef: { current: null },
+                    portalRootRef: { current: portalRoot }
+                }}>
+                <HoverCard.Root open>
+                    <HoverCard.Trigger>Hover me</HoverCard.Trigger>
+                    <HoverCard.Portal>
+                        <HoverCard.Content>Hover label</HoverCard.Content>
+                    </HoverCard.Portal>
+                </HoverCard.Root>
+            </ThemeContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(portalRoot).toContainElement(screen.getByText('Hover label'));
+        });
+
+        portalRoot.remove();
+    });
+});


### PR DESCRIPTION
Removes querySelector fallbacks from HoverCardPortal.\n\nFixes #1100