### PR TITLE
test(Tooltip): lazy mount tooltip content (#1847)

### DIFF
--- a/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.lazyMount.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Tooltip from '../Tooltip';
+
+describe('Tooltip lazy mount', () => {
+    test('does not mount tooltip content until opened', () => {
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content data-testid="tooltip-content">Tooltip label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content after hover opens the tooltip', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Tooltip.Root>
+                <Tooltip.Trigger>Hover me</Tooltip.Trigger>
+                <Tooltip.Content>Tooltip label</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        await user.hover(screen.getByText('Hover me'));
+        expect(screen.getByText('Tooltip label')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Adds tests verifying tooltip content is not mounted until opened.\n\nRelated to #1847