### PR TITLE
fix(checkbox): expose state data attributes

### DIFF
--- a/.changeset/checkbox-data-slots.md
+++ b/.changeset/checkbox-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+fix(checkbox): expose protected anatomy and state data attributes

--- a/src/components/ui/Checkbox/fragments/CheckboxIndicator.tsx
+++ b/src/components/ui/Checkbox/fragments/CheckboxIndicator.tsx
@@ -12,7 +12,7 @@ export type CheckboxIndicatorProps = {
 
 const CheckboxIndicator = forwardRef<CheckboxIndicatorElement, CheckboxIndicatorProps>(({ children, className = '', ...props }, ref) => {
     const { rootClass } = useContext(CheckboxContext);
-    return <CheckboxPrimitiveIndicator ref={ref} {...props}>
+    return <CheckboxPrimitiveIndicator ref={ref} {...props} data-slot="checkbox-indicator">
         <Check
             width={15}
             height={15}

--- a/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
+++ b/src/components/ui/Checkbox/fragments/CheckboxRoot.tsx
@@ -20,7 +20,9 @@ const CheckboxRoot = forwardRef<CheckboxRootElement, CheckboxRootProps>(({ child
 
     const dataAttributes = createDataAttributes('checkbox', { variant, size });
     const accentAttributes = createDataAccentColorAttribute(color);
-    const composedAttributes = composeAttributes(dataAttributes, accentAttributes);
+    const composedAttributes = composeAttributes(dataAttributes, accentAttributes, {
+        'data-slot': 'checkbox-root'
+    });
 
     return <CheckboxContext.Provider value={{ rootClass }}>
         <CheckboxPrimitiveRoot ref={ref} className={clsx(rootClass, className)} {...props} {...composedAttributes}>

--- a/src/components/ui/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox/tests/Checkbox.test.tsx
@@ -52,6 +52,32 @@ describe('Checkbox', () => {
         expect(queryByText('Checked')).toBeInTheDocument();
     });
 
+    it('updates state attributes when controlled checked changes', () => {
+        const { container, rerender } = render(
+            <Checkbox.Root checked={false} onCheckedChange={jest.fn()}>
+                <Checkbox.Indicator>
+                    <span>Checked</span>
+                </Checkbox.Indicator>
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).toHaveAttribute('data-slot', 'checkbox-root');
+        expect(button).toHaveAttribute('data-state', 'unchecked');
+        expect(container.querySelector('[data-slot="checkbox-indicator"]')).toBeNull();
+
+        rerender(
+            <Checkbox.Root checked={true} onCheckedChange={jest.fn()}>
+                <Checkbox.Indicator>
+                    <span>Checked</span>
+                </Checkbox.Indicator>
+            </Checkbox.Root>
+        );
+
+        const indicator = container.querySelector('[data-slot="checkbox-indicator"]');
+        expect(button).toHaveAttribute('data-state', 'checked');
+        expect(indicator).toHaveAttribute('data-state', 'checked');
+    });
+
     it('applies disabled and required props', () => {
         const { container } = render(
             <Checkbox.Root disabled required>
@@ -63,6 +89,60 @@ describe('Checkbox', () => {
         const button = container.querySelector('button');
         expect(button).toBeDisabled();
         expect(button).toHaveAttribute('aria-required', 'true');
+        expect(button).toHaveAttribute('data-disabled');
+    });
+
+    it('omits data-disabled when enabled', () => {
+        const { container } = render(
+            <Checkbox.Root>
+                <Checkbox.Indicator>
+                    <span>Checked</span>
+                </Checkbox.Indicator>
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button');
+        expect(button).not.toHaveAttribute('data-disabled');
+    });
+
+    it('protects component-owned data attributes from consumer props', () => {
+        const { container } = render(
+            <Checkbox.Root
+                defaultChecked
+                data-slot="custom-root"
+                data-state="custom-state"
+                data-disabled="custom-disabled"
+            >
+                <Checkbox.Indicator
+                    data-slot="custom-indicator"
+                    data-state="custom-indicator-state"
+                    data-disabled="custom-indicator-disabled"
+                >
+                    <span>Checked</span>
+                </Checkbox.Indicator>
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button');
+        const indicator = container.querySelector('[data-slot="checkbox-indicator"]');
+        expect(button).toHaveAttribute('data-slot', 'checkbox-root');
+        expect(button).toHaveAttribute('data-state', 'checked');
+        expect(button).not.toHaveAttribute('data-disabled');
+        expect(indicator).toHaveAttribute('data-state', 'checked');
+        expect(indicator).not.toHaveAttribute('data-disabled');
+    });
+
+    it('composes consumer click handlers with internal toggling', () => {
+        const onClick = jest.fn();
+        const { container } = render(
+            <Checkbox.Root onClick={onClick}>
+                <Checkbox.Indicator>
+                    <span>Checked</span>
+                </Checkbox.Indicator>
+            </Checkbox.Root>
+        );
+        const button = container.querySelector('button');
+        fireEvent.click(button!);
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(button).toHaveAttribute('data-state', 'checked');
     });
 
     it('passes name and value to the hidden input for form usage', () => {

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveIndicator.tsx
@@ -9,11 +9,17 @@ export type CheckboxPrimitiveIndicatorProps = ComponentPropsWithoutRef<'span'> &
 };
 
 const CheckboxPrimitiveIndicator = forwardRef<CheckboxPrimitiveIndicatorElement, CheckboxPrimitiveIndicatorProps>(({ children, className = '', ...props }, ref) => {
-    const { isChecked } = React.useContext(CheckboxPrimitiveContext);
+    const { isChecked, disabled } = React.useContext(CheckboxPrimitiveContext);
 
     if (isChecked !== true) return null;
 
-    return <span ref={ref} className={className} {...props}>{children}</span>;
+    return <span
+        ref={ref}
+        {...props}
+        className={className}
+        data-state="checked"
+        data-disabled={disabled ? '' : undefined}
+    >{children}</span>;
 });
 
 CheckboxPrimitiveIndicator.displayName = 'CheckboxPrimitiveIndicator';

--- a/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
+++ b/src/core/primitives/Checkbox/fragments/CheckboxPrimitiveTrigger.tsx
@@ -3,12 +3,13 @@
 import React, { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 import ButtonPrimitive from '~/core/primitives/Button';
 import CheckboxPrimitiveContext from '../context/CheckboxPrimitiveContext';
+import composeEventHandlers from '~/core/hooks/composeEventHandlers';
 
 export type CheckboxPrimitiveTriggerElement = ElementRef<typeof ButtonPrimitive>;
 export type CheckboxPrimitiveTriggerProps = ComponentPropsWithoutRef<typeof ButtonPrimitive>;
 
 const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, CheckboxPrimitiveTriggerProps>(
-    ({ children, className = '', ...props }, ref) => {
+    ({ children, className = '', onClick, ...props }, ref) => {
         const { isChecked, setIsChecked, id, required, disabled } = React.useContext(CheckboxPrimitiveContext);
         const toggleChecked = () => {
             const next = isChecked === 'indeterminate' || isChecked === null ? true : !isChecked;
@@ -21,7 +22,8 @@ const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, Che
             isChecked === 'indeterminate' || isChecked === null ? 'mixed' : isChecked;
         return <ButtonPrimitive
             ref={ref}
-            onClick={toggleChecked}
+            {...props}
+            onClick={composeEventHandlers(onClick, toggleChecked)}
             role="checkbox"
             id={id}
             aria-checked={ariaChecked}
@@ -29,9 +31,8 @@ const CheckboxPrimitiveTrigger = forwardRef<CheckboxPrimitiveTriggerElement, Che
             data-checked={isChecked as any}
             data-state={dataState}
             disabled={disabled}
-            data-disabled={disabled}
+            data-disabled={disabled ? '' : undefined}
             className={className}
-            {...props}
         >{children}</ButtonPrimitive>;
     }
 );


### PR DESCRIPTION
## Summary

- Adds Checkbox root and indicator `data-slot` hooks
- Keeps Checkbox state and disabled data attributes component-owned
- Covers controlled updates, override protection, and click handler composition

## Validation

- `npm test -- Checkbox.test.tsx --runInBand`
- `npm run validate:changesets`
- `npm run check:api-surface`
- `git diff --check`
- `NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process`\n- `npm run check:exports`\n\nPart of #1782.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Checkbox state indicators for checked and disabled states.
  * Added reliable data attributes for Checkbox root and indicator elements.
  * Preserved consumer click handlers while maintaining built-in toggling behavior.
  * Prevented consumer props from overriding component-managed Checkbox attributes.
* **Tests**
  * Expanded coverage for controlled state changes, disabled behavior, attribute protection, and click handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->