### PR TITLE
fix(tabs): expose anatomy data slots

### DIFF
--- a/.changeset/tabs-data-slots.md
+++ b/.changeset/tabs-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable Tabs anatomy markers through `data-slot` attributes on root, list, trigger, and content parts.

--- a/src/components/ui/Tabs/fragments/TabContent.tsx
+++ b/src/components/ui/Tabs/fragments/TabContent.tsx
@@ -38,6 +38,7 @@ const TabContent = React.forwardRef<React.ElementRef<'div'>, TabContentProps>(
                 className={clsx(rootClass, className)}
                 role="tabpanel"
                 aria-hidden={!isActive}
+                data-slot="tabs-content"
                 asChild={asChild}
                 {...dataAttributes}
                 {...props}

--- a/src/components/ui/Tabs/fragments/TabList.tsx
+++ b/src/components/ui/Tabs/fragments/TabList.tsx
@@ -27,6 +27,7 @@ const TabList = React.forwardRef<React.ElementRef<'div'>, TabListProps>(
                     aria-orientation={orientation}
                     aria-label="todo"
                     className={clsx(rootClass && `${rootClass}-list`, className)}
+                    data-slot="tabs-list"
                     asChild={asChild}
                     {...props}
                 >

--- a/src/components/ui/Tabs/fragments/TabRoot.tsx
+++ b/src/components/ui/Tabs/fragments/TabRoot.tsx
@@ -80,6 +80,7 @@ const TabRoot = React.forwardRef<React.ElementRef<'div'>, TabRootProps>(({
                     ref={forwardedRef}
                     className={clsx(rootClass, className)}
                     data-color={color}
+                    data-slot="tabs-root"
                     asChild={asChild}
                     {...dataAttributes}
                     {...props}

--- a/src/components/ui/Tabs/fragments/TabTrigger.tsx
+++ b/src/components/ui/Tabs/fragments/TabTrigger.tsx
@@ -72,6 +72,7 @@ const TabTrigger = React.forwardRef<React.ElementRef<'button'>, TabTriggerProps>
                     aria-selected={isActive}
                     aria-disabled={disabled}
                     disabled={disabled}
+                    data-slot="tabs-trigger"
                     asChild={asChild}
                     {...dataAttributes}
                     {...props}

--- a/src/components/ui/Tabs/tests/Tabs.test.tsx
+++ b/src/components/ui/Tabs/tests/Tabs.test.tsx
@@ -431,7 +431,7 @@ describe('Tabs Component', () => {
 
         test('data attributes are set correctly', () => {
             render(
-                <Tabs.Root defaultValue="tab1" orientation="horizontal">
+                <Tabs.Root defaultValue="tab1" orientation="horizontal" data-testid="tabs-root">
                     <Tabs.List>
                         <Tabs.Trigger value="tab1">Tab 1</Tabs.Trigger>
                         <Tabs.Trigger value="tab2" disabled>Tab 2</Tabs.Trigger>
@@ -444,21 +444,26 @@ describe('Tabs Component', () => {
             // Check root data-orientation
             const root = screen.getByRole('tablist').closest('[data-orientation]');
             expect(root).toHaveAttribute('data-orientation', 'horizontal');
+            expect(screen.getByTestId('tabs-root')).toHaveAttribute('data-slot', 'tabs-root');
+            expect(screen.getByRole('tablist')).toHaveAttribute('data-slot', 'tabs-list');
 
             // Check trigger data attributes
             const tab1 = screen.getByText('Tab 1');
             const tab2 = screen.getByText('Tab 2');
 
+            expect(tab1).toHaveAttribute('data-slot', 'tabs-trigger');
             expect(tab1).toHaveAttribute('data-state', 'active');
             expect(tab1).toHaveAttribute('data-orientation', 'horizontal');
             expect(tab1).not.toHaveAttribute('data-disabled');
 
+            expect(tab2).toHaveAttribute('data-slot', 'tabs-trigger');
             expect(tab2).toHaveAttribute('data-state', 'inactive');
             expect(tab2).toHaveAttribute('data-orientation', 'horizontal');
             expect(tab2).toHaveAttribute('data-disabled', '');
 
             // Check content data attributes
             const content1 = screen.getByText('Content 1');
+            expect(content1).toHaveAttribute('data-slot', 'tabs-content');
             expect(content1).toHaveAttribute('data-state', 'active');
             expect(content1).toHaveAttribute('data-orientation', 'horizontal');
         });


### PR DESCRIPTION
## Summary
- add stable `data-slot` markers to Tabs root, list, trigger, and content
- cover the public anatomy contract in the Tabs data-attribute test
- add a patch changeset

## Checks
- npm test -- Tabs.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- git diff --check
- NODE_OPTIONS="--max-old-space-size=12288" npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable `data-slot` markers to Tabs components, including the root, list, triggers, and content.
  * Improved support for identifying and styling individual Tabs parts.

* **Tests**
  * Added coverage verifying the new Tabs `data-slot` attributes alongside existing state and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->