### PR TITLE
fix(HoverCard): portal via Theme refs without querySelector (#1100)

### DIFF
--- a/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardPortal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState, forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import Floater from '~/core/primitives/Floater';
-import HoverCardContext from '../contexts/HoverCardContext';
 import ThemeContext from '~/components/ui/Theme/ThemeContext';
 
 export type HoverCardPortalElement = ElementRef<typeof Floater.Portal>;
@@ -9,7 +8,6 @@ export type HoverCardPortalProps = ComponentPropsWithoutRef<typeof Floater.Porta
 };
 
 const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>(({ children, rootElement, ...props }, ref) => {
-    const { rootTriggerClass } = useContext(HoverCardContext);
     const themeContext = useContext(ThemeContext);
     const [rootElem, setRootElem] = useState<HTMLElement | null>(null);
 
@@ -21,22 +19,20 @@ const HoverCardPortal = forwardRef<HoverCardPortalElement, HoverCardPortalProps>
         const resolvedRoot = explicitRoot
             || themeContext?.portalRootRef.current
             || themeContext?.containerRef.current
-            || document.querySelector('[data-rad-ui-portal-root]') as HTMLElement | null
-            || document.querySelector('#rad-ui-theme-container') as HTMLElement | null
-            || document.getElementsByClassName(rootTriggerClass)[0] as HTMLElement | undefined
             || document.body;
 
         setRootElem(resolvedRoot);
-    }, [rootElement, rootTriggerClass, themeContext]);
+    }, [rootElement, themeContext]);
 
     if (!rootElem) {
         return null;
     }
 
-    return <Floater.Portal
-        root={rootElem}
-        {...props}
-    >{children}</Floater.Portal>;
+    return (
+        <Floater.Portal root={rootElem} {...props}>
+            {children}
+        </Floater.Portal>
+    );
 });
 
 HoverCardPortal.displayName = 'HoverCardPortal';

--- a/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.portal.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HoverCard from '../HoverCard';
+import Theme from '~/components/ui/Theme/Theme';
+
+const mockMatchMedia = () => {
+    if ('matchMedia' in window && typeof window.matchMedia === 'function') return;
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        }))
+    });
+};
+
+describe('HoverCard portal', () => {
+    beforeEach(() => mockMatchMedia());
+
+    test('portals content into Theme portal root', async() => {
+        const user = userEvent.setup();
+
+        render(
+            <Theme>
+                <HoverCard.Root openDelay={0} closeDelay={0}>
+                    <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                    <HoverCard.Portal>
+                        <HoverCard.Content>Portaled</HoverCard.Content>
+                    </HoverCard.Portal>
+                </HoverCard.Root>
+            </Theme>
+        );
+
+        const portalRoot = document.querySelector('[data-rad-ui-portal-root]');
+        expect(portalRoot).not.toBeNull();
+
+        await act(async() => {
+            await user.hover(screen.getByText('Trigger'));
+        });
+
+        await waitFor(() => {
+            const content = screen.getByText('Portaled');
+            expect(portalRoot?.contains(content)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
resolve portal container from ThemeContext refs instead of querySelector

## Test plan
- [x] Related unit tests pass locally

Fixes #1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved where the hover card content is rendered when a custom portal root is not provided, making portal placement more reliable.
* **Tests**
  * Added coverage to verify hover card content appears in the expected portal container when triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->