### PR TITLE
feat(accordion): expose anatomy data slots

### DIFF
--- a/.changeset/accordion-data-slots.md
+++ b/.changeset/accordion-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable Accordion anatomy data slots for root, item, header, trigger, content, and content inner parts.

--- a/src/components/ui/Accordion/fragments/AccordionContent.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionContent.tsx
@@ -26,6 +26,7 @@ const AccordionContent = React.forwardRef<React.ElementRef<'div'>, AccordionCont
                 role="region"
                 aria-labelledby={headerId}
                 data-orientation={orientation}
+                data-slot="accordion-content"
                 style={{
                     ['--radix-accordion-content-height' as string]:
                         'var(--radix-collapsible-content-height)',
@@ -42,7 +43,10 @@ const AccordionContent = React.forwardRef<React.ElementRef<'div'>, AccordionCont
                 {asChild ? (
                     children
                 ) : (
-                    <div className={rootClass ? `${rootClass}-content-inner` : undefined}>
+                    <div
+                        className={rootClass ? `${rootClass}-content-inner` : undefined}
+                        data-slot="accordion-content-inner"
+                    >
                         {children}
                     </div>
                 )}

--- a/src/components/ui/Accordion/fragments/AccordionHeader.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionHeader.tsx
@@ -16,7 +16,7 @@ const AccordionHeader = React.forwardRef<HTMLHeadingElement, AccordionHeaderProp
         if (asChild && isValidElement(children)) {
             const child = children as React.ReactElement;
             const merged = mergeProps(
-                { className: mergedClass, 'data-orientation': orientation },
+                { className: mergedClass, 'data-orientation': orientation, 'data-slot': 'accordion-header' },
                 child.props as Record<string, unknown>
             );
             return cloneElement(child, {
@@ -26,7 +26,13 @@ const AccordionHeader = React.forwardRef<HTMLHeadingElement, AccordionHeaderProp
         }
 
         return (
-            <h3 ref={ref} className={mergedClass} data-orientation={orientation} {...props}>
+            <h3
+                ref={ref}
+                className={mergedClass}
+                data-orientation={orientation}
+                data-slot="accordion-header"
+                {...props}
+            >
                 {children}
             </h3>
         );

--- a/src/components/ui/Accordion/fragments/AccordionItem.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionItem.tsx
@@ -79,6 +79,7 @@ const AccordionItem = React.forwardRef<React.ElementRef<'div'>, AccordionItemPro
                     data-state={isOpen ? 'open' : 'closed'}
                     data-disabled={effectiveDisabled ? '' : undefined}
                     data-orientation={orientation}
+                    data-slot="accordion-item"
                     asChild={asChild}
                     {...props}
                 >

--- a/src/components/ui/Accordion/fragments/AccordionRoot.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionRoot.tsx
@@ -124,6 +124,7 @@ const AccordionRoot = React.forwardRef<React.ElementRef<'div'>, AccordionRootPro
                         className={clsx(rootClass, className)}
                         dir={dir}
                         data-orientation={orientation}
+                        data-slot="accordion-root"
                         ref={(node) => {
                             const element = node as HTMLDivElement | null;
                             accordionRef.current = element;

--- a/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
+++ b/src/components/ui/Accordion/fragments/AccordionTrigger.tsx
@@ -26,6 +26,7 @@ const AccordionTrigger = React.forwardRef<React.ElementRef<'button'>, AccordionT
                         aria-disabled={disabled}
                         aria-expanded={activeItems.includes(itemValue)}
                         data-orientation={orientation}
+                        data-slot="accordion-trigger"
                         asChild={asChild}
                         {...props}
                     >

--- a/src/components/ui/Accordion/tests/Accordion.test.tsx
+++ b/src/components/ui/Accordion/tests/Accordion.test.tsx
@@ -98,6 +98,28 @@ describe('Accordion Component', () => {
         expect(content.firstElementChild).toHaveClass('acme-accordion-content-inner');
     });
 
+    test('exposes stable anatomy data slots', () => {
+        render(
+            <Accordion.Root data-testid="accordion-root" defaultValue="0">
+                <Accordion.Item data-testid="accordion-item" value="0">
+                    <Accordion.Header data-testid="accordion-header">
+                        <Accordion.Trigger data-testid="accordion-trigger">Item 1</Accordion.Trigger>
+                    </Accordion.Header>
+                    <Accordion.Content data-testid="accordion-content">Content 1</Accordion.Content>
+                </Accordion.Item>
+            </Accordion.Root>
+        );
+
+        const content = screen.getByTestId('accordion-content');
+
+        expect(screen.getByTestId('accordion-root')).toHaveAttribute('data-slot', 'accordion-root');
+        expect(screen.getByTestId('accordion-item')).toHaveAttribute('data-slot', 'accordion-item');
+        expect(screen.getByTestId('accordion-header')).toHaveAttribute('data-slot', 'accordion-header');
+        expect(screen.getByTestId('accordion-trigger')).toHaveAttribute('data-slot', 'accordion-trigger');
+        expect(content).toHaveAttribute('data-slot', 'accordion-content');
+        expect(content.firstElementChild).toHaveAttribute('data-slot', 'accordion-content-inner');
+    });
+
     test('maps collapsible measurement variables to radix accordion variables', () => {
         render(
             <Accordion.Root defaultValue="0">


### PR DESCRIPTION
## Summary

Expose stable `data-slot` markers across Accordion root, item, header, trigger, content, and content inner parts so consumers can style anatomy without generated classes.

## Validation

- `npm test -- Accordion.test.tsx --runInBand`
- `npm run validate:changesets`
- `npm run check:api-surface`
- `git diff --check`
- `NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process`
- `npm run check:exports`