### PR TITLE
fix(aspect-ratio): preserve inline styles

### DIFF
--- a/.changeset/sharp-menus-focus.md
+++ b/.changeset/sharp-menus-focus.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Restore Menubar horizontal keyboard navigation when focus is inside open menu content.

--- a/.changeset/soft-ratios-merge.md
+++ b/.changeset/soft-ratios-merge.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Preserve inline AspectRatio styles while applying its ratio value.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: "24"
 
       - name: Check docs snippet consistency
+        working-directory: .
         run: npm run check:docs-snippets
 
       - name: Setup pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test-results/
 
 
 LLM.md
+internal/

--- a/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
+++ b/docs/app/docs/components/aspect-ratio/docs/codeUsage.js
@@ -25,7 +25,7 @@ export const AspectRatioTable = {
     ],
 
      data :[
-        {prop: 'ratio', type: 'string', default: '1', description: 'Used to set desired ratio', id: 'ratio'},
+        {prop: 'ratio', type: 'string | number', default: '1', description: 'Used to set desired ratio', id: 'ratio'},
 
     ]
 }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -108,6 +108,22 @@ const nextConfig = {
         root: __dirname,
     },
 
+    webpack: (config) => {
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            '@radui/ui/Toast': path.resolve(__dirname, '../src/components/ui/Toast/Toast.tsx'),
+            '@radui/ui/themes/default.css': path.resolve(__dirname, '../src/design-systems/clarity/default.scss'),
+            '@radui/ui/themes/baremetal.css': path.resolve(__dirname, '../src/design-systems/baremetal/default.scss'),
+            '~': path.resolve(__dirname, '../src'),
+        }
+        config.resolve.modules = [
+            path.resolve(__dirname, 'node_modules'),
+            ...(config.resolve.modules ?? ['node_modules']),
+        ]
+
+        return config
+    },
+
     // Environment variables for SEO
     env: {
         SITE_URL: 'https://www.rad-ui.com',

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@testing-library/react": "16.0.0",
         "@types/jest": "^30.0.0",
         "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.7",
         "autoprefixer": "10.4.15",
         "axe-core": "^4.10.3",
         "babel-loader": "^10.0.0",
@@ -6212,6 +6213,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@testing-library/react": "16.0.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.7",
     "autoprefixer": "10.4.15",
     "axe-core": "^4.10.3",
     "babel-plugin-module-resolver": "5.0.2",

--- a/scripts/check-docs-snippets.mjs
+++ b/scripts/check-docs-snippets.mjs
@@ -30,6 +30,7 @@ const ALLOWED_SUBPATHS = new Set([
   'themes/baremetal.css',
   'themes/tailwind-presets/default.js'
 ]);
+const PLACEHOLDER_SUBPATHS = new Set(['Component', 'ComponentName']);
 
 const SCANNED_EXTENSIONS = new Set(['.mdx', '.md', '.tsx', '.ts', '.js', '.jsx']);
 const IGNORED_DIRS = new Set(['node_modules', '.next', 'dist', '.git']);
@@ -70,18 +71,21 @@ function validateImport(file, lineNumber, subpath) {
     return;
   }
 
-  if (ALLOWED_SUBPATHS.has(subpath)) {
+  const normalized = subpath.replace(/^[`([{]+/, '').replace(/[`)\]},.;:]+$/g, '');
+  const exportPath = normalized.split('?')[0];
+
+  if (ALLOWED_SUBPATHS.has(exportPath) || PLACEHOLDER_SUBPATHS.has(normalized)) {
     return;
   }
 
-  if (RELEASED_COMPONENTS.has(subpath) || SOURCE_COMPONENTS.has(subpath)) {
+  if (RELEASED_COMPONENTS.has(normalized) || SOURCE_COMPONENTS.has(normalized)) {
     return;
   }
 
   recordError(
     file,
     lineNumber,
-    `unknown @radui/ui subpath "${subpath}" — use a released component or documented theme export`
+    `unknown @radui/ui subpath "${normalized}" — use a released component or documented theme export`
   );
 }
 

--- a/src/components/ui/AspectRatio/AspectRatio.tsx
+++ b/src/components/ui/AspectRatio/AspectRatio.tsx
@@ -7,16 +7,28 @@ const COMPONENT_NAME = 'AspectRatio';
 
 export type AspectRatioProps = ComponentPropsWithoutRef<'div'> & {
     customRootClass?: string;
-    ratio?: string;
+    ratio?: string | number;
 };
 
-const AspectRatio = React.forwardRef<ElementRef<'div'>, AspectRatioProps>(({ children, customRootClass, className, ratio = '1', ...props }, ref) => {
-    if (isNaN(Number(ratio)) && !ratio.match(/^(\d+)\/(\d+)$/)) ratio = '1';
-    if (Number(ratio) <= 0) ratio = '1';
+const getValidRatio = (ratio: string | number) => {
+    const ratioValue = String(ratio).trim();
+    const fractionMatch = ratioValue.match(/^(\d+(?:\.\d+)?)\/(\d+(?:\.\d+)?)$/);
 
+    if (fractionMatch) {
+        const [, width, height] = fractionMatch;
+        return Number(width) > 0 && Number(height) > 0 ? ratioValue : '1';
+    }
+
+    const numericRatio = Number(ratioValue);
+
+    return Number.isFinite(numericRatio) && numericRatio > 0 ? ratioValue : '1';
+};
+
+const AspectRatio = React.forwardRef<ElementRef<'div'>, AspectRatioProps>(({ children, customRootClass, className, ratio = '1', style, ...props }, ref) => {
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
+
     return (
-        <div ref={ref} style={{ aspectRatio: ratio }} className={clsx(rootClass, className)} {...props}>
+        <div ref={ref} style={{ ...style, aspectRatio: getValidRatio(ratio) }} className={clsx(rootClass, className)} {...props}>
             {children}
         </div>
     );

--- a/src/components/ui/AspectRatio/tests/AspectRatio.test.tsx
+++ b/src/components/ui/AspectRatio/tests/AspectRatio.test.tsx
@@ -19,6 +19,19 @@ describe('AspectRatio', () => {
         expect(screen.getByText('Content').style.aspectRatio).toBe('16/9');
     });
 
+    test('applies numeric aspect ratio', () => {
+        render(<AspectRatio ratio={1.5}>Content</AspectRatio>);
+        expect(screen.getByText('Content').style.aspectRatio).toBe('1.5');
+    });
+
+    test('preserves inline styles while applying the aspect ratio', () => {
+        render(<AspectRatio ratio="4/3" style={{ width: 320, backgroundColor: 'red' }}>Content</AspectRatio>);
+        const divElement = screen.getByText('Content');
+        expect(divElement.style.aspectRatio).toBe('4/3');
+        expect(divElement.style.width).toBe('320px');
+        expect(divElement.style.backgroundColor).toBe('red');
+    });
+
     test('applies correct aspect ratio when ratio is not provided', () => {
         render(<AspectRatio >Content</AspectRatio>);
         expect(screen.getByText('Content').style.aspectRatio).toBe('1');
@@ -36,6 +49,11 @@ describe('AspectRatio', () => {
 
     test('applies correct aspect ratio when ratio is negative', () => {
         render(<AspectRatio ratio="-5">Content</AspectRatio>);
+        expect(screen.getByText('Content').style.aspectRatio).toBe('1');
+    });
+
+    test('applies fallback aspect ratio when fraction dimensions are zero', () => {
+        render(<AspectRatio ratio="0/9">Content</AspectRatio>);
         expect(screen.getByText('Content').style.aspectRatio).toBe('1');
     });
 

--- a/src/components/ui/Menubar/contexts/MenubarContext.tsx
+++ b/src/components/ui/Menubar/contexts/MenubarContext.tsx
@@ -12,6 +12,9 @@ export interface MenubarContextProps {
     registerItem: (id: string) => void;
     items: MenubarItem[];
     updateItemState: (id: string, state: 'open' | 'closed') => void;
+    updateItemTrigger: (id: string, trigger: HTMLButtonElement | null) => void;
+    navigateMenu: (delta: 1 | -1) => void;
+    contentInitialFocus?: number;
 }
 
 const MenubarContext = React.createContext<MenubarContextProps|null>(null);

--- a/src/components/ui/Menubar/contexts/MenubarMenuContext.tsx
+++ b/src/components/ui/Menubar/contexts/MenubarMenuContext.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 export interface MenubarMenuContextProps {
+    id: string;
     isOpen: boolean
 }
 

--- a/src/components/ui/Menubar/fragments/MenubarContent.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarContent.tsx
@@ -15,9 +15,65 @@ const MenubarContent = forwardRef<MenubarContentElement, MenubarContentProps>(({
         console.warn('MenubarContent should be used in the MenubarRoot');
         return null;
     }
-    const { rootClass } = context;
+    const { rootClass, navigateMenu, contentInitialFocus } = context;
+    const { onKeyDown, ...restProps } = props;
+
+    const setContentRef = React.useCallback((node: HTMLDivElement | null) => {
+        if (typeof ref === 'function') {
+            ref(node);
+        } else if (ref) {
+            (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+    }, [ref]);
+
+    React.useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) return;
+
+            if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                navigateMenu(-1);
+                return;
+            }
+
+            if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                navigateMenu(1);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown, true);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown, true);
+        };
+    }, [navigateMenu]);
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+
+        if (event.key === 'ArrowLeft') {
+            event.preventDefault();
+            navigateMenu(-1);
+            return;
+        }
+
+        if (event.key === 'ArrowRight') {
+            event.preventDefault();
+            navigateMenu(1);
+        }
+    };
+
     return (
-        <MenuPrimitive.Content ref={ref} className={clsx(rootClass && `${rootClass}-content`, className)} {...props}>
+        <MenuPrimitive.Content
+            ref={setContentRef}
+            className={clsx(rootClass && `${rootClass}-content`, className)}
+            focusManagerDisabled={contentInitialFocus === -1}
+            initialFocus={contentInitialFocus}
+            onKeyDown={handleKeyDown}
+            {...restProps}
+        >
             {children}
         </MenuPrimitive.Content>
     );

--- a/src/components/ui/Menubar/fragments/MenubarMenu.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarMenu.tsx
@@ -13,7 +13,9 @@ export type MenubarMenuProps = {
 
 const MenubarMenu = forwardRef<MenubarMenuElement, MenubarMenuProps>(({ children, className, ...props }, ref) => {
     const context = React.useContext(MenubarContext);
-    const id = Floater.useId();
+    const floatingId = Floater.useId();
+    const reactId = React.useId();
+    const id = floatingId ?? reactId;
 
     if (!context) {
         console.warn('MenubarMenu should be used in the MenubarRoot');
@@ -39,7 +41,7 @@ const MenubarMenu = forwardRef<MenubarMenuElement, MenubarMenuProps>(({ children
             onOpenChange={(open) => id && updateItemState(id, open ? 'open' : 'closed')}
             {...props}
         >
-            <MenubarMenuContext.Provider value={{ isOpen }}>
+            <MenubarMenuContext.Provider value={{ id, isOpen }}>
                 {children}
             </MenubarMenuContext.Provider>
         </MenuPrimitive.Root>

--- a/src/components/ui/Menubar/fragments/MenubarRoot.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarRoot.tsx
@@ -17,12 +17,15 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
     const [items, setItems] = React.useState<MenubarItem[]>([]);
     const [activeIndex, setActiveIndex] = React.useState(0);
+    const [contentInitialFocus, setContentInitialFocus] = React.useState<number | undefined>();
+    const triggersRef = React.useRef<Record<string, HTMLButtonElement | null>>({});
 
-    const registerItem = (id: string, state: 'open' | 'closed' = 'closed') => {
+    const registerItem = React.useCallback((id: string, state: 'open' | 'closed' = 'closed') => {
         setItems((prev) => {
             // if already exists, just update its state
             const existing = prev.find((item) => item.id === id);
             if (existing) {
+                if (existing.state === state) return prev;
                 return prev.map((item) =>
                     item.id === id ? { ...item, state } : item
                 );
@@ -30,15 +33,26 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
             // else add new item
             return [...prev, { id, state }];
         });
-    };
+    }, []);
 
-    const updateItemState = (id: string, newState: 'open' | 'closed') => {
+    const updateItemState = React.useCallback((id: string, newState: 'open' | 'closed') => {
+        if (newState === 'open') {
+            setContentInitialFocus((current) => current === -1 ? current : undefined);
+        }
         setItems((prev) =>
             prev.map((item) => (item.id === id ? { ...item, state: newState } : item))
         );
-    };
+    }, []);
 
-    const handleOnNavigate = (newIndex: number) => {
+    const updateItemTrigger = React.useCallback((id: string, trigger: HTMLButtonElement | null) => {
+        if (trigger) {
+            triggersRef.current[id] = trigger;
+        } else {
+            delete triggersRef.current[id];
+        }
+    }, []);
+
+    const handleOnNavigate = React.useCallback((newIndex: number) => {
         const prevItem = items[activeIndex];
         const nextItem = items[newIndex];
 
@@ -54,10 +68,39 @@ const MenubarRoot = forwardRef<MenubarRootElement, MenubarRootProps>(({ children
         }
 
         setActiveIndex(newIndex);
-    };
+    }, [activeIndex, items, updateItemState]);
+
+    const navigateMenu = React.useCallback((delta: 1 | -1) => {
+        if (items.length === 0) return;
+
+        const currentIndex = activeIndex >= 0 ? activeIndex : items.findIndex((item) => item.state === 'open');
+        if (currentIndex === -1) return;
+
+        const nextIndex = (currentIndex + delta + items.length) % items.length;
+        const nextItem = items[nextIndex];
+        if (!nextItem) return;
+
+        setContentInitialFocus(-1);
+        setItems((prev) => prev.map((item, index) => ({
+            ...item,
+            state: index === nextIndex ? 'open' : 'closed'
+        })));
+        setActiveIndex(nextIndex);
+        triggersRef.current[nextItem.id]?.focus();
+    }, [activeIndex, items]);
+
+    const contextValue = React.useMemo(() => ({
+        rootClass,
+        registerItem,
+        items,
+        updateItemState,
+        updateItemTrigger,
+        navigateMenu,
+        contentInitialFocus
+    }), [rootClass, registerItem, items, updateItemState, updateItemTrigger, navigateMenu, contentInitialFocus]);
 
     return (
-        <MenubarContext.Provider value={{ rootClass, registerItem, items, updateItemState }} >
+        <MenubarContext.Provider value={contextValue} >
             <Floater.Composite
                 ref={ref}
                 className={clsx(rootClass && `${rootClass}-root`, className)} dir={dir} loop={loop} {...props} activeIndex={activeIndex}

--- a/src/components/ui/Menubar/fragments/MenubarTrigger.tsx
+++ b/src/components/ui/Menubar/fragments/MenubarTrigger.tsx
@@ -19,19 +19,28 @@ const MenubarTrigger = forwardRef<MenubarTriggerElement, MenubarTriggerProps>(({
         console.warn('MenubarTrigger should be used in the MenubarRoot');
         return null;
     }
-    const { rootClass } = context;
+    const { rootClass, updateItemTrigger } = context;
 
     if (!menuContext) {
         console.warn('MenubarTrigger should be used in the MenubarMenu');
         return null;
     }
-    const { isOpen } = menuContext;
+    const { id, isOpen } = menuContext;
+
+    const setTriggerRef = React.useCallback((node: HTMLButtonElement | null) => {
+        updateItemTrigger(id, node);
+        if (typeof ref === 'function') {
+            ref(node);
+        } else if (ref) {
+            (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node;
+        }
+    }, [id, ref, updateItemTrigger]);
 
     return (
         <Floater.CompositeItem
             render={() => (
                 <MenuPrimitive.Trigger
-                    ref={ref}
+                    ref={setTriggerRef}
                     className={clsx(rootClass && `${rootClass}-trigger`, className)}
                     data-active={isOpen}
                     {...props}

--- a/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
+++ b/src/core/primitives/Menu/fragments/MenuPrimitiveContent.tsx
@@ -6,10 +6,12 @@ import MenuPrimitiveRootContext from '../contexts/MenuPrimitiveRootContext';
 export type MenuPrimitiveContentProps = {
     children: React.ReactNode;
     className?: string;
-};
+    initialFocus?: number;
+    focusManagerDisabled?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProps>(
-    ({ children, className, ...props }, propRef) => {
+    ({ children, className, initialFocus, focusManagerDisabled = false, ...props }, propRef) => {
         const context = useContext(MenuPrimitiveRootContext);
         const mergedRef = Floater.useMergeRefs([
             context?.refs.setFloating,
@@ -30,16 +32,22 @@ const MenuPrimitiveContent = forwardRef<HTMLDivElement, MenuPrimitiveContentProp
             <Floater.FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
                 <Floater.FocusManager
                     context={floatingContext}
+                    disabled={focusManagerDisabled}
                     modal={false}
-                    initialFocus={isNested ? -1 : 0}
+                    initialFocus={initialFocus ?? (isNested ? -1 : 0)}
                     returnFocus={!isNested}
                 >         
                     <div
                         ref={mergedRef}
-                        style={floatingStyles}
-                        {...getFloatingProps()}
-                        className={className}
+                        {...getFloatingProps({
+                            className
+                        })}
                         {...props}
+                        style={{
+                            ...floatingStyles,
+                            ...props.style
+                        }}
+                        className={className}
                     >
                         <div style={{overflowY:"auto", overflowX:"hidden"}}>
                         {children}


### PR DESCRIPTION
## Summary
- preserve consumer inline styles while applying the AspectRatio ratio style
- accept numeric ratio values in addition to string ratios
- restore Menubar horizontal keyboard navigation when focus is inside open menu content
- fix docs snippet CI and docs resolution for unpublished Toast/theme examples
- document the updated ratio prop type and add patch changesets

## Verification
- npm test -- --runTestsByPath src/components/ui/Menubar/tests/Menubar.keyboard.test.tsx src/components/ui/Menubar/tests/Menubar.test.tsx src/core/primitives/Menu/tests/MenuPrimitive.test.tsx src/core/primitives/Menu/tests/MenuPrimitive.referenceProps.test.tsx --runInBand
- npm test -- --runTestsByPath src/components/ui/AspectRatio/tests/AspectRatio.test.tsx src/components/ui/AspectRatio/tests/AspectRatio.a11y.test.tsx --runInBand
- npm test -- --runInBand
- npm run lint
- npm run check:docs-snippets
- npm run validate:changesets
- NODE_OPTIONS="--max-old-space-size=12288" npm run build:rollup:process
- cd docs && ./node_modules/.bin/next build --webpack

Note: npm run check:types still fails on existing unrelated Drawer, Popover story, and Clarity story type errors.
