### PR TITLE
test(NavigationMenu): lazy mount panel content (#1847)

### DIFF
--- a/src/components/ui/NavigationMenu/tests/NavigationMenu.lazyMount.test.tsx
+++ b/src/components/ui/NavigationMenu/tests/NavigationMenu.lazyMount.test.tsx
@@ -1,38 +1,59 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import Theme from '~/components/ui/Theme/Theme';
 import NavigationMenu from '../NavigationMenu';
 
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
 describe('NavigationMenu lazy mount', () => {
+    beforeEach(() => mockMatchMedia());
+
     test('does not mount panel content until opened', () => {
         render(
-            <NavigationMenu.Root>
-                <NavigationMenu.Item value="item1">
-                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
-                    <NavigationMenu.Content data-testid="nav-content">
-                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
-                    </NavigationMenu.Content>
-                </NavigationMenu.Item>
-            </NavigationMenu.Root>
+            <Theme>
+                <NavigationMenu.Root>
+                    <NavigationMenu.Item value="item1">
+                        <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                        <NavigationMenu.Content data-testid="nav-content">
+                            <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                        </NavigationMenu.Content>
+                    </NavigationMenu.Item>
+                </NavigationMenu.Root>
+            </Theme>
         );
 
         expect(screen.queryByTestId('nav-content')).not.toBeInTheDocument();
         expect(screen.queryByText('Item 1 Content')).not.toBeInTheDocument();
     });
 
-    test('mounts content after trigger opens the panel', () => {
+    test('mounts content after trigger opens the panel', async() => {
+        const user = userEvent.setup({ skipHover: true });
+
         render(
-            <NavigationMenu.Root>
-                <NavigationMenu.Item value="item1">
-                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
-                    <NavigationMenu.Content>
-                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
-                    </NavigationMenu.Content>
-                </NavigationMenu.Item>
-            </NavigationMenu.Root>
+            <Theme>
+                <NavigationMenu.Root>
+                    <NavigationMenu.Item value="item1">
+                        <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                        <NavigationMenu.Content>
+                            <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                        </NavigationMenu.Content>
+                    </NavigationMenu.Item>
+                </NavigationMenu.Root>
+            </Theme>
         );
 
-        fireEvent.click(screen.getByText('Open'));
-        expect(screen.getByText('Item 1 Content')).toBeInTheDocument();
+        await user.click(screen.getByText('Open'));
+        await waitFor(() => expect(screen.getByText('Item 1 Content')).toBeInTheDocument());
     });
 });

--- a/src/components/ui/NavigationMenu/tests/NavigationMenu.lazyMount.test.tsx
+++ b/src/components/ui/NavigationMenu/tests/NavigationMenu.lazyMount.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NavigationMenu from '../NavigationMenu';
+
+describe('NavigationMenu lazy mount', () => {
+    test('does not mount panel content until opened', () => {
+        render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content data-testid="nav-content">
+                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        expect(screen.queryByTestId('nav-content')).not.toBeInTheDocument();
+        expect(screen.queryByText('Item 1 Content')).not.toBeInTheDocument();
+    });
+
+    test('mounts content after trigger opens the panel', () => {
+        render(
+            <NavigationMenu.Root>
+                <NavigationMenu.Item value="item1">
+                    <NavigationMenu.Trigger>Open</NavigationMenu.Trigger>
+                    <NavigationMenu.Content>
+                        <NavigationMenu.Link href="#">Item 1 Content</NavigationMenu.Link>
+                    </NavigationMenu.Content>
+                </NavigationMenu.Item>
+            </NavigationMenu.Root>
+        );
+
+        fireEvent.click(screen.getByText('Open'));
+        expect(screen.getByText('Item 1 Content')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
assert panel content is not mounted until opened

## Test plan
- [x] Related unit tests pass locally

Related to #1847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for navigation menu lazy loading behavior.
  * Verified that menu panel content is not shown until the menu is opened.
  * Confirmed that opening the trigger displays the expected content in the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->