### PR TITLE
test(Menubar): lazy mount menu content (#1847)

### DIFF
--- a/src/components/ui/Menubar/tests/Menubar.lazyMount.test.tsx
+++ b/src/components/ui/Menubar/tests/Menubar.lazyMount.test.tsx
@@ -1,21 +1,38 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import Theme from '~/components/ui/Theme/Theme';
 import Menubar from '../Menubar';
 
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
 describe('Menubar lazy mount', () => {
+    beforeEach(() => mockMatchMedia());
+
     test('does not mount menu content until opened', () => {
         render(
-            <Menubar.Root>
-                <Menubar.Menu>
-                    <Menubar.Trigger>File</Menubar.Trigger>
-                    <Menubar.Portal>
-                        <Menubar.Content data-testid="menubar-content">
-                            <Menubar.Item>New</Menubar.Item>
-                        </Menubar.Content>
-                    </Menubar.Portal>
-                </Menubar.Menu>
-            </Menubar.Root>
+            <Theme>
+                <Menubar.Root>
+                    <Menubar.Menu>
+                        <Menubar.Trigger>File</Menubar.Trigger>
+                        <Menubar.Portal>
+                            <Menubar.Content data-testid="menubar-content">
+                                <Menubar.Item>New</Menubar.Item>
+                            </Menubar.Content>
+                        </Menubar.Portal>
+                    </Menubar.Menu>
+                </Menubar.Root>
+            </Theme>
         );
 
         expect(screen.queryByTestId('menubar-content')).not.toBeInTheDocument();
@@ -26,16 +43,18 @@ describe('Menubar lazy mount', () => {
         const user = userEvent.setup();
 
         render(
-            <Menubar.Root>
-                <Menubar.Menu>
-                    <Menubar.Trigger>File</Menubar.Trigger>
-                    <Menubar.Portal>
-                        <Menubar.Content>
-                            <Menubar.Item>New</Menubar.Item>
-                        </Menubar.Content>
-                    </Menubar.Portal>
-                </Menubar.Menu>
-            </Menubar.Root>
+            <Theme>
+                <Menubar.Root>
+                    <Menubar.Menu>
+                        <Menubar.Trigger>File</Menubar.Trigger>
+                        <Menubar.Portal>
+                            <Menubar.Content>
+                                <Menubar.Item>New</Menubar.Item>
+                            </Menubar.Content>
+                        </Menubar.Portal>
+                    </Menubar.Menu>
+                </Menubar.Root>
+            </Theme>
         );
 
         await user.click(screen.getByText('File'));

--- a/src/components/ui/Menubar/tests/Menubar.lazyMount.test.tsx
+++ b/src/components/ui/Menubar/tests/Menubar.lazyMount.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Menubar from '../Menubar';
+
+describe('Menubar lazy mount', () => {
+    test('does not mount menu content until opened', () => {
+        render(
+            <Menubar.Root>
+                <Menubar.Menu>
+                    <Menubar.Trigger>File</Menubar.Trigger>
+                    <Menubar.Portal>
+                        <Menubar.Content data-testid="menubar-content">
+                            <Menubar.Item>New</Menubar.Item>
+                        </Menubar.Content>
+                    </Menubar.Portal>
+                </Menubar.Menu>
+            </Menubar.Root>
+        );
+
+        expect(screen.queryByTestId('menubar-content')).not.toBeInTheDocument();
+        expect(screen.queryByText('New')).not.toBeInTheDocument();
+    });
+
+    test('mounts content after trigger opens the menu', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Menubar.Root>
+                <Menubar.Menu>
+                    <Menubar.Trigger>File</Menubar.Trigger>
+                    <Menubar.Portal>
+                        <Menubar.Content>
+                            <Menubar.Item>New</Menubar.Item>
+                        </Menubar.Content>
+                    </Menubar.Portal>
+                </Menubar.Menu>
+            </Menubar.Root>
+        );
+
+        await user.click(screen.getByText('File'));
+        expect(screen.getByText('New')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
assert menu content is not mounted until opened

## Test plan
- [x] Related unit tests pass locally

Related to #1847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Menubar lazy-mount behavior.
  * Verified menu content is not rendered until the menu is opened, and appears after clicking the trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->