### PR TITLE
fix(radio-group): expose anatomy data slots

### DIFF
--- a/.changeset/radio-group-data-slots.md
+++ b/.changeset/radio-group-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable RadioGroup anatomy markers through `data-slot` attributes on root, label, item, and indicator parts.

--- a/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupIndicator.tsx
@@ -14,7 +14,12 @@ const RadioGroupIndicator = React.forwardRef<RadioGroupIndicatorElement, RadioGr
     ({ className = '', children, ...props }, ref) => {
         const { rootClass } = React.useContext(RadioGroupContext);
         return (
-            <RadioGroupPrimitive.Indicator ref={ref} className={clsx(rootClass && `${rootClass}-indicator`, className)} {...props} >
+            <RadioGroupPrimitive.Indicator
+                ref={ref}
+                className={clsx(rootClass && `${rootClass}-indicator`, className)}
+                data-slot="radio-group-indicator"
+                {...props}
+            >
                 {children}
             </RadioGroupPrimitive.Indicator>
         );

--- a/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupItem.tsx
@@ -14,7 +14,17 @@ export type RadioGroupItemProps = {
 const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
     ({ children, className = '', value, ...props }, ref) => {
         const { rootClass } = useContext(RadioGroupContext);
-        return <RadioGroupPrimitive.Item ref={ref} className={clsx(rootClass && `${rootClass}-item`, className)} value={value} {...props}>{children}</RadioGroupPrimitive.Item>;
+        return (
+            <RadioGroupPrimitive.Item
+                ref={ref}
+                className={clsx(rootClass && `${rootClass}-item`, className)}
+                value={value}
+                data-slot="radio-group-item"
+                {...props}
+            >
+                {children}
+            </RadioGroupPrimitive.Item>
+        );
     }
 );
 

--- a/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupLabel.tsx
@@ -10,7 +10,17 @@ export type RadioGroupLabelProps = React.ComponentPropsWithoutRef<typeof Primiti
 const RadioGroupLabel = React.forwardRef<RadioGroupLabelElement, RadioGroupLabelProps>(
     ({ className = '', asChild = false, children, ...props }, ref) => {
         const { rootClass } = React.useContext(RadioGroupContext);
-        return <Primitive.label ref={ref} {...props} className={clsx(rootClass && `${rootClass}-label`, className)} asChild={asChild}> {children} </Primitive.label>;
+        return (
+            <Primitive.label
+                ref={ref}
+                data-slot="radio-group-label"
+                {...props}
+                className={clsx(rootClass && `${rootClass}-label`, className)}
+                asChild={asChild}
+            >
+                {children}
+            </Primitive.label>
+        );
     }
 );
 

--- a/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
+++ b/src/components/ui/RadioGroup/fragments/RadioGroupRoot.tsx
@@ -28,7 +28,9 @@ const RadioGroupRoot = React.forwardRef<RadioGroupRootElement, RadioGroupRootPro
         const dataAttributes = createDataAttributes('radio-group', { variant, size });
 
         const accentAttributes = createDataAccentColorAttribute(color);
-        const composedAttributes = composeAttributes(dataAttributes, accentAttributes);
+        const composedAttributes = composeAttributes(dataAttributes, accentAttributes, {
+            'data-slot': 'radio-group-root'
+        });
 
         return <RadioGroupContext.Provider value={{ rootClass }}>
             <RadioGroupPrimitive.Root ref={ref} className={clsx(rootClass && `${rootClass}-root`, className)} {...composedAttributes} {...props}> {children} </RadioGroupPrimitive.Root>

--- a/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
+++ b/src/components/ui/RadioGroup/tests/RadioGroup.test.tsx
@@ -89,6 +89,15 @@ describe('RadioGroup (fragments)', () => {
         expect(group.getAttribute('data-color')).toBe('primary');
     });
 
+    it('exposes stable anatomy data slots', () => {
+        render(<StoryRadioGroup defaultValue="html" data-testid="radio-group" />);
+
+        expect(screen.getByTestId('radio-group')).toHaveAttribute('data-slot', 'radio-group-root');
+        expect(screen.getByTestId('label-html')).toHaveAttribute('data-slot', 'radio-group-label');
+        expect(screen.getByTestId('item-html')).toHaveAttribute('data-slot', 'radio-group-item');
+        expect(screen.getByTestId('indicator-html')).toHaveAttribute('data-slot', 'radio-group-indicator');
+    });
+
     it('warns on direct usage of RadioGroup', () => {
         const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         render(<RadioGroup />);


### PR DESCRIPTION
## Summary
- expose stable `data-slot` markers on RadioGroup root, label, item, and indicator
- add fragment coverage for the public anatomy contract
- add a patch changeset

## Checks
- npm test -- RadioGroup.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- git diff --check
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable anatomy markers to RadioGroup root, label, item, and indicator elements for improved styling and inspection.
* **Tests**
  * Added coverage verifying the RadioGroup anatomy markers.
* **Documentation**
  * Documented the new stable RadioGroup markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->