### PR TITLE
feat(popover): expose anatomy data slots

### DIFF
--- a/.changeset/popover-data-slots.md
+++ b/.changeset/popover-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose Popover anatomy data slots for root, anchor, trigger, content, close, and arrow parts.

--- a/src/components/ui/Popover/fragments/PopoverAnchor.tsx
+++ b/src/components/ui/Popover/fragments/PopoverAnchor.tsx
@@ -15,6 +15,7 @@ const PopoverAnchor = forwardRef<PopoverAnchorElement, PopoverAnchorProps>(({ cl
         <PopoverPrimitive.Anchor
             ref={ref}
             className={clsx(rootClass && `${rootClass}-anchor`, className)}
+            data-slot="popover-anchor"
             {...props}
         />
     );

--- a/src/components/ui/Popover/fragments/PopoverArrow.tsx
+++ b/src/components/ui/Popover/fragments/PopoverArrow.tsx
@@ -15,6 +15,7 @@ const PopoverArrow = forwardRef<PopoverArrowElement, PopoverArrowProps>(({ class
         <PopoverPrimitive.Arrow
             ref={ref}
             className={clsx(rootClass && `${rootClass}-arrow`, className)}
+            data-slot="popover-arrow"
             {...props}
         />
     );

--- a/src/components/ui/Popover/fragments/PopoverClose.tsx
+++ b/src/components/ui/Popover/fragments/PopoverClose.tsx
@@ -15,6 +15,7 @@ const PopoverClose = forwardRef<PopoverCloseElement, PopoverCloseProps>(({ class
         <PopoverPrimitive.Close
             ref={ref}
             className={clsx(rootClass && `${rootClass}-close`, className)}
+            data-slot="popover-close"
             {...props}
         />
     );

--- a/src/components/ui/Popover/fragments/PopoverContent.tsx
+++ b/src/components/ui/Popover/fragments/PopoverContent.tsx
@@ -15,6 +15,7 @@ const PopoverContent = forwardRef<PopoverContentElement, PopoverContentProps>(({
         <PopoverPrimitive.Content
             ref={ref}
             className={clsx(rootClass && `${rootClass}-content`, className)}
+            data-slot="popover-content"
             {...props}
         />
     );

--- a/src/components/ui/Popover/fragments/PopoverRoot.tsx
+++ b/src/components/ui/Popover/fragments/PopoverRoot.tsx
@@ -24,7 +24,12 @@ const PopoverRoot = forwardRef<PopoverRootElement, PopoverRootProps>(({
 
     return (
         <PopoverContext.Provider value={{ rootClass }}>
-            <PopoverPrimitive.Root ref={ref} className={clsx(rootClass, className)} {...props}>
+            <PopoverPrimitive.Root
+                ref={ref}
+                className={clsx(rootClass, className)}
+                data-slot="popover-root"
+                {...props}
+            >
                 {children}
             </PopoverPrimitive.Root>
         </PopoverContext.Provider>

--- a/src/components/ui/Popover/fragments/PopoverTrigger.tsx
+++ b/src/components/ui/Popover/fragments/PopoverTrigger.tsx
@@ -15,6 +15,7 @@ const PopoverTrigger = forwardRef<PopoverTriggerElement, PopoverTriggerProps>(({
         <PopoverPrimitive.Trigger
             ref={ref}
             className={clsx(rootClass && `${rootClass}-trigger`, className)}
+            data-slot="popover-trigger"
             {...props}
         />
     );

--- a/src/components/ui/Popover/tests/Popover.test.tsx
+++ b/src/components/ui/Popover/tests/Popover.test.tsx
@@ -39,6 +39,7 @@ describe('Popover', () => {
 
         render(
             <Popover.Root ref={rootRef}>
+                <Popover.Anchor data-testid="anchor">Anchor</Popover.Anchor>
                 <Popover.Trigger ref={triggerRef}>Open</Popover.Trigger>
                 <Popover.Content ref={contentRef}>
                     Body
@@ -55,6 +56,12 @@ describe('Popover', () => {
         expect(contentRef.current).toBeInstanceOf(HTMLDivElement);
         expect(closeRef.current).toBeInstanceOf(HTMLButtonElement);
         expect(arrowRef.current).toBeInstanceOf(SVGSVGElement);
+        expect(rootRef.current).toHaveAttribute('data-slot', 'popover-root');
+        expect(screen.getByTestId('anchor')).toHaveAttribute('data-slot', 'popover-anchor');
+        expect(screen.getByRole('button', { name: 'Open' })).toHaveAttribute('data-slot', 'popover-trigger');
+        expect(screen.getByRole('dialog')).toHaveAttribute('data-slot', 'popover-content');
+        expect(screen.getByRole('button', { name: 'Close' })).toHaveAttribute('data-slot', 'popover-close');
+        expect(arrowRef.current).toHaveAttribute('data-slot', 'popover-arrow');
     });
 
     test('toggles open state and dismisses on outside interaction', async() => {


### PR DESCRIPTION
## Summary
- Add stable data-slot markers to Popover root, anchor, trigger, content, close, and arrow parts.
- Cover the anatomy contract in the existing Popover compound API test.
- Add a patch changeset for the public styling hook.

## Checks
- npm test -- Popover.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- git diff --check
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identifiable data slots to all Popover parts, including the root, anchor, trigger, content, close button, and arrow.
  * Enables more targeted styling, customization, and integration with Popover anatomy.

* **Tests**
  * Added coverage confirming data slots are applied across Popover components.
  * Expanded compound component and ref-forwarding coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->