### PR TITLE
fix(switch): expose anatomy slots

### DIFF
--- a/.changeset/switch-anatomy-semantics.md
+++ b/.changeset/switch-anatomy-semantics.md
@@ -1,0 +1,5 @@
+---
+"@rad-ui/ui": patch
+---
+
+Expose stable Switch anatomy data slots and keep the thumb visual-only for assistive technologies.

--- a/src/components/ui/Switch/fragments/SwitchRoot.tsx
+++ b/src/components/ui/Switch/fragments/SwitchRoot.tsx
@@ -72,6 +72,7 @@ const SwitchRoot = forwardRef<SwitchRootElement, SwitchRootProps>(({
 
     const switchAttributes: Record<string, any> = {
         ...composedAttributes,
+        'data-slot': 'switch-root',
         'data-state': isChecked ? 'checked' : 'unchecked',
         'data-disabled': disabled ? '' : undefined,
         role: 'switch',

--- a/src/components/ui/Switch/fragments/SwitchThumb.tsx
+++ b/src/components/ui/Switch/fragments/SwitchThumb.tsx
@@ -16,6 +16,7 @@ const SwitchThumb = forwardRef<SwitchThumbElement, SwitchThumbProps>(({ asChild 
     const { checked, rootClass, disabled } = useContext(SwitchContext);
 
     const dataAttributes: Record<string, string> = {};
+    dataAttributes['data-slot'] = 'switch-thumb';
     dataAttributes['data-state'] = checked ? 'checked' : 'unchecked';
     if (disabled) {
         dataAttributes['data-disabled'] = '';
@@ -24,7 +25,6 @@ const SwitchThumb = forwardRef<SwitchThumbElement, SwitchThumbProps>(({ asChild 
     return (
         <Primitive.span
             ref={ref}
-            role='switch'
             className={clsx(rootClass && `${rootClass}-indicator`, className)}
             asChild={asChild}
             {...dataAttributes}

--- a/src/components/ui/Switch/tests/Switch.behavior.test.tsx
+++ b/src/components/ui/Switch/tests/Switch.behavior.test.tsx
@@ -25,6 +25,20 @@ describe('Switch behaviour', () => {
         expect(button).toHaveAttribute('data-state', 'unchecked');
     });
 
+    test('exposes stable anatomy slots without duplicating switch semantics', () => {
+        const { container } = render(
+            <Switch.Root>
+                <Switch.Thumb />
+            </Switch.Root>
+        );
+        const switches = screen.getAllByRole('switch');
+        expect(switches).toHaveLength(1);
+        expect(switches[0]).toHaveAttribute('data-slot', 'switch-root');
+        const thumb = container.querySelector('[data-slot="switch-thumb"]');
+        expect(thumb).toBeInTheDocument();
+        expect(thumb).not.toHaveAttribute('role');
+    });
+
     test('controlled and uncontrolled checked states stay in sync', async() => {
         const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- Adds stable data-slot markers to Switch.Root and Switch.Thumb for anatomy-based styling.
- Keeps Switch.Thumb visual-only so assistive technologies see one switch control.
- Adds regression coverage and a patch changeset.

## Test plan
- npm test -- Switch.behavior.test.tsx Switch.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- NODE_OPTIONS="--max-old-space-size=12288" npm run build:rollup:process
- npm run check:exports
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved Switch semantics so assistive technologies recognize a single switch control without a duplicate role on the thumb.

- **Enhancements**
  - Added stable anatomy markers for the Switch root and thumb, supporting more reliable styling and integration.

- **Tests**
  - Added coverage verifying Switch anatomy markers and correct accessibility roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->