### PR TITLE
fix(radio): expose state data attributes

### DIFF
--- a/.changeset/radio-data-state-slot.md
+++ b/.changeset/radio-data-state-slot.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable Radio state and anatomy data attributes.

--- a/src/components/ui/Radio/Radio.tsx
+++ b/src/components/ui/Radio/Radio.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useComponentClass } from '~/components/ui/Theme/useComponentClass';
 
 import { createDataAttributes, composeAttributes, createDataAccentColorAttribute } from '~/core/hooks/createDataAttribute';
+import useControllableState from '~/core/hooks/useControllableState';
 
 const COMPONENT_NAME = 'Radio';
 
@@ -20,20 +21,23 @@ export type RadioProps = Omit<RadioPrimitiveProps, 'size'> & {
 };
 
 const Radio = React.forwardRef<RadioElement, RadioProps>(function Radio(
-    { name, value, id, checked = false, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props },
+    { name, value, id, checked, required, onChange, disabled, asChild, className, customRootClass, variant = '', size = '', color = '', ...props },
     ref
 ) {
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
-    const [isChecked, setIsChecked] = React.useState(checked);
+    const [isChecked, setIsChecked] = useControllableState(checked, false, () => {
+        onChange?.();
+    });
 
     const dataAttributes = createDataAttributes('button', { variant, size });
     const accentAttributes = createDataAccentColorAttribute(color);
-    const composedAttributes = composeAttributes(dataAttributes, accentAttributes);
+    const composedAttributes = composeAttributes(dataAttributes, accentAttributes, {
+        'data-slot': 'radio-root',
+        'data-state': isChecked ? 'checked' : 'unchecked',
+        'data-disabled': disabled ? '' : undefined
+    });
 
     const handleChange = () => {
-        if (onChange) {
-            onChange();
-        }
         setIsChecked(!isChecked);
     };
     return (
@@ -48,9 +52,9 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(function Radio(
             disabled={disabled}
             asChild={asChild}
             className={clsx(rootClass, className)}
+            {...props}
             data-checked={isChecked}
             {...composedAttributes}
-            {...props}
         />
 
     );

--- a/src/components/ui/Radio/tests/Radio.test.tsx
+++ b/src/components/ui/Radio/tests/Radio.test.tsx
@@ -48,6 +48,19 @@ describe('Radio', () => {
         expect(handleChange).toHaveBeenCalled();
     });
 
+    it('syncs controlled checked prop changes', () => {
+        const { rerender } = render(<Radio {...baseProps} checked={false} onChange={jest.fn()} />);
+        const radio = screen.getByRole('radio');
+
+        expect(radio).not.toBeChecked();
+        expect(radio).toHaveAttribute('data-state', 'unchecked');
+
+        rerender(<Radio {...baseProps} checked onChange={jest.fn()} />);
+
+        expect(radio).toBeChecked();
+        expect(radio).toHaveAttribute('data-state', 'checked');
+    });
+
     it('applies custom class names', () => {
         render(
             <Radio {...baseProps} className="custom-class" customRootClass="root-class" />
@@ -65,6 +78,38 @@ describe('Radio', () => {
         expect(radio).toHaveAttribute('data-variant', 'filled');
         expect(radio).toHaveAttribute('data-size', 'lg');
         expect(radio).toHaveAttribute('data-color', 'red');
+    });
+
+    it('exposes stable state and anatomy data attributes', () => {
+        render(<Radio {...baseProps} />);
+        const radio = screen.getByRole('radio');
+
+        expect(radio).toHaveAttribute('data-slot', 'radio-root');
+        expect(radio).toHaveAttribute('data-state', 'unchecked');
+
+        fireEvent.click(radio);
+
+        expect(radio).toHaveAttribute('data-state', 'checked');
+    });
+
+    it('exposes disabled state as a data attribute', () => {
+        const { rerender } = render(<Radio {...baseProps} />);
+        const radio = screen.getByRole('radio');
+
+        expect(radio).not.toHaveAttribute('data-disabled');
+
+        rerender(<Radio {...baseProps} disabled />);
+
+        expect(radio).toHaveAttribute('data-disabled');
+    });
+
+    it('preserves component-owned data attributes', () => {
+        render(<Radio {...baseProps} data-slot="custom-radio" data-state="custom" data-disabled="custom" />);
+        const radio = screen.getByRole('radio');
+
+        expect(radio).toHaveAttribute('data-slot', 'radio-root');
+        expect(radio).toHaveAttribute('data-state', 'unchecked');
+        expect(radio).not.toHaveAttribute('data-disabled');
     });
 
     it('forwards refs', () => {


### PR DESCRIPTION
## Summary

- Exposes Radio root anatomy with `data-slot="radio-root"`
- Adds Radio `data-state="checked|unchecked"` and `data-disabled` hooks
- Covers the public attribute contract with focused tests

## Validation

- `npm test -- Radio.test.tsx --runInBand`
- `npm run validate:changesets`
- `npm run check:api-surface`
- `git diff --check`
- `NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process`

Part of #1782.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable data attributes to radio controls for identifying their component slot and checked or unchecked state.
  - Disabled radios now expose a data attribute indicating their disabled status.
  - Controlled radio values now stay synchronized with their displayed state.

- **Tests**
  - Added coverage for radio state transitions, controlled values, stable attributes, disabled-state attributes, and protection of component-owned attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->