### PR TITLE
fix(progress): omit indeterminate aria value

### DIFF
--- a/.changeset/progress-indeterminate-aria.md
+++ b/.changeset/progress-indeterminate-aria.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Render indeterminate Progress without determinate ARIA value attributes.

--- a/src/components/ui/Progress/fragments/ProgressIndicator.tsx
+++ b/src/components/ui/Progress/fragments/ProgressIndicator.tsx
@@ -20,7 +20,8 @@ const ProgressIndicator = forwardRef<
     ProgressIndicatorProps
 >(({ className, style, ...props }, ref) => {
     const { value, minValue, maxValue, rootClass, state } = useContext(ProgressContext);
-    // Ensure value stays within bounds in production, use 0 if value is null
+    const isIndeterminate = value === null;
+    // Use 0 internally for the visual transform when the public value is unknown.
     const boundedValue = Math.min(Math.max(value ?? 0, minValue), maxValue);
 
     // Calculate the percentage of completion
@@ -33,7 +34,7 @@ const ProgressIndicator = forwardRef<
             className={clsx(rootClass && `${rootClass}-indicator`, className)}
             style={{ transform: `translateX(-${100 - percentage}%)`, ...style }}
             data-state={state}
-            data-value={boundedValue}
+            data-value={isIndeterminate ? undefined : boundedValue}
             data-max={maxValue}
             data-min={minValue}
             asChild={asChild}

--- a/src/components/ui/Progress/fragments/ProgressRoot.tsx
+++ b/src/components/ui/Progress/fragments/ProgressRoot.tsx
@@ -1,7 +1,5 @@
 'use client';
 import React, {
-    useEffect,
-    useState,
     forwardRef,
     ElementRef,
     ComponentPropsWithoutRef
@@ -27,8 +25,16 @@ export type ProgressRootProps = {
 const STATE_ENUMS = {
     LOADING: 'loading', // a progress is loading when the value is not null and not equal to the maxValue
     COMPLETE: 'complete', // a progress is complete when the value is equal to the maxValue
-    INDETERMINATE: 'indeterminate' // a progress is indeterminate when the value is null, by default it's 0
+    INDETERMINATE: 'indeterminate' // a progress is indeterminate when the value is null
 } as const;
+
+const getProgressState = (value: number | null, maxValue: number) => {
+    if (value === null) {
+        return STATE_ENUMS.INDETERMINATE;
+    }
+
+    return value === maxValue ? STATE_ENUMS.COMPLETE : STATE_ENUMS.LOADING;
+};
 
 const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
     (
@@ -44,22 +50,10 @@ const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
         },
         ref
     ) => {
-        const [state, setState] = useState<
-            (typeof STATE_ENUMS)[keyof typeof STATE_ENUMS]
-                >(STATE_ENUMS.LOADING);
-
         const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
         const ariaLabel = getValueLabel?.(value ?? 0, minValue, maxValue) ?? '';
-
-        useEffect(() => {
-            setState(
-                value === null
-                    ? STATE_ENUMS.INDETERMINATE
-                    : value === maxValue
-                        ? STATE_ENUMS.COMPLETE
-                        : STATE_ENUMS.LOADING
-            );
-        }, [value, maxValue]);
+        const state = getProgressState(value, maxValue);
+        const isIndeterminate = value === null;
 
         const sendValues = {
             value,
@@ -79,11 +73,11 @@ const ProgressRoot = forwardRef<ProgressRootElement, ProgressRootProps>(
                     role="progressbar"
                     aria-label={ariaLabel}
                     aria-valuetext={ariaLabel}
-                    aria-valuenow={value ?? 0}
+                    aria-valuenow={isIndeterminate ? undefined : value}
                     aria-valuemin={minValue}
                     aria-valuemax={maxValue}
                     data-state={state}
-                    data-value={value ?? 0}
+                    data-value={isIndeterminate ? undefined : value}
                     data-max={maxValue}
                     data-min={minValue}
                     className={clsx(rootClass, className)}

--- a/src/components/ui/Progress/tests/Progress.test.tsx
+++ b/src/components/ui/Progress/tests/Progress.test.tsx
@@ -39,10 +39,10 @@ describe('Progress', () => {
         expect(ref.current).not.toBeNull();
     });
 
-    test('renders progress bar with clamped value', () => {
+    test('renders progress bar with raw determinate value', () => {
         const { rerender } = render(<ProgressComp value={110} maxValue={100} minValue={0} />);
         const progressBars = screen.getAllByRole('progressbar');
-        expect(progressBars[0]).toHaveAttribute('aria-valuenow', '110'); // Root doesn't clamp, indicator does
+        expect(progressBars[0]).toHaveAttribute('aria-valuenow', '110');
 
         rerender(<ProgressComp value={100} maxValue={100} minValue={0} />);
         const updatedProgressBars = screen.getAllByRole('progressbar');
@@ -53,6 +53,12 @@ describe('Progress', () => {
         render(<ProgressComp minValue={100} maxValue={0} />);
         const progressBars = screen.getAllByRole('progressbar');
         expect(progressBars[0]).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    test('omits aria-valuenow when progress is indeterminate', () => {
+        render(<ProgressComp value={null} maxValue={100} minValue={0} />);
+        const progressBars = screen.getAllByRole('progressbar');
+        expect(progressBars[0]).not.toHaveAttribute('aria-valuenow');
     });
 
     test('binds value to progress bar', () => {
@@ -86,6 +92,7 @@ describe('Progress', () => {
                 const progressBars = screen.getAllByRole('progressbar');
                 const root = progressBars[0];
                 expect(root).toHaveAttribute('data-state', 'indeterminate');
+                expect(root).not.toHaveAttribute('data-value');
             });
 
             test('renders with correct data-value', () => {
@@ -205,6 +212,7 @@ describe('Progress', () => {
                 render(<ProgressComp value={null} maxValue={100} minValue={0} />);
                 const indicator = screen.getByTestId('progress-indicator');
                 expect(indicator).toHaveAttribute('data-state', 'indeterminate'); // Indicator now shows actual state
+                expect(indicator).not.toHaveAttribute('data-value');
             });
 
             test('indicator renders with correct data-value (bounded)', () => {


### PR DESCRIPTION
## Summary

- derive Progress state during render instead of through an effect
- omit `aria-valuenow` and `data-value` when `value` is `null`
- cover indeterminate root and indicator attributes in Progress tests

## Checks

- npm test -- Progress --runInBand
- npm run validate:changesets
- npm run check:api-surface
- npm run lint -- --quiet
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indeterminate progress indicators by omitting misleading `aria-valuenow` and `data-value` attributes.
  * Preserved accurate values and accessibility attributes for determinate progress indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->