### PR TITLE
test(HoverCard): lazy mount overlay content (#1847)

### DIFF
--- a/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.lazyMount.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HoverCard from '../HoverCard';
+
+describe('HoverCard lazy mount', () => {
+    test('does not mount content until opened', () => {
+        render(
+            <HoverCard.Root>
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Portal>
+                    <HoverCard.Content data-testid="hover-content">Hover body</HoverCard.Content>
+                </HoverCard.Portal>
+            </HoverCard.Root>
+        );
+
+        expect(screen.queryByTestId('hover-content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content when open', () => {
+        render(
+            <HoverCard.Root open>
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Portal>
+                    <HoverCard.Content>Hover body</HoverCard.Content>
+                </HoverCard.Portal>
+            </HoverCard.Root>
+        );
+
+        expect(screen.getByText('Hover body')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Adds tests verifying hover card content is not mounted until opened.\n\nRelated to #1847