### PR TITLE
test(Popover): pointer and keyboard hybrid interaction (#1814)

### DIFF
--- a/src/components/ui/Popover/tests/Popover.hybridInteraction.test.tsx
+++ b/src/components/ui/Popover/tests/Popover.hybridInteraction.test.tsx
@@ -40,7 +40,7 @@ describe('Popover hybrid interaction', () => {
 
         await user.keyboard('{Escape}');
         await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-        expect(trigger).toHaveFocus();
+        await waitFor(() => expect(trigger).toHaveFocus());
     });
 
     test('keyboard open via Space then pointer click on close dismisses', async() => {

--- a/src/components/ui/Popover/tests/Popover.hybridInteraction.test.tsx
+++ b/src/components/ui/Popover/tests/Popover.hybridInteraction.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Popover from '../Popover';
+import Theme from '~/components/ui/Theme/Theme';
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
+describe('Popover hybrid interaction', () => {
+    beforeEach(() => mockMatchMedia());
+
+    test('pointer open then escape closes popover', async() => {
+        const user = userEvent.setup();
+        render(
+            <Theme>
+                <Popover.Root>
+                    <Popover.Trigger>Open</Popover.Trigger>
+                    <Popover.Portal>
+                        <Popover.Content>
+                            <button type="button">First</button>
+                        </Popover.Content>
+                    </Popover.Portal>
+                </Popover.Root>
+            </Theme>
+        );
+
+        const trigger = screen.getByText('Open');
+        await user.click(trigger);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        await user.keyboard('{Escape}');
+        await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+        expect(trigger).toHaveFocus();
+    });
+
+    test('keyboard open via Space then pointer click on close dismisses', async() => {
+        const user = userEvent.setup();
+        render(
+            <Theme>
+                <Popover.Root>
+                    <Popover.Trigger>Open</Popover.Trigger>
+                    <Popover.Portal>
+                        <Popover.Content>
+                            Body
+                            <Popover.Close>Close</Popover.Close>
+                        </Popover.Content>
+                    </Popover.Portal>
+                </Popover.Root>
+            </Theme>
+        );
+
+        const trigger = screen.getByText('Open');
+        trigger.focus();
+        await user.keyboard(' ');
+
+        await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+
+        await user.click(screen.getByText('Close'));
+        await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    });
+});


### PR DESCRIPTION
## Summary
cover mixed pointer and keyboard interaction paths

## Test plan
- [x] Related unit tests pass locally

Related to #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Popover hybrid interactions, including mouse and keyboard opening flows.
  * Verified Escape key dismissal returns focus to the trigger.
  * Verified closing via the Popover control removes the dialog.
  * Improved test stability by mocking responsive media-query behavior in browser-like test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->