### PR TITLE
feat(tooltip): expose anatomy data slots

### DIFF
--- a/.changeset/tooltip-data-slots.md
+++ b/.changeset/tooltip-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose Tooltip anatomy data slots for root, trigger, content, and arrow parts.

--- a/src/components/ui/Tooltip/fragments/TooltipContent.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipContent.tsx
@@ -44,12 +44,13 @@ const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentPro
                 <Primitive.div
                     className="rad-ui-tooltip-floating-element"
                     ref={mergedRef}
+                    data-slot="tooltip-content"
                     data-state={isOpen ? 'open' : 'closed'}
                     style={{ ...data.floatingStyles }}
                     {...getFloatingProps(props)}
                 >
                     <div className="rad-ui-tooltip-content-inner">
-                        {showArrow && <FloatingArrow className={clsx('rad-ui-arrow')} ref={arrowRef} context={context} />}
+                        {showArrow && <FloatingArrow className={clsx('rad-ui-arrow')} ref={arrowRef} context={context} data-slot="tooltip-arrow" />}
                         {children}
                     </div>
                 </Primitive.div>

--- a/src/components/ui/Tooltip/fragments/TooltipRoot.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipRoot.tsx
@@ -85,7 +85,7 @@ const TooltipRoot = React.forwardRef<TooltipRootElement, TooltipRootProps>(
 
         return (
             <TooltipContext.Provider value={{ isOpen, setIsOpen, data, interactions, context, arrowRef }}>
-                <div ref={ref} {...props}>
+                <div ref={ref} data-slot="tooltip-root" {...props}>
                     {children}
                 </div>
             </TooltipContext.Provider>

--- a/src/components/ui/Tooltip/fragments/TooltipTrigger.tsx
+++ b/src/components/ui/Tooltip/fragments/TooltipTrigger.tsx
@@ -31,6 +31,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             <ButtonPrimitive
                 asChild={asChild}
                 ref={mergedRef}
+                data-slot="tooltip-trigger"
                 data-state={isOpen ? 'open' : 'closed'}
                 {...getReferenceProps(props)}
             >

--- a/src/components/ui/Tooltip/tests/Tooltip.behavior.test.tsx
+++ b/src/components/ui/Tooltip/tests/Tooltip.behavior.test.tsx
@@ -34,6 +34,24 @@ describe('Tooltip interactions', () => {
         await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
     });
 
+    test('exposes stable anatomy data slots', async() => {
+        render(
+            <Tooltip.Root data-testid="tooltip-root">
+                <Tooltip.Trigger>Trigger</Tooltip.Trigger>
+                <Tooltip.Content>Content</Tooltip.Content>
+            </Tooltip.Root>
+        );
+
+        expect(screen.getByTestId('tooltip-root')).toHaveAttribute('data-slot', 'tooltip-root');
+        expect(screen.getByText('Trigger')).toHaveAttribute('data-slot', 'tooltip-trigger');
+
+        await userEvent.hover(screen.getByText('Trigger'));
+
+        const tooltip = await screen.findByRole('tooltip');
+        expect(tooltip).toHaveAttribute('data-slot', 'tooltip-content');
+        expect(tooltip.querySelector('[data-slot="tooltip-arrow"]')).toBeInTheDocument();
+    });
+
     test('asChild trigger preserves element and forwards refs', async() => {
         const childRef = React.createRef<HTMLAnchorElement>();
         const triggerRef = React.createRef<HTMLAnchorElement>();


### PR DESCRIPTION
## Summary
- add stable Tooltip anatomy data slots for root, trigger, content, and arrow
- cover the public slot contract in Tooltip behavior tests
- add a patch changeset

## Checks
- npm test -- Tooltip.behavior.test.tsx Tooltip.test.tsx --runInBand
- npm run validate:changesets
- npm run lint

Note: `npm run check:exports` is blocked in this fresh worktree because `dist/components` is not present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable data-slot attributes to Tooltip root, trigger, content, and arrow elements.
  * Improved support for targeted styling and customization of Tooltip parts.

* **Tests**
  * Added interaction coverage confirming Tooltip data slots remain available after hover.

* **Documentation**
  * Documented the exposed Tooltip anatomy data slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->