### PR TITLE
feat(breadcrumb): add component

### DIFF
--- a/.changeset/bright-breadcrumbs-walk.md
+++ b/.changeset/bright-breadcrumbs-walk.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Add a composable Breadcrumb component with accessible navigation semantics.

--- a/docs/app/docs/components/breadcrumb/content.mdx
+++ b/docs/app/docs/components/breadcrumb/content.mdx
@@ -1,0 +1,43 @@
+import Documentation from "@/components/layout/Documentation/Documentation"
+import Breadcrumb from "@radui/ui/Breadcrumb"
+import codeUsage, { api_documentation, features } from "./docs/codeUsage"
+
+<Documentation
+  title="Breadcrumb"
+  description="Breadcrumbs show the user's location within a hierarchy and provide links back to parent pages."
+>
+  <Documentation.ComponentHero codeUsage={codeUsage}>
+    <Breadcrumb.Root>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
+          <Breadcrumb.Separator />
+        </Breadcrumb.Item>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+          <Breadcrumb.Separator />
+        </Breadcrumb.Item>
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  </Documentation.ComponentHero>
+
+  <Documentation.ComponentFeatures features={features} />
+
+  <Documentation.Section title="API Documentation" as="h2">
+    <Documentation.Table
+      title="Root"
+      description={api_documentation.root.description}
+      columns={api_documentation.root.columns}
+      data={api_documentation.root.data}
+    />
+    <Documentation.Table
+      title="Parts"
+      description={api_documentation.parts.description}
+      columns={api_documentation.parts.columns}
+      data={api_documentation.parts.data}
+    />
+  </Documentation.Section>
+</Documentation>

--- a/docs/app/docs/components/breadcrumb/docs/codeUsage.js
+++ b/docs/app/docs/components/breadcrumb/docs/codeUsage.js
@@ -1,0 +1,47 @@
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import root_api_SourceCode from './component_api/root.tsx';
+import parts_api_SourceCode from './component_api/parts.tsx';
+
+const scss_SourceCode = await getSourceCodeFromPath('src/components/ui/Breadcrumb/breadcrumb.clarity.scss');
+
+const code = {
+    javascript: {
+        code: `import Breadcrumb from "@radui/ui/Breadcrumb"
+
+const BreadcrumbExample = () => (
+    <Breadcrumb.Root>
+        <Breadcrumb.List>
+            <Breadcrumb.Item>
+                <Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
+                <Breadcrumb.Separator />
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>
+                <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
+                <Breadcrumb.Separator />
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>
+                <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+            </Breadcrumb.Item>
+        </Breadcrumb.List>
+    </Breadcrumb.Root>
+)`
+    },
+    scss: {
+        code: scss_SourceCode
+    },
+}
+
+export const api_documentation = {
+    root: root_api_SourceCode,
+    parts: parts_api_SourceCode
+};
+
+export const features = [
+    "Uses native nav and ordered-list semantics",
+    "Marks the current page with aria-current by default",
+    "Supports router links through Breadcrumb.Link asChild",
+    "Exposes stable classes for each part",
+    "Allows custom separator content"
+];
+
+export default code;

--- a/docs/app/docs/components/breadcrumb/docs/component_api/parts.tsx
+++ b/docs/app/docs/components/breadcrumb/docs/component_api/parts.tsx
@@ -1,0 +1,47 @@
+const data = {
+    name: "Parts",
+    description: "Composable breadcrumb parts for list structure, links, current page text, and separators.",
+    columns: [
+        {
+            name: "Part",
+            id: "part",
+        },
+        {
+            name: "Element",
+            id: "element",
+        },
+        {
+            name: "Notes",
+            id: "notes",
+        }
+    ],
+    data: [
+        {
+            part: "Breadcrumb.List",
+            element: "ol",
+            notes: "Wraps breadcrumb items in source order.",
+        },
+        {
+            part: "Breadcrumb.Item",
+            element: "li",
+            notes: "Groups a link or current page with its separator.",
+        },
+        {
+            part: "Breadcrumb.Link",
+            element: "a",
+            notes: "Supports asChild for router link components.",
+        },
+        {
+            part: "Breadcrumb.Page",
+            element: "span",
+            notes: "Sets aria-current=\"page\" by default.",
+        },
+        {
+            part: "Breadcrumb.Separator",
+            element: "span",
+            notes: "Decorative separator hidden from assistive technology.",
+        }
+    ]
+};
+
+export default data;

--- a/docs/app/docs/components/breadcrumb/docs/component_api/root.tsx
+++ b/docs/app/docs/components/breadcrumb/docs/component_api/root.tsx
@@ -1,0 +1,46 @@
+const data = {
+    name: "Root",
+    description: "The navigation landmark that labels the breadcrumb trail.",
+    columns: [
+        {
+            name: "Prop",
+            id: "prop",
+        },
+        {
+            name: "Type",
+            id: "type",
+        },
+        {
+            name: "Default",
+            id: "default",
+        }
+    ],
+    data: [
+        {
+            prop: {
+                name: "aria-label",
+                info_tooltips: "Accessible name for the breadcrumb navigation landmark."
+            },
+            type: "string",
+            default: "'Breadcrumb'",
+        },
+        {
+            prop: {
+                name: "customRootClass",
+                info_tooltips: "Class namespace used to generate the component part class."
+            },
+            type: "string",
+            default: "''",
+        },
+        {
+            prop: {
+                name: "className",
+                info_tooltips: "Additional class names for the root element."
+            },
+            type: "string",
+            default: "''",
+        }
+    ]
+};
+
+export default data;

--- a/docs/app/docs/components/breadcrumb/page.tsx
+++ b/docs/app/docs/components/breadcrumb/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/components/breadcrumb/seo.ts
+++ b/docs/app/docs/components/breadcrumb/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from "@/utils/seo/generateSeoMetadata"
+
+const breadcrumbMetadata = generateSeoMetadata({
+    title: "Breadcrumb - Rad UI",
+    description: "A composable React Breadcrumb component for accessible page hierarchy navigation."
+});
+
+export default breadcrumbMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -32,6 +32,7 @@ export const docsNavigationSections = [
             { title:"AvatarGroup", path:"/docs/components/avatar-group" },
             { title:"Badge", path:"/docs/components/badge" },
             { title:"BlockQuote", path:"/docs/components/blockquote" },
+            { title:"Breadcrumb", path:"/docs/components/breadcrumb", is_new:true },
             { title:"Button", path:"/docs/components/button" },
             { title:"Callout", path:"/docs/components/callout" },
             { title:"Card", path:"/docs/components/card" },

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -111,6 +111,7 @@ const nextConfig = {
     webpack: (config) => {
         config.resolve.alias = {
             ...config.resolve.alias,
+            '@radui/ui/Breadcrumb': path.resolve(__dirname, '../src/components/ui/Breadcrumb/Breadcrumb.tsx'),
             '@radui/ui/Toast': path.resolve(__dirname, '../src/components/ui/Toast/Toast.tsx'),
             '@radui/ui/themes/default.css': path.resolve(__dirname, '../src/design-systems/clarity/default.scss'),
             '@radui/ui/themes/baremetal.css': path.resolve(__dirname, '../src/design-systems/baremetal/default.scss'),

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  sharp: true
+  unrs-resolver: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,312 @@
     },
     "./themes/default.css": "./dist/themes/default.css",
     "./themes/baremetal.css": "./dist/themes/baremetal.css",
-    "./themes/tailwind-presets/default.js": "./dist/themes/tailwind-presets/default.js"
+    "./themes/tailwind-presets/default.js": "./dist/themes/tailwind-presets/default.js",
+    "./Accordion": {
+      "import": "./dist/components/Accordion.js",
+      "require": "./dist/components/Accordion.cjs",
+      "types": "./dist/components/Accordion.d.ts"
+    },
+    "./AlertDialog": {
+      "import": "./dist/components/AlertDialog.js",
+      "require": "./dist/components/AlertDialog.cjs",
+      "types": "./dist/components/AlertDialog.d.ts"
+    },
+    "./AspectRatio": {
+      "import": "./dist/components/AspectRatio.js",
+      "require": "./dist/components/AspectRatio.cjs",
+      "types": "./dist/components/AspectRatio.d.ts"
+    },
+    "./Avatar": {
+      "import": "./dist/components/Avatar.js",
+      "require": "./dist/components/Avatar.cjs",
+      "types": "./dist/components/Avatar.d.ts"
+    },
+    "./AvatarGroup": {
+      "import": "./dist/components/AvatarGroup.js",
+      "require": "./dist/components/AvatarGroup.cjs",
+      "types": "./dist/components/AvatarGroup.d.ts"
+    },
+    "./Badge": {
+      "import": "./dist/components/Badge.js",
+      "require": "./dist/components/Badge.cjs",
+      "types": "./dist/components/Badge.d.ts"
+    },
+    "./BlockQuote": {
+      "import": "./dist/components/BlockQuote.js",
+      "require": "./dist/components/BlockQuote.cjs",
+      "types": "./dist/components/BlockQuote.d.ts"
+    },
+    "./Breadcrumb": {
+      "import": "./dist/components/Breadcrumb.js",
+      "require": "./dist/components/Breadcrumb.cjs",
+      "types": "./dist/components/Breadcrumb.d.ts"
+    },
+    "./Button": {
+      "import": "./dist/components/Button.js",
+      "require": "./dist/components/Button.cjs",
+      "types": "./dist/components/Button.d.ts"
+    },
+    "./Callout": {
+      "import": "./dist/components/Callout.js",
+      "require": "./dist/components/Callout.cjs",
+      "types": "./dist/components/Callout.d.ts"
+    },
+    "./Card": {
+      "import": "./dist/components/Card.js",
+      "require": "./dist/components/Card.cjs",
+      "types": "./dist/components/Card.d.ts"
+    },
+    "./Checkbox": {
+      "import": "./dist/components/Checkbox.js",
+      "require": "./dist/components/Checkbox.cjs",
+      "types": "./dist/components/Checkbox.d.ts"
+    },
+    "./CheckboxCards": {
+      "import": "./dist/components/CheckboxCards.js",
+      "require": "./dist/components/CheckboxCards.cjs",
+      "types": "./dist/components/CheckboxCards.d.ts"
+    },
+    "./CheckboxGroup": {
+      "import": "./dist/components/CheckboxGroup.js",
+      "require": "./dist/components/CheckboxGroup.cjs",
+      "types": "./dist/components/CheckboxGroup.d.ts"
+    },
+    "./Code": {
+      "import": "./dist/components/Code.js",
+      "require": "./dist/components/Code.cjs",
+      "types": "./dist/components/Code.d.ts"
+    },
+    "./Collapsible": {
+      "import": "./dist/components/Collapsible.js",
+      "require": "./dist/components/Collapsible.cjs",
+      "types": "./dist/components/Collapsible.d.ts"
+    },
+    "./Combobox": {
+      "import": "./dist/components/Combobox.js",
+      "require": "./dist/components/Combobox.cjs",
+      "types": "./dist/components/Combobox.d.ts"
+    },
+    "./Command": {
+      "import": "./dist/components/Command.js",
+      "require": "./dist/components/Command.cjs",
+      "types": "./dist/components/Command.d.ts"
+    },
+    "./ContextMenu": {
+      "import": "./dist/components/ContextMenu.js",
+      "require": "./dist/components/ContextMenu.cjs",
+      "types": "./dist/components/ContextMenu.d.ts"
+    },
+    "./DataList": {
+      "import": "./dist/components/DataList.js",
+      "require": "./dist/components/DataList.cjs",
+      "types": "./dist/components/DataList.d.ts"
+    },
+    "./Dialog": {
+      "import": "./dist/components/Dialog.js",
+      "require": "./dist/components/Dialog.cjs",
+      "types": "./dist/components/Dialog.d.ts"
+    },
+    "./Disclosure": {
+      "import": "./dist/components/Disclosure.js",
+      "require": "./dist/components/Disclosure.cjs",
+      "types": "./dist/components/Disclosure.d.ts"
+    },
+    "./Drawer": {
+      "import": "./dist/components/Drawer.js",
+      "require": "./dist/components/Drawer.cjs",
+      "types": "./dist/components/Drawer.d.ts"
+    },
+    "./DropdownMenu": {
+      "import": "./dist/components/DropdownMenu.js",
+      "require": "./dist/components/DropdownMenu.cjs",
+      "types": "./dist/components/DropdownMenu.d.ts"
+    },
+    "./Em": {
+      "import": "./dist/components/Em.js",
+      "require": "./dist/components/Em.cjs",
+      "types": "./dist/components/Em.d.ts"
+    },
+    "./Heading": {
+      "import": "./dist/components/Heading.js",
+      "require": "./dist/components/Heading.cjs",
+      "types": "./dist/components/Heading.d.ts"
+    },
+    "./HoverCard": {
+      "import": "./dist/components/HoverCard.js",
+      "require": "./dist/components/HoverCard.cjs",
+      "types": "./dist/components/HoverCard.d.ts"
+    },
+    "./Kbd": {
+      "import": "./dist/components/Kbd.js",
+      "require": "./dist/components/Kbd.cjs",
+      "types": "./dist/components/Kbd.d.ts"
+    },
+    "./Link": {
+      "import": "./dist/components/Link.js",
+      "require": "./dist/components/Link.cjs",
+      "types": "./dist/components/Link.d.ts"
+    },
+    "./Menubar": {
+      "import": "./dist/components/Menubar.js",
+      "require": "./dist/components/Menubar.cjs",
+      "types": "./dist/components/Menubar.d.ts"
+    },
+    "./Minimap": {
+      "import": "./dist/components/Minimap.js",
+      "require": "./dist/components/Minimap.cjs",
+      "types": "./dist/components/Minimap.d.ts"
+    },
+    "./NavigationMenu": {
+      "import": "./dist/components/NavigationMenu.js",
+      "require": "./dist/components/NavigationMenu.cjs",
+      "types": "./dist/components/NavigationMenu.d.ts"
+    },
+    "./NumberField": {
+      "import": "./dist/components/NumberField.js",
+      "require": "./dist/components/NumberField.cjs",
+      "types": "./dist/components/NumberField.d.ts"
+    },
+    "./Popover": {
+      "import": "./dist/components/Popover.js",
+      "require": "./dist/components/Popover.cjs",
+      "types": "./dist/components/Popover.d.ts"
+    },
+    "./Progress": {
+      "import": "./dist/components/Progress.js",
+      "require": "./dist/components/Progress.cjs",
+      "types": "./dist/components/Progress.d.ts"
+    },
+    "./Quote": {
+      "import": "./dist/components/Quote.js",
+      "require": "./dist/components/Quote.cjs",
+      "types": "./dist/components/Quote.d.ts"
+    },
+    "./Radio": {
+      "import": "./dist/components/Radio.js",
+      "require": "./dist/components/Radio.cjs",
+      "types": "./dist/components/Radio.d.ts"
+    },
+    "./RadioCards": {
+      "import": "./dist/components/RadioCards.js",
+      "require": "./dist/components/RadioCards.cjs",
+      "types": "./dist/components/RadioCards.d.ts"
+    },
+    "./RadioGroup": {
+      "import": "./dist/components/RadioGroup.js",
+      "require": "./dist/components/RadioGroup.cjs",
+      "types": "./dist/components/RadioGroup.d.ts"
+    },
+    "./ScrollArea": {
+      "import": "./dist/components/ScrollArea.js",
+      "require": "./dist/components/ScrollArea.cjs",
+      "types": "./dist/components/ScrollArea.d.ts"
+    },
+    "./Select": {
+      "import": "./dist/components/Select.js",
+      "require": "./dist/components/Select.cjs",
+      "types": "./dist/components/Select.d.ts"
+    },
+    "./Separator": {
+      "import": "./dist/components/Separator.js",
+      "require": "./dist/components/Separator.cjs",
+      "types": "./dist/components/Separator.d.ts"
+    },
+    "./Skeleton": {
+      "import": "./dist/components/Skeleton.js",
+      "require": "./dist/components/Skeleton.cjs",
+      "types": "./dist/components/Skeleton.d.ts"
+    },
+    "./Slider": {
+      "import": "./dist/components/Slider.js",
+      "require": "./dist/components/Slider.cjs",
+      "types": "./dist/components/Slider.d.ts"
+    },
+    "./Spinner": {
+      "import": "./dist/components/Spinner.js",
+      "require": "./dist/components/Spinner.cjs",
+      "types": "./dist/components/Spinner.d.ts"
+    },
+    "./Splitter": {
+      "import": "./dist/components/Splitter.js",
+      "require": "./dist/components/Splitter.cjs",
+      "types": "./dist/components/Splitter.d.ts"
+    },
+    "./Steps": {
+      "import": "./dist/components/Steps.js",
+      "require": "./dist/components/Steps.cjs",
+      "types": "./dist/components/Steps.d.ts"
+    },
+    "./Strong": {
+      "import": "./dist/components/Strong.js",
+      "require": "./dist/components/Strong.cjs",
+      "types": "./dist/components/Strong.d.ts"
+    },
+    "./Switch": {
+      "import": "./dist/components/Switch.js",
+      "require": "./dist/components/Switch.cjs",
+      "types": "./dist/components/Switch.d.ts"
+    },
+    "./TabNav": {
+      "import": "./dist/components/TabNav.js",
+      "require": "./dist/components/TabNav.cjs",
+      "types": "./dist/components/TabNav.d.ts"
+    },
+    "./Table": {
+      "import": "./dist/components/Table.js",
+      "require": "./dist/components/Table.cjs",
+      "types": "./dist/components/Table.d.ts"
+    },
+    "./Tabs": {
+      "import": "./dist/components/Tabs.js",
+      "require": "./dist/components/Tabs.cjs",
+      "types": "./dist/components/Tabs.d.ts"
+    },
+    "./Text": {
+      "import": "./dist/components/Text.js",
+      "require": "./dist/components/Text.cjs",
+      "types": "./dist/components/Text.d.ts"
+    },
+    "./TextArea": {
+      "import": "./dist/components/TextArea.js",
+      "require": "./dist/components/TextArea.cjs",
+      "types": "./dist/components/TextArea.d.ts"
+    },
+    "./Theme": {
+      "import": "./dist/components/Theme.js",
+      "require": "./dist/components/Theme.cjs",
+      "types": "./dist/components/Theme.d.ts"
+    },
+    "./Toggle": {
+      "import": "./dist/components/Toggle.js",
+      "require": "./dist/components/Toggle.cjs",
+      "types": "./dist/components/Toggle.d.ts"
+    },
+    "./ToggleGroup": {
+      "import": "./dist/components/ToggleGroup.js",
+      "require": "./dist/components/ToggleGroup.cjs",
+      "types": "./dist/components/ToggleGroup.d.ts"
+    },
+    "./Toolbar": {
+      "import": "./dist/components/Toolbar.js",
+      "require": "./dist/components/Toolbar.cjs",
+      "types": "./dist/components/Toolbar.d.ts"
+    },
+    "./Tooltip": {
+      "import": "./dist/components/Tooltip.js",
+      "require": "./dist/components/Tooltip.cjs",
+      "types": "./dist/components/Tooltip.d.ts"
+    },
+    "./Tree": {
+      "import": "./dist/components/Tree.js",
+      "require": "./dist/components/Tree.cjs",
+      "types": "./dist/components/Tree.d.ts"
+    },
+    "./VisuallyHidden": {
+      "import": "./dist/components/VisuallyHidden.js",
+      "require": "./dist/components/VisuallyHidden.cjs",
+      "types": "./dist/components/VisuallyHidden.d.ts"
+    }
   },
   "files": [
     "dist",

--- a/scripts/RELEASED_COMPONENTS.cjs
+++ b/scripts/RELEASED_COMPONENTS.cjs
@@ -8,6 +8,7 @@ const RELEASED_COMPONENTS = [
     'Badge',
     'Button',
     'BlockQuote',
+    'Breadcrumb',
     'Callout',
     'Card',
     'Code',

--- a/src/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Breadcrumb from '../Breadcrumb';
+import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
+
+export default {
+    title: 'Components/Breadcrumb',
+    component: Breadcrumb.Root
+};
+
+export const Default = () => (
+    <SandboxEditor>
+        <Breadcrumb.Root>
+            <Breadcrumb.List>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+                    <Breadcrumb.Separator />
+                </Breadcrumb.Item>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
+                    <Breadcrumb.Separator />
+                </Breadcrumb.Item>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+                </Breadcrumb.Item>
+            </Breadcrumb.List>
+        </Breadcrumb.Root>
+    </SandboxEditor>
+);
+
+export const CustomSeparator = () => (
+    <SandboxEditor>
+        <Breadcrumb.Root>
+            <Breadcrumb.List>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+                    <Breadcrumb.Separator>&gt;</Breadcrumb.Separator>
+                </Breadcrumb.Item>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Link href="/components">Components</Breadcrumb.Link>
+                    <Breadcrumb.Separator>&gt;</Breadcrumb.Separator>
+                </Breadcrumb.Item>
+                <Breadcrumb.Item>
+                    <Breadcrumb.Page>Navigation</Breadcrumb.Page>
+                </Breadcrumb.Item>
+            </Breadcrumb.List>
+        </Breadcrumb.Root>
+    </SandboxEditor>
+);

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,147 @@
+'use client';
+import React from 'react';
+import clsx from 'clsx';
+import { useComponentClass } from '~/components/ui/Theme/useComponentClass';
+import Primitive from '~/core/primitives/Primitive';
+
+const COMPONENT_NAME = 'Breadcrumb';
+
+type RootElement = HTMLElement;
+type ListElement = HTMLOListElement;
+type ItemElement = HTMLLIElement;
+type LinkElement = HTMLAnchorElement;
+type PageElement = HTMLSpanElement;
+type SeparatorElement = HTMLSpanElement;
+
+export type BreadcrumbRootProps = React.ComponentPropsWithoutRef<'nav'> & {
+    customRootClass?: string;
+};
+
+export type BreadcrumbListProps = React.ComponentPropsWithoutRef<'ol'> & {
+    customRootClass?: string;
+};
+
+export type BreadcrumbItemProps = React.ComponentPropsWithoutRef<'li'> & {
+    customRootClass?: string;
+};
+
+export type BreadcrumbLinkProps = React.ComponentPropsWithoutRef<'a'> & {
+    customRootClass?: string;
+    asChild?: boolean;
+};
+
+export type BreadcrumbPageProps = React.ComponentPropsWithoutRef<'span'> & {
+    customRootClass?: string;
+};
+
+export type BreadcrumbSeparatorProps = React.ComponentPropsWithoutRef<'span'> & {
+    customRootClass?: string;
+};
+
+const BreadcrumbRoot = React.forwardRef<RootElement, BreadcrumbRootProps>(
+    ({ children, customRootClass = '', className = '', 'aria-label': ariaLabel = 'Breadcrumb', ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'root');
+
+        return (
+            <nav ref={ref} aria-label={ariaLabel} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </nav>
+        );
+    }
+);
+
+const BreadcrumbList = React.forwardRef<ListElement, BreadcrumbListProps>(
+    ({ children, customRootClass = '', className = '', ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'list');
+
+        return (
+            <ol ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </ol>
+        );
+    }
+);
+
+const BreadcrumbItem = React.forwardRef<ItemElement, BreadcrumbItemProps>(
+    ({ children, customRootClass = '', className = '', ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'item');
+
+        return (
+            <li ref={ref} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </li>
+        );
+    }
+);
+
+const BreadcrumbLink = React.forwardRef<LinkElement, BreadcrumbLinkProps>(
+    ({ children, customRootClass = '', className = '', asChild = false, ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'link');
+        const Anchor = Primitive.a as any;
+
+        return (
+            <Anchor ref={ref} asChild={asChild} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </Anchor>
+        );
+    }
+);
+
+const BreadcrumbPage = React.forwardRef<PageElement, BreadcrumbPageProps>(
+    ({ children, customRootClass = '', className = '', 'aria-current': ariaCurrent = 'page', ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'page');
+
+        return (
+            <span ref={ref} aria-current={ariaCurrent} className={clsx(rootClass, className)} {...props}>
+                {children}
+            </span>
+        );
+    }
+);
+
+const BreadcrumbSeparator = React.forwardRef<SeparatorElement, BreadcrumbSeparatorProps>(
+    ({ children = '/', customRootClass = '', className = '', ...props }, ref) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME, 'separator');
+
+        return (
+            <span ref={ref} aria-hidden="true" className={clsx(rootClass, className)} {...props}>
+                {children}
+            </span>
+        );
+    }
+);
+
+BreadcrumbRoot.displayName = 'Breadcrumb.Root';
+BreadcrumbList.displayName = 'Breadcrumb.List';
+BreadcrumbItem.displayName = 'Breadcrumb.Item';
+BreadcrumbLink.displayName = 'Breadcrumb.Link';
+BreadcrumbPage.displayName = 'Breadcrumb.Page';
+BreadcrumbSeparator.displayName = 'Breadcrumb.Separator';
+
+const Breadcrumb = {
+    Root: BreadcrumbRoot,
+    List: BreadcrumbList,
+    Item: BreadcrumbItem,
+    Link: BreadcrumbLink,
+    Page: BreadcrumbPage,
+    Separator: BreadcrumbSeparator
+};
+
+export {
+    BreadcrumbRoot as Root,
+    BreadcrumbList as List,
+    BreadcrumbItem as Item,
+    BreadcrumbLink as Link,
+    BreadcrumbPage as Page,
+    BreadcrumbSeparator as Separator
+};
+
+export default Breadcrumb;
+export type {
+    RootElement as BreadcrumbRootElement,
+    ListElement as BreadcrumbListElement,
+    ItemElement as BreadcrumbItemElement,
+    LinkElement as BreadcrumbLinkElement,
+    PageElement as BreadcrumbPageElement,
+    SeparatorElement as BreadcrumbSeparatorElement
+};

--- a/src/components/ui/Breadcrumb/breadcrumb.baremetal.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.baremetal.scss
@@ -1,0 +1,23 @@
+@use "src/design-systems/baremetal/scope" as baremetal;
+
+#{baremetal.$theme-root} :where(.rad-ui-breadcrumb-root) {
+    color: var(--rad-ui-baremetal-black);
+}
+
+#{baremetal.$theme-root} :where(.rad-ui-breadcrumb-list) {
+    gap: var(--rad-ui-spacing-2);
+}
+
+#{baremetal.$theme-root} :where(.rad-ui-breadcrumb-link) {
+    color: var(--rad-ui-baremetal-black);
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
+}
+
+#{baremetal.$theme-root} :where(.rad-ui-breadcrumb-page) {
+    font-weight: var(--rad-ui-font-weight-semibold);
+}
+
+#{baremetal.$theme-root} :where(.rad-ui-breadcrumb-separator) {
+    color: var(--rad-ui-baremetal-black);
+}

--- a/src/components/ui/Breadcrumb/breadcrumb.clarity.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.clarity.scss
@@ -1,0 +1,50 @@
+.rad-ui-breadcrumb-root {
+    color: var(--rad-ui-text-secondary);
+    font-family: var(--rad-ui-font-sans);
+    font-size: var(--rad-ui-font-size-2);
+    line-height: var(--rad-ui-line-height-2);
+}
+
+.rad-ui-breadcrumb-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--rad-ui-spacing-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.rad-ui-breadcrumb-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rad-ui-spacing-2);
+    min-width: 0;
+}
+
+.rad-ui-breadcrumb-link {
+    color: var(--rad-ui-text-secondary);
+    text-decoration: none;
+    border-radius: var(--rad-ui-radius-sm);
+
+    &:hover {
+        color: var(--rad-ui-text-primary);
+        text-decoration: underline;
+        text-underline-offset: 0.16em;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--rad-ui-focus-ring-shadow-sm);
+    }
+}
+
+.rad-ui-breadcrumb-page {
+    color: var(--rad-ui-text-primary);
+    font-weight: var(--rad-ui-font-weight-medium);
+}
+
+.rad-ui-breadcrumb-separator {
+    color: var(--rad-ui-text-muted);
+    user-select: none;
+}

--- a/src/components/ui/Breadcrumb/tests/Breadcrumb.a11y.test.tsx
+++ b/src/components/ui/Breadcrumb/tests/Breadcrumb.a11y.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as axe from 'axe-core';
+import { ACCESSIBILITY_TEST_TAGS } from '~/setupTests';
+import Breadcrumb from '../Breadcrumb';
+
+describe('Breadcrumb accessibility', () => {
+    test('axe: no violations', async() => {
+        const { container } = render(
+            <Breadcrumb.Root>
+                <Breadcrumb.List>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+                        <Breadcrumb.Separator />
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
+                        <Breadcrumb.Separator />
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>
+                    </Breadcrumb.Item>
+                </Breadcrumb.List>
+            </Breadcrumb.Root>
+        );
+
+        const results = await axe.run(container, { runOnly: { type: 'tag', values: ACCESSIBILITY_TEST_TAGS } });
+        expect(results.violations).toHaveLength(0);
+    });
+});

--- a/src/components/ui/Breadcrumb/tests/Breadcrumb.test.tsx
+++ b/src/components/ui/Breadcrumb/tests/Breadcrumb.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Breadcrumb from '../Breadcrumb';
+
+describe('Breadcrumb', () => {
+    test('renders accessible breadcrumb navigation by default', () => {
+        render(
+            <Breadcrumb.Root>
+                <Breadcrumb.List>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+                        <Breadcrumb.Separator />
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Page>Docs</Breadcrumb.Page>
+                    </Breadcrumb.Item>
+                </Breadcrumb.List>
+            </Breadcrumb.Root>
+        );
+
+        expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument();
+        expect(screen.getByRole('list')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+        expect(screen.getByText('Docs')).toHaveAttribute('aria-current', 'page');
+    });
+
+    test('applies component part classes and custom class names', () => {
+        render(
+            <Breadcrumb.Root customRootClass="acme" className="root-extra">
+                <Breadcrumb.List customRootClass="acme" className="list-extra">
+                    <Breadcrumb.Item customRootClass="acme" className="item-extra">
+                        <Breadcrumb.Link customRootClass="acme" className="link-extra" href="/">Home</Breadcrumb.Link>
+                        <Breadcrumb.Separator customRootClass="acme" className="separator-extra">/</Breadcrumb.Separator>
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item customRootClass="acme">
+                        <Breadcrumb.Page customRootClass="acme" className="page-extra">Docs</Breadcrumb.Page>
+                    </Breadcrumb.Item>
+                </Breadcrumb.List>
+            </Breadcrumb.Root>
+        );
+
+        expect(screen.getByRole('navigation')).toHaveClass('acme-breadcrumb-root', 'root-extra');
+        expect(screen.getByRole('list')).toHaveClass('acme-breadcrumb-list', 'list-extra');
+        expect(screen.getAllByRole('listitem')[0]).toHaveClass('acme-breadcrumb-item', 'item-extra');
+        expect(screen.getByRole('link')).toHaveClass('acme-breadcrumb-link', 'link-extra');
+        expect(screen.getByText('/')).toHaveClass('acme-breadcrumb-separator', 'separator-extra');
+        expect(screen.getByText('Docs')).toHaveClass('acme-breadcrumb-page', 'page-extra');
+    });
+
+    test('supports asChild links', () => {
+        render(
+            <Breadcrumb.Root>
+                <Breadcrumb.List>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Link asChild className="router-link">
+                            <a href="/docs" data-testid="custom-link">Docs</a>
+                        </Breadcrumb.Link>
+                    </Breadcrumb.Item>
+                </Breadcrumb.List>
+            </Breadcrumb.Root>
+        );
+
+        expect(screen.getByTestId('custom-link')).toHaveClass('router-link');
+        expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('href', '/docs');
+    });
+
+    test('forwards refs to every part', () => {
+        const rootRef = React.createRef<HTMLElement>();
+        const listRef = React.createRef<HTMLOListElement>();
+        const itemRef = React.createRef<HTMLLIElement>();
+        const linkRef = React.createRef<HTMLAnchorElement>();
+        const pageRef = React.createRef<HTMLSpanElement>();
+        const separatorRef = React.createRef<HTMLSpanElement>();
+
+        render(
+            <Breadcrumb.Root ref={rootRef}>
+                <Breadcrumb.List ref={listRef}>
+                    <Breadcrumb.Item ref={itemRef}>
+                        <Breadcrumb.Link ref={linkRef} href="/">Home</Breadcrumb.Link>
+                        <Breadcrumb.Separator ref={separatorRef} />
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item>
+                        <Breadcrumb.Page ref={pageRef}>Docs</Breadcrumb.Page>
+                    </Breadcrumb.Item>
+                </Breadcrumb.List>
+            </Breadcrumb.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLElement);
+        expect(listRef.current).toBeInstanceOf(HTMLOListElement);
+        expect(itemRef.current).toBeInstanceOf(HTMLLIElement);
+        expect(linkRef.current).toBeInstanceOf(HTMLAnchorElement);
+        expect(pageRef.current).toBeInstanceOf(HTMLSpanElement);
+        expect(separatorRef.current).toBeInstanceOf(HTMLSpanElement);
+    });
+});

--- a/src/design-systems/baremetal/default.scss
+++ b/src/design-systems/baremetal/default.scss
@@ -5,6 +5,7 @@
 @use "../../components/ui/AvatarGroup/avatar-group.baremetal";
 @use "../../components/ui/Badge/badge.baremetal";
 @use "../../components/ui/BlockQuote/blockquote.baremetal";
+@use "../../components/ui/Breadcrumb/breadcrumb.baremetal";
 @use "../../components/ui/Button/button.baremetal";
 @use "../../components/ui/Callout/callout.baremetal";
 @use "../../components/ui/Card/card.baremetal";

--- a/src/design-systems/clarity/default.scss
+++ b/src/design-systems/clarity/default.scss
@@ -4,6 +4,7 @@
 @use "../../components/ui/AvatarGroup/avatar-group.clarity";
 @use "../../components/ui/Badge/badge.clarity";
 @use "../../components/ui/BlockQuote/blockquote.clarity";
+@use "../../components/ui/Breadcrumb/breadcrumb.clarity";
 @use "../../components/ui/Button/button.clarity";
 @use "../../components/ui/Callout/callout.clarity";
 @use "../../components/ui/Card/card.clarity";


### PR DESCRIPTION
## Summary
- add a composable Breadcrumb component with Root, List, Item, Link, Page, and Separator parts
- wire Breadcrumb into released component exports and both theme bundles
- add docs, navigation entry, examples, API tables, and a patch changeset
- keep docs builds working for the unpublished local component through a webpack alias

## Verification
- npm test -- --runTestsByPath src/components/ui/Breadcrumb/tests/Breadcrumb.test.tsx src/components/ui/Breadcrumb/tests/Breadcrumb.a11y.test.tsx --runInBand
- npm run validate:changesets
- npm run check:docs-snippets
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports
- npx stylelint src/components/ui/Breadcrumb/breadcrumb.clarity.scss src/components/ui/Breadcrumb/breadcrumb.baremetal.scss src/design-systems/clarity/default.scss src/design-systems/baremetal/default.scss
- cd docs && pnpm approve-builds --all && pnpm build

Note: the first default-heap build attempt hit the existing Rollup declaration-generation heap limit; the larger-heap command above completed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a composable Breadcrumb component with links, current-page indicators, separators, customizable styling, and accessible navigation semantics.
  - Added support for custom separators and flexible link composition.
  - Added public package exports for Breadcrumb and individual UI components.

- **Documentation**
  - Added Breadcrumb usage guidance, API reference, examples, and navigation entry.

- **Style**
  - Added Breadcrumb styling for Baremetal and Clarity themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->