### PR TITLE
fix(select): expose anatomy data slots

### DIFF
--- a/.changeset/select-data-slots.md
+++ b/.changeset/select-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable Select anatomy markers through `data-slot` attributes on root, trigger, content, group, item, item text, and item indicator parts.

--- a/src/components/ui/Select/fragments/SelectContent.tsx
+++ b/src/components/ui/Select/fragments/SelectContent.tsx
@@ -16,6 +16,7 @@ const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>
             className={rootClass ? `${rootClass}-content` : undefined}
             position={position}
             data-position={position}
+            data-slot="select-content"
             ref={forwardedRef}
             {...props}
         >

--- a/src/components/ui/Select/fragments/SelectGroup.tsx
+++ b/src/components/ui/Select/fragments/SelectGroup.tsx
@@ -16,6 +16,7 @@ const SelectGroup = React.forwardRef<SelectGroupElement, SelectGroupComponentPro
     return (
         <ComboboxPrimitive.Group
             className={mergedClassName}
+            data-slot="select-group"
             ref={forwardedRef}
             {...props}
         >

--- a/src/components/ui/Select/fragments/SelectIndicator.tsx
+++ b/src/components/ui/Select/fragments/SelectIndicator.tsx
@@ -9,7 +9,7 @@ export type SelectIndicatorProps = React.ComponentPropsWithoutRef<'div'>;
 const SelectIndicator = React.forwardRef<SelectIndicatorElement, SelectIndicatorProps>((props, forwardedRef) => {
     const { rootClass } = useContext(SelectRootContext);
     return (
-        <div className={rootClass ? `${rootClass}-item-indicator` : undefined} ref={forwardedRef} {...props}>
+        <div className={rootClass ? `${rootClass}-item-indicator` : undefined} data-slot="select-item-indicator" ref={forwardedRef} {...props}>
             <Check width={16} height={16} />
         </div>
     );

--- a/src/components/ui/Select/fragments/SelectItem.tsx
+++ b/src/components/ui/Select/fragments/SelectItem.tsx
@@ -35,12 +35,13 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(({ custo
             label={itemLabel}
             disabled={disabled}
             data-disabled={disabled ? '' : undefined}
+            data-slot="select-item"
             role="option"
             aria-disabled={disabled ? 'true' : undefined}
             ref={forwardedRef}
             {...props}
         >
-            <span className={rootClass ? `${rootClass}-text` : undefined}>{children}</span>
+            <span className={rootClass ? `${rootClass}-text` : undefined} data-slot="select-item-text">{children}</span>
         </ComboboxPrimitive.Item>
     );
 });

--- a/src/components/ui/Select/fragments/SelectRoot.tsx
+++ b/src/components/ui/Select/fragments/SelectRoot.tsx
@@ -18,6 +18,7 @@ const SelectRoot = React.forwardRef<SelectRootElement, SelectRootProps>(
             <SelectRootContext.Provider value={{ rootClass }}>
                 <ComboboxPrimitive.Root
                     className={rootClass ? `${rootClass}-root` : undefined}
+                    data-slot="select-root"
                     defaultValue={defaultValue}
                     value={value}
                     onValueChange={onValueChange}

--- a/src/components/ui/Select/fragments/SelectTrigger.tsx
+++ b/src/components/ui/Select/fragments/SelectTrigger.tsx
@@ -18,6 +18,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
             className={rootClass ? `${rootClass}-trigger` : undefined}
             aria-disabled={disabled ? 'true' : undefined}
             data-placeholder={placeholder ? '' : undefined}
+            data-slot="select-trigger"
             disabled={disabled}
             ref={forwardedRef}
             {...props}

--- a/src/components/ui/Select/tests/Select.test.tsx
+++ b/src/components/ui/Select/tests/Select.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Select from '../Select';
 
 describe('Select', () => {
@@ -24,6 +25,35 @@ describe('Select', () => {
         const hiddenSelect = container.querySelector('select');
         expect(hiddenSelect).toHaveAttribute('aria-hidden', 'true');
         expect(hiddenSelect).toHaveValue('Apple');
+    });
+
+    test('exposes stable anatomy data slots', async() => {
+        const { getByRole } = render(
+            <Select.Root defaultValue="Apple">
+                <Select.Trigger>Apple</Select.Trigger>
+                <Select.Portal>
+                    <Select.Content>
+                        <Select.Group>
+                            <Select.Item value="Apple">
+                                Apple
+                                <Select.Indicator />
+                            </Select.Item>
+                        </Select.Group>
+                    </Select.Content>
+                </Select.Portal>
+            </Select.Root>
+        );
+
+        const trigger = getByRole('combobox');
+        expect(trigger).toHaveAttribute('data-slot', 'select-trigger');
+        await userEvent.click(trigger);
+
+        expect(document.querySelector('[data-slot="select-root"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-slot="select-content"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-slot="select-group"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-slot="select-item"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-slot="select-item-text"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-slot="select-item-indicator"]')).toBeInTheDocument();
     });
 
     test('renders without warnings', () => {


### PR DESCRIPTION
## Summary
- add stable `data-slot` markers for Select root, trigger, content, group, item, item text, and indicator
- cover the anatomy contract with a Select regression test
- add a patch changeset

## Checks
- npm test -- Select.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- git diff --check
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable `data-slot` markers to Select components and their parts, making them easier to identify for styling and integrations.
  * Covered Select roots, triggers, content, groups, items, item text, and indicators.

* **Tests**
  * Added coverage verifying Select markers remain available when the dropdown is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->