### PR TITLE
test(CheckboxGroup): controlled/uncontrolled value switch (#1825)

### DIFF
--- a/src/components/ui/CheckboxGroup/tests/CheckboxGroup.controlledSwitch.test.tsx
+++ b/src/components/ui/CheckboxGroup/tests/CheckboxGroup.controlledSwitch.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CheckboxGroup from '../CheckboxGroup';
+
+describe('CheckboxGroup controlled switch', () => {
+    const items = (
+        <>
+            <CheckboxGroup.Label>
+                <CheckboxGroup.Trigger value="apple">
+                    <CheckboxGroup.Indicator />
+                </CheckboxGroup.Trigger>
+                Apple
+            </CheckboxGroup.Label>
+            <CheckboxGroup.Label>
+                <CheckboxGroup.Trigger value="banana">
+                    <CheckboxGroup.Indicator />
+                </CheckboxGroup.Trigger>
+                Banana
+            </CheckboxGroup.Label>
+        </>
+    );
+
+    const group = (rootProps: Partial<React.ComponentProps<typeof CheckboxGroup.Root>>) => (
+        <CheckboxGroup.Root name="fruits" {...rootProps}>
+            {items}
+        </CheckboxGroup.Root>
+    );
+
+    test('switches from uncontrolled defaultValue to controlled value', async() => {
+        const user = userEvent.setup();
+        const onValueChange = jest.fn();
+
+        const { rerender } = render(group({ defaultValue: ['apple'] }));
+
+        expect(screen.getByRole('checkbox', { name: 'Apple' })).toHaveAttribute('aria-checked', 'true');
+
+        rerender(group({ value: ['banana'], onValueChange }));
+
+        expect(screen.getByRole('checkbox', { name: 'Banana' })).toHaveAttribute('aria-checked', 'true');
+
+        await user.click(screen.getByRole('checkbox', { name: 'Apple' }));
+        expect(onValueChange).toHaveBeenCalledWith(['banana', 'apple']);
+    });
+
+    test('switches from controlled value to uncontrolled defaultValue', async() => {
+        const user = userEvent.setup();
+
+        const { unmount } = render(group({ value: ['banana'], onValueChange: () => {} }));
+
+        expect(screen.getByRole('checkbox', { name: 'Banana' })).toHaveAttribute('aria-checked', 'true');
+        unmount();
+
+        render(group({ defaultValue: ['apple'] }));
+
+        expect(screen.getByRole('checkbox', { name: 'Apple' })).toHaveAttribute('aria-checked', 'true');
+
+        await user.click(screen.getByRole('checkbox', { name: 'Banana' }));
+        expect(screen.getByRole('checkbox', { name: 'Banana' })).toHaveAttribute('aria-checked', 'true');
+    });
+});


### PR DESCRIPTION
## Summary
add controlled/uncontrolled value switch regression tests

## Test plan
- [x] Related unit tests pass locally

Related to #1825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for `CheckboxGroup` switching between uncontrolled and controlled states.
  * Verified that selected items update correctly after rerendering with new selection values.
  * Confirmed click interactions continue to report the expected combined selection when choices change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->