### PR TITLE
test(HoverCard): controlled/uncontrolled open switch (#1825)

### DIFF
--- a/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.controlledSwitch.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HoverCard from '../HoverCard';
+
+describe('HoverCard controlled switch', () => {
+    const hoverCard = (rootProps: Partial<React.ComponentProps<typeof HoverCard.Root>>) => (
+        <HoverCard.Root {...rootProps}>
+            <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+            <HoverCard.Content>Hover content</HoverCard.Content>
+        </HoverCard.Root>
+    );
+
+    test('switches from uncontrolled to controlled open', () => {
+        const onOpenChange = jest.fn();
+
+        const { rerender } = render(hoverCard({ open: true }));
+
+        expect(screen.getByText('Hover content')).toBeInTheDocument();
+
+        rerender(hoverCard({ open: false, onOpenChange }));
+        expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+    });
+
+    test('switches from controlled open to uncontrolled', () => {
+        const { rerender } = render(hoverCard({ open: true }));
+
+        expect(screen.getByText('Hover content')).toBeInTheDocument();
+
+        rerender(hoverCard({}));
+        expect(screen.queryByText('Hover content')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Adds rerender tests for switching between controlled and uncontrolled open.\n\nRelated to #1825