### PR TITLE
fix(hover-card): expose anatomy data slots

### DIFF
--- a/.changeset/hover-card-data-slots.md
+++ b/.changeset/hover-card-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@rad-ui/ui": patch
+---
+
+Expose stable `data-slot` anatomy markers on HoverCard root, trigger, content, and arrow parts.

--- a/src/components/ui/HoverCard/fragments/HoverCardArrow.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardArrow.tsx
@@ -10,7 +10,7 @@ const HoverCardArrow = forwardRef<HoverCardArrowElement, HoverCardArrowProps>((p
     const { floatingContext, arrowRef, rootClass } = useContext(HoverCardContext);
     const mergedRef = Floater.useMergeRefs([arrowRef, ref]);
 
-    return <Floater.Arrow className={clsx(rootClass && `${rootClass}-arrow`)} {...props} context={floatingContext} ref={mergedRef} />;
+    return <Floater.Arrow className={clsx(rootClass && `${rootClass}-arrow`)} data-slot="hover-card-arrow" {...props} context={floatingContext} ref={mergedRef} />;
 });
 
 HoverCardArrow.displayName = 'HoverCardArrow';

--- a/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardContent.tsx
@@ -43,6 +43,7 @@ const HoverCardContent = forwardRef<HoverCardContentElement, HoverCardContentPro
         style={floatingStyles}
         {...dataAttributes}
         {...getFloatingProps({
+            'data-slot': 'hover-card-content',
             onPointerEnter: openWithDelay,
             onPointerLeave: closeWithDelay,
             ...props

--- a/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardRoot.tsx
@@ -154,7 +154,7 @@ const HoverCardRoot = forwardRef<HoverCardRootElement, HoverCardRootProps>(({ ch
     };
 
     return <HoverCardContext.Provider value={sendValues}>
-        <div ref={ref} className={clsx(rootClass && `${rootClass}-root`, className)} {...props}>{children}</div>
+        <div ref={ref} className={clsx(rootClass && `${rootClass}-root`, className)} data-slot="hover-card-root" {...props}>{children}</div>
     </HoverCardContext.Provider>;
 });
 

--- a/src/components/ui/HoverCard/fragments/HoverCardTrigger.tsx
+++ b/src/components/ui/HoverCard/fragments/HoverCardTrigger.tsx
@@ -17,6 +17,7 @@ const HoverCardTrigger = forwardRef<HoverCardTriggerElement, HoverCardTriggerPro
         ref={mergedRef}
         className={clsx(rootTriggerClass, className)}
         {...getReferenceProps({
+            'data-slot': 'hover-card-trigger',
             onMouseEnter: openWithDelay,
             onMouseLeave: closeWithDelay,
             ...props

--- a/src/components/ui/HoverCard/tests/HoverCard.test.tsx
+++ b/src/components/ui/HoverCard/tests/HoverCard.test.tsx
@@ -51,6 +51,25 @@ describe('HoverCard', () => {
         expect(arrowRef.current).toBeInstanceOf(SVGSVGElement);
     });
 
+    test('exposes stable anatomy data slots', () => {
+        const arrowRef = createRef<SVGSVGElement>();
+
+        render(
+            <HoverCard.Root open onOpenChange={() => {}} data-testid="hover-card-root">
+                <HoverCard.Trigger>Trigger</HoverCard.Trigger>
+                <HoverCard.Content>
+                    Content
+                    <HoverCard.Arrow ref={arrowRef} />
+                </HoverCard.Content>
+            </HoverCard.Root>
+        );
+
+        expect(screen.getByTestId('hover-card-root')).toHaveAttribute('data-slot', 'hover-card-root');
+        expect(screen.getByText('Trigger')).toHaveAttribute('data-slot', 'hover-card-trigger');
+        expect(screen.getByRole('dialog')).toHaveAttribute('data-slot', 'hover-card-content');
+        expect(arrowRef.current).toHaveAttribute('data-slot', 'hover-card-arrow');
+    });
+
     test('does not hijack child refs', () => {
         const triggerRef = createRef<HTMLSpanElement>();
         const buttonRef = createRef<HTMLButtonElement>();


### PR DESCRIPTION
## Summary
- add stable `data-slot` markers to HoverCard root, trigger, content, and arrow
- cover the anatomy contract with a focused HoverCard test
- add a patch changeset

## Testing
- npm test -- HoverCard.test.tsx --runInBand
- npm run validate:changesets
- git diff --check
- npm run check:api-surface
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable `data-slot` markers to HoverCard root, trigger, content, and arrow elements.
  * Enables more reliable styling, testing, and element targeting.

* **Tests**
  * Added coverage verifying the new HoverCard markers.

* **Chores**
  * Prepared a patch release for the HoverCard updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->