### PR TITLE
fix(text-field): expose anatomy data slots

### DIFF
--- a/.changeset/text-field-data-slots.md
+++ b/.changeset/text-field-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose TextField anatomy through stable `data-slot` attributes.

--- a/src/components/ui/TextField/fragments/TextFieldInput.tsx
+++ b/src/components/ui/TextField/fragments/TextFieldInput.tsx
@@ -29,7 +29,7 @@ const TextFieldInput = React.forwardRef<HTMLInputElement, TextFieldInputProps>((
         onChange?.(event);
     };
 
-    return <input ref={composeRefs(ref, inputRef)} type={type} className={clsx(rootClass && `${rootClass}-input`, className)} value={value} defaultValue={defaultValue} onInput={handleInput} onChange={handleChange} {...props} />;
+    return <input ref={composeRefs(ref, inputRef)} type={type} className={clsx(rootClass && `${rootClass}-input`, className)} data-slot="text-field-input" value={value} defaultValue={defaultValue} onInput={handleInput} onChange={handleChange} {...props} />;
 });
 
 TextFieldInput.displayName = 'TextFieldInput';

--- a/src/components/ui/TextField/fragments/TextFieldReset.tsx
+++ b/src/components/ui/TextField/fragments/TextFieldReset.tsx
@@ -26,6 +26,7 @@ const TextFieldReset = React.forwardRef<HTMLButtonElement, TextFieldResetProps>(
             ref={ref}
             type={type}
             className={clsx(rootClass && `${rootClass}-reset`, className)}
+            data-slot="text-field-reset"
             onClick={handleClick}
             {...props}
         >

--- a/src/components/ui/TextField/fragments/TextFieldRoot.tsx
+++ b/src/components/ui/TextField/fragments/TextFieldRoot.tsx
@@ -31,7 +31,7 @@ const TextFieldRoot = React.forwardRef<HTMLDivElement, TextFieldRootProps>(({ cl
 
     return (
         <TextFieldContext.Provider value={{ rootClass, inputRef, clearInput, hasValue, setHasValue }}>
-            <div ref={ref} className={clsx(rootClass, className)} {...props}>
+            <div ref={ref} className={clsx(rootClass, className)} data-slot="text-field-root" {...props}>
                 {children}
             </div>
         </TextFieldContext.Provider>

--- a/src/components/ui/TextField/fragments/TextFieldSlot.tsx
+++ b/src/components/ui/TextField/fragments/TextFieldSlot.tsx
@@ -20,7 +20,7 @@ const TextFieldSlot = React.forwardRef<HTMLDivElement, TextFieldSlotProps>(({ ch
         inputRef.current?.focus();
     };
 
-    return <div ref={ref} role="presentation" className={clsx(rootClass && `${rootClass}-slot`, className)} data-text-field-slot={side} {...props} onMouseDown={handleMouseDown}>{children}</div>;
+    return <div ref={ref} role="presentation" className={clsx(rootClass && `${rootClass}-slot`, className)} data-slot="text-field-slot" data-text-field-slot={side} {...props} onMouseDown={handleMouseDown}>{children}</div>;
 });
 
 TextFieldSlot.displayName = 'TextFieldSlot';

--- a/src/components/ui/TextField/tests/TextField.test.tsx
+++ b/src/components/ui/TextField/tests/TextField.test.tsx
@@ -52,11 +52,16 @@ describe('TextField', () => {
         );
 
         expect(screen.getByTestId('root')).toHaveClass('rad-ui-text-field');
+        expect(screen.getByTestId('root')).toHaveAttribute('data-slot', 'text-field-root');
         expect(screen.getByLabelText('Compound field')).toHaveClass('rad-ui-text-field-input');
+        expect(screen.getByLabelText('Compound field')).toHaveAttribute('data-slot', 'text-field-input');
         expect(screen.getByTestId('start-slot')).toHaveClass('rad-ui-text-field-slot');
+        expect(screen.getByTestId('start-slot')).toHaveAttribute('data-slot', 'text-field-slot');
         expect(screen.getByTestId('start-slot')).toHaveAttribute('data-text-field-slot', 'start');
         expect(screen.getByTestId('reset')).toHaveClass('rad-ui-text-field-reset');
+        expect(screen.getByTestId('reset')).toHaveAttribute('data-slot', 'text-field-reset');
         expect(screen.getByTestId('end-slot')).toHaveClass('rad-ui-text-field-slot');
+        expect(screen.getByTestId('end-slot')).toHaveAttribute('data-slot', 'text-field-slot');
         expect(screen.getByTestId('end-slot')).toHaveAttribute('data-text-field-slot', 'end');
     });
 


### PR DESCRIPTION
## Summary

- expose TextField root/input/slot/reset anatomy through stable `data-slot` attributes
- keep the existing `data-text-field-slot` side marker for compatibility
- add a patch changeset for the additive styling contract

## Validation

- `npm test -- TextField.test.tsx --runInBand`
- `npm run validate:changesets`
- `npm run check:api-surface`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable `data-slot` attributes to TextField elements, including the root, input, reset control, and start/end slots.
  * Enables more reliable styling, customization, and targeting of individual TextField parts.

* **Tests**
  * Added coverage verifying the new TextField slot attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->