### PR TITLE
fix(checkbox-group): expose anatomy data slots

### DIFF
--- a/.changeset/checkbox-group-data-slots.md
+++ b/.changeset/checkbox-group-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable `data-slot` anatomy markers on CheckboxGroup parts.

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupIndicator.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupIndicator.tsx
@@ -9,7 +9,7 @@ export type CheckboxGroupIndicatorProps = ComponentPropsWithoutRef<'svg'>;
 const CheckboxGroupIndicator = forwardRef<CheckboxGroupIndicatorElement, CheckboxGroupIndicatorProps>(({ className, ...props }, ref) => {
     const { rootClass } = useContext(CheckboxGroupRootContext);
     return (
-        <Check ref={ref} width={15} height={15} className={clsx(rootClass && `${rootClass}-tick-icon`, className)} {...props} />
+        <Check ref={ref} width={15} height={15} className={clsx(rootClass && `${rootClass}-tick-icon`, className)} data-slot="checkbox-group-indicator" {...props} />
     );
 });
 

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupLabel.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupLabel.tsx
@@ -10,7 +10,7 @@ const CheckboxGroupLabel = forwardRef<CheckboxGroupLabelElement, CheckboxGroupLa
     const { rootClass } = useContext(CheckboxGroupRootContext);
 
     return (
-        <Primitive.label ref={ref} className={clsx(rootClass && `${rootClass}-label`, className)} {...props}>
+        <Primitive.label ref={ref} className={clsx(rootClass && `${rootClass}-label`, className)} data-slot="checkbox-group-label" {...props}>
             {children}
         </Primitive.label>
     );

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupRoot.tsx
@@ -20,7 +20,9 @@ const CheckboxGroupRoot = forwardRef<CheckboxGroupRootElement, CheckboxGroupRoot
 
     const dataAttributes = createDataAttributes('checkbox-group', { variant, size });
     const accentAttributes = createDataAccentColorAttribute(color);
-    const composedAttributes = composeAttributes(dataAttributes, accentAttributes);
+    const composedAttributes = composeAttributes(dataAttributes, accentAttributes, {
+        'data-slot': 'checkbox-group-root'
+    });
 
     return (
         <CheckboxGroupRootContext.Provider value={{ rootClass }}>

--- a/src/components/ui/CheckboxGroup/fragments/CheckboxGroupTrigger.tsx
+++ b/src/components/ui/CheckboxGroup/fragments/CheckboxGroupTrigger.tsx
@@ -12,7 +12,7 @@ const CheckboxGroupTrigger = forwardRef<CheckboxGroupTriggerElement, CheckboxGro
     const { rootClass } = React.useContext(CheckboxGroupRootContext);
 
     return (
-        <CheckboxGroupPrimitive.Trigger ref={ref} className={clsx(rootClass && `${rootClass}-trigger`, className)} value={value} {...props}>
+        <CheckboxGroupPrimitive.Trigger ref={ref} className={clsx(rootClass && `${rootClass}-trigger`, className)} value={value} data-slot="checkbox-group-trigger" {...props}>
             <CheckboxGroupPrimitive.Content>
                 {children}
             </CheckboxGroupPrimitive.Content>

--- a/src/components/ui/CheckboxGroup/tests/CheckboxGroup.test.tsx
+++ b/src/components/ui/CheckboxGroup/tests/CheckboxGroup.test.tsx
@@ -3,6 +3,24 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import CheckboxGroup from '../CheckboxGroup';
 
 describe('CheckboxGroup', () => {
+    it('exposes stable anatomy data slots', () => {
+        render(
+            <CheckboxGroup.Root name="fruits" defaultValue={['apple']} data-testid="checkbox-group">
+                <CheckboxGroup.Label data-testid="label-html">
+                    <CheckboxGroup.Trigger value="apple" data-testid="trigger-html">
+                        <CheckboxGroup.Indicator data-testid="indicator-html" />
+                    </CheckboxGroup.Trigger>
+                    Apple
+                </CheckboxGroup.Label>
+            </CheckboxGroup.Root>
+        );
+
+        expect(screen.getByTestId('checkbox-group')).toHaveAttribute('data-slot', 'checkbox-group-root');
+        expect(screen.getByTestId('label-html')).toHaveAttribute('data-slot', 'checkbox-group-label');
+        expect(screen.getByTestId('trigger-html')).toHaveAttribute('data-slot', 'checkbox-group-trigger');
+        expect(screen.getByTestId('indicator-html')).toHaveAttribute('data-slot', 'checkbox-group-indicator');
+    });
+
     it('renders triggers and content, and toggles checked state (uncontrolled)', () => {
         render(
             <CheckboxGroup.Root name="fruits" defaultValue={['apple']}>


### PR DESCRIPTION
## Summary
- expose stable data-slot markers on CheckboxGroup root, label, trigger, and indicator
- add regression coverage for the public anatomy hooks
- include a patch changeset

## Checks
- npm test -- CheckboxGroup.test.tsx --runInBand
- npm run validate:changesets
- npm run check:api-surface
- git diff --check
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable `data-slot` markers to CheckboxGroup elements, including the root, label, trigger, and indicator, enabling more reliable styling and customization.

- **Tests**
  - Added coverage verifying the expected `data-slot` attributes across CheckboxGroup components.

- **Documentation**
  - Documented the new stable CheckboxGroup slot markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->