### PR TITLE
docs(drawer): add component docs page

### DIFF
--- a/.changeset/drawer-docs-page.md
+++ b/.changeset/drawer-docs-page.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+docs(drawer): add the component documentation page and align the internal context type

--- a/docs/app/docs/components/drawer/content.mdx
+++ b/docs/app/docs/components/drawer/content.mdx
@@ -1,0 +1,36 @@
+import Documentation from '@/components/layout/Documentation/Documentation'
+import DrawerExample from './docs/examples/DrawerExample'
+import DrawerModesExample from './docs/examples/DrawerModesExample'
+import DrawerDirectionsExample from './docs/examples/DrawerDirectionsExample'
+import {
+    code,
+    anatomy,
+    api_documentation,
+    modesCodeUsage,
+    directionsCodeUsage,
+} from './docs/codeUsage'
+
+<Documentation
+    title="Drawer"
+    description="A headless drawer primitive for React with modal and non-modal modes, side-aware placement, focus management, portaling, and drag-to-close handles."
+>
+    <Documentation.ComponentHero codeUsage={code}>
+        <DrawerExample />
+    </Documentation.ComponentHero>
+
+    <Documentation.ApiReference
+        anatomy={anatomy.code}
+        tables={api_documentation}
+        order={['root', 'trigger', 'portal', 'overlay', 'content', 'title', 'description', 'close', 'handle']}
+    />
+
+    ## Examples
+
+    <Documentation.ComponentHero title="Modal modes" codeUsage={modesCodeUsage}>
+        <DrawerModesExample />
+    </Documentation.ComponentHero>
+
+    <Documentation.ComponentHero title="Directions" codeUsage={directionsCodeUsage}>
+        <DrawerDirectionsExample />
+    </Documentation.ComponentHero>
+</Documentation>

--- a/docs/app/docs/components/drawer/docs/anatomy.tsx
+++ b/docs/app/docs/components/drawer/docs/anatomy.tsx
@@ -1,0 +1,18 @@
+import Drawer from '@radui/ui/Drawer'
+
+export default () => {
+    return (
+        <Drawer.Root>
+            <Drawer.Trigger>Open drawer</Drawer.Trigger>
+            <Drawer.Portal>
+                <Drawer.Overlay />
+                <Drawer.Content>
+                    <Drawer.Handle />
+                    <Drawer.Title>Drawer title</Drawer.Title>
+                    <Drawer.Description>Drawer description</Drawer.Description>
+                    <Drawer.Close>Close</Drawer.Close>
+                </Drawer.Content>
+            </Drawer.Portal>
+        </Drawer.Root>
+    )
+}

--- a/docs/app/docs/components/drawer/docs/codeUsage.js
+++ b/docs/app/docs/components/drawer/docs/codeUsage.js
@@ -1,0 +1,54 @@
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode'
+
+import root_api from './component_api/root.tsx'
+import trigger_api from './component_api/trigger.tsx'
+import portal_api from './component_api/portal.tsx'
+import overlay_api from './component_api/overlay.tsx'
+import content_api from './component_api/content.tsx'
+import title_api from './component_api/title.tsx'
+import description_api from './component_api/description.tsx'
+import close_api from './component_api/close.tsx'
+import handle_api from './component_api/handle.tsx'
+
+const example_1_SourceCode = await getSourceCodeFromPath(
+    'docs/app/docs/components/drawer/docs/examples/DrawerExample.tsx',
+)
+const example_modes_SourceCode = await getSourceCodeFromPath(
+    'docs/app/docs/components/drawer/docs/examples/DrawerModesExample.tsx',
+)
+const example_directions_SourceCode = await getSourceCodeFromPath(
+    'docs/app/docs/components/drawer/docs/examples/DrawerDirectionsExample.tsx',
+)
+const scss_SourceCode = await getSourceCodeFromPath('src/components/ui/Drawer/drawer.clarity.scss')
+const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/drawer/docs/anatomy.tsx')
+
+export const code = {
+    javascript: { code: example_1_SourceCode },
+    scss: { code: scss_SourceCode },
+}
+
+export const modesCodeUsage = {
+    javascript: { code: example_modes_SourceCode },
+    scss: { code: scss_SourceCode },
+}
+
+export const directionsCodeUsage = {
+    javascript: { code: example_directions_SourceCode },
+    scss: { code: scss_SourceCode },
+}
+
+export const anatomy = { code: anatomy_SourceCode }
+
+export const api_documentation = {
+    root: root_api,
+    trigger: trigger_api,
+    portal: portal_api,
+    overlay: overlay_api,
+    content: content_api,
+    title: title_api,
+    description: description_api,
+    close: close_api,
+    handle: handle_api,
+}
+
+export default code

--- a/docs/app/docs/components/drawer/docs/component_api/close.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/close.tsx
@@ -1,0 +1,28 @@
+const data = {
+    name: 'Close',
+    description: 'A button-like part that closes the drawer intentionally.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Close control contents.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'asChild', info_tooltips: 'Renders the close behavior onto the child element.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the close control.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/content.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/content.tsx
@@ -1,0 +1,33 @@
+const data = {
+    name: 'Content',
+    description: 'The positioned drawer panel.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Panel contents, including title, description, controls, and optional handle.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'forceMount', info_tooltips: 'Keeps content mounted when the drawer is closed.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'asChild', info_tooltips: 'Renders the content behavior onto the child element.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the content.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/description.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/description.tsx
@@ -1,0 +1,23 @@
+const data = {
+    name: 'Description',
+    description: 'A text part for describing the drawer content.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Description contents.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the description.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/handle.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/handle.tsx
@@ -1,0 +1,23 @@
+const data = {
+    name: 'Handle',
+    description: 'An optional draggable handle that lets users dismiss the drawer by dragging outward.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'closeThreshold', info_tooltips: 'Pointer distance in pixels required before a drag closes the drawer.' },
+            type: 'number',
+            default: '80',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the handle.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/overlay.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/overlay.tsx
@@ -1,0 +1,23 @@
+const data = {
+    name: 'Overlay',
+    description: 'The backdrop layer that can lock scroll and dismiss the drawer.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'forceMount', info_tooltips: 'Keeps the overlay mounted when the drawer is closed.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the overlay.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/portal.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/portal.tsx
@@ -1,0 +1,18 @@
+const data = {
+    name: 'Portal',
+    description: 'Portals drawer overlay and content outside the normal DOM flow.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Overlay and content parts to portal.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/root.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/root.tsx
@@ -1,0 +1,78 @@
+const data = {
+    name: 'Root',
+    description: 'The root component that owns drawer state, modal behavior, snap point state, and child drawer nesting.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Drawer parts rendered inside the root.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'defaultOpen', info_tooltips: 'Initial open state for uncontrolled drawers.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'open', info_tooltips: 'Controlled open state.' },
+            type: 'boolean',
+            default: '--',
+        },
+        {
+            prop: { name: 'onOpenChange', info_tooltips: 'Called when the drawer requests an open state change.' },
+            type: '(open: boolean) => void',
+            default: '--',
+        },
+        {
+            prop: { name: 'onOpenChangeComplete', info_tooltips: 'Called after the open or close animation completes.' },
+            type: '(open: boolean) => void',
+            default: '--',
+        },
+        {
+            prop: { name: 'modal', info_tooltips: 'Controls focus trapping, scroll locking, and outside interaction policy.' },
+            type: "boolean | 'trap-focus'",
+            default: 'true',
+        },
+        {
+            prop: { name: 'swipeDirection', info_tooltips: 'Direction used for placement and swipe-to-dismiss behavior.' },
+            type: "'left' | 'right' | 'top' | 'bottom'",
+            default: "'right'",
+        },
+        {
+            prop: { name: 'disablePointerDismissal', info_tooltips: 'Prevents outside pointer interactions from closing the drawer.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'snapPoints', info_tooltips: 'Available snap points as viewport fractions, pixel numbers, or CSS length strings.' },
+            type: 'Array<number | string>',
+            default: '[]',
+        },
+        {
+            prop: { name: 'snapPoint', info_tooltips: 'Controlled active snap point.' },
+            type: 'number | string | null',
+            default: '--',
+        },
+        {
+            prop: { name: 'onSnapPointChange', info_tooltips: 'Called when the active snap point changes.' },
+            type: '(snapPoint: number | string | null) => void',
+            default: '--',
+        },
+        {
+            prop: { name: 'actionsRef', info_tooltips: 'Imperative close and unmount actions.' },
+            type: 'RefObject<DrawerRootActions | null>',
+            default: '--',
+        },
+        {
+            prop: { name: 'customRootClass', info_tooltips: 'Overrides the generated Drawer class namespace.' },
+            type: 'string',
+            default: "''",
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/title.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/title.tsx
@@ -1,0 +1,23 @@
+const data = {
+    name: 'Title',
+    description: 'A heading part for naming the drawer content.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Title contents.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the title.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/component_api/trigger.tsx
+++ b/docs/app/docs/components/drawer/docs/component_api/trigger.tsx
@@ -1,0 +1,28 @@
+const data = {
+    name: 'Trigger',
+    description: 'A button-like part that opens the drawer.',
+    columns: [
+        { name: 'Prop', id: 'prop' },
+        { name: 'Type', id: 'type' },
+        { name: 'Default', id: 'default' },
+    ],
+    data: [
+        {
+            prop: { name: 'children', info_tooltips: 'Trigger contents.' },
+            type: 'ReactNode',
+            default: '--',
+        },
+        {
+            prop: { name: 'asChild', info_tooltips: 'Renders the trigger behavior onto the child element.' },
+            type: 'boolean',
+            default: 'false',
+        },
+        {
+            prop: { name: 'className', info_tooltips: 'Additional class names for the trigger.' },
+            type: 'string',
+            default: '--',
+        },
+    ],
+}
+
+export default data

--- a/docs/app/docs/components/drawer/docs/examples/DrawerDirectionsExample.tsx
+++ b/docs/app/docs/components/drawer/docs/examples/DrawerDirectionsExample.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import Drawer from '@radui/ui/Drawer'
+
+const directions = ['right', 'left', 'top', 'bottom'] as const
+
+export default function DrawerDirectionsExample() {
+    return (
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            {directions.map((direction) => (
+                <Drawer.Root key={direction} swipeDirection={direction}>
+                    <Drawer.Trigger>From {direction}</Drawer.Trigger>
+                    <Drawer.Portal>
+                        <Drawer.Overlay />
+                        <Drawer.Content>
+                            <Drawer.Handle />
+                            <Drawer.Title>Drawer from {direction}</Drawer.Title>
+                            <Drawer.Description>
+                                The same composition supports each placement direction.
+                            </Drawer.Description>
+                            <div style={{ padding: '0 1.25rem 1.25rem' }}>
+                                <Drawer.Close>Close</Drawer.Close>
+                            </div>
+                        </Drawer.Content>
+                    </Drawer.Portal>
+                </Drawer.Root>
+            ))}
+        </div>
+    )
+}

--- a/docs/app/docs/components/drawer/docs/examples/DrawerExample.tsx
+++ b/docs/app/docs/components/drawer/docs/examples/DrawerExample.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import Drawer from '@radui/ui/Drawer'
+
+export default function DrawerExample() {
+    return (
+        <Drawer.Root swipeDirection="right">
+            <Drawer.Trigger>Open drawer</Drawer.Trigger>
+            <Drawer.Portal>
+                <Drawer.Overlay />
+                <Drawer.Content>
+                    <Drawer.Handle />
+                    <Drawer.Title>Project settings</Drawer.Title>
+                    <Drawer.Description>
+                        Update workspace details without leaving the current page.
+                    </Drawer.Description>
+                    <div style={{ padding: '0 1.25rem 1.25rem' }}>
+                        <Drawer.Close>Close</Drawer.Close>
+                    </div>
+                </Drawer.Content>
+            </Drawer.Portal>
+        </Drawer.Root>
+    )
+}

--- a/docs/app/docs/components/drawer/docs/examples/DrawerModesExample.tsx
+++ b/docs/app/docs/components/drawer/docs/examples/DrawerModesExample.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Drawer from '@radui/ui/Drawer'
+
+const modes = [
+    { label: 'Modal', value: true },
+    { label: 'Non-modal', value: false },
+    { label: 'Trap focus', value: 'trap-focus' },
+] as const
+
+export default function DrawerModesExample() {
+    return (
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            {modes.map((mode) => (
+                <Drawer.Root key={mode.label} modal={mode.value} swipeDirection="right">
+                    <Drawer.Trigger>{mode.label}</Drawer.Trigger>
+                    <Drawer.Portal>
+                        <Drawer.Overlay />
+                        <Drawer.Content>
+                            <Drawer.Title>{mode.label} drawer</Drawer.Title>
+                            <Drawer.Description>
+                                Use this mode to tune focus, scroll, and outside interaction behavior.
+                            </Drawer.Description>
+                            <div style={{ padding: '0 1.25rem 1.25rem' }}>
+                                <Drawer.Close>Close</Drawer.Close>
+                            </div>
+                        </Drawer.Content>
+                    </Drawer.Portal>
+                </Drawer.Root>
+            ))}
+        </div>
+    )
+}

--- a/docs/app/docs/components/drawer/page.tsx
+++ b/docs/app/docs/components/drawer/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/components/drawer/seo.ts
+++ b/docs/app/docs/components/drawer/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from '@/utils/seo/generateSeoMetadata'
+
+const drawerMetadata = generateSeoMetadata({
+    title: 'Drawer - Rad UI',
+    description: 'A headless React drawer component with modal modes, side placement, portaling, focus management, and drag-to-close handles.'
+})
+
+export default drawerMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -47,6 +47,7 @@ export const docsNavigationSections = [
             { title:"DataList", path:"/docs/components/data-list", is_preview:true },
             { title:"Dialog", path:"/docs/components/dialog", is_new:true },
             { title:"Disclosure", path:"/docs/components/disclosure", is_preview:true },
+            { title:"Drawer", path:"/docs/components/drawer", is_preview:true },
             { title:"DropdownMenu", path:"/docs/components/dropdown-menu", is_preview:true },
             { title:"Em", path:"/docs/components/em" },
             { title:"Heading", path:"/docs/components/heading" },

--- a/src/components/ui/Drawer/context/DrawerContext.tsx
+++ b/src/components/ui/Drawer/context/DrawerContext.tsx
@@ -10,6 +10,8 @@ export type DrawerRootActions = {
 export type DrawerContextType = {
     rootClass: string;
     swipeDirection: 'left' | 'right' | 'top' | 'bottom';
+    isOpen: boolean;
+    onOpen: () => void;
     // Snap point state
     snapPoints: DrawerSnapPoint[];
     activeSnapPoint: DrawerSnapPoint | null;
@@ -31,6 +33,8 @@ export type DrawerContextType = {
 export const DrawerContext = createContext<DrawerContextType>({
     rootClass: '',
     swipeDirection: 'right',
+    isOpen: false,
+    onOpen: () => {},
     snapPoints: [],
     activeSnapPoint: null,
     setActiveSnapPoint: () => {},

--- a/src/components/ui/Drawer/tests/Drawer.context.test.tsx
+++ b/src/components/ui/Drawer/tests/Drawer.context.test.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import { DrawerContext } from '../context/DrawerContext';
+
+function DrawerContextProbe() {
+    const { isOpen, onOpen } = useContext(DrawerContext);
+    onOpen();
+
+    return <div data-testid="drawer-context-open">{String(isOpen)}</div>;
+}
+
+describe('Drawer context defaults', () => {
+    test('provides closed state and a no-op open handler outside a provider', () => {
+        render(<DrawerContextProbe />);
+
+        expect(screen.getByTestId('drawer-context-open')).toHaveTextContent('false');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds the Drawer docs route with anatomy, API tables, examples, and SEO metadata.
- Adds Drawer to the component navigation.
- Aligns the Drawer context type with the open helpers already provided by Drawer.Root.
- Covers the new context defaults with a focused regression test.

Closes #1774.

## Validation

- npm test -- Drawer.context.test.tsx Drawer.lazyMount.test.tsx Drawer.controlledSwitch.test.tsx Drawer.rtl.test.tsx --runInBand
- npm run validate:changesets
- npm run check:docs-snippets
- npm run check:docs-examples
- pnpm --dir docs lint
- pnpm --dir docs build
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process