### PR TITLE
feat(meter): add primitive

### DIFF
--- a/.changeset/fresh-meters-learn.md
+++ b/.changeset/fresh-meters-learn.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": minor
+---
+
+feat(meter): add headless Meter primitive

--- a/docs/app/docs/components/meter/content.mdx
+++ b/docs/app/docs/components/meter/content.mdx
@@ -1,0 +1,20 @@
+import Documentation from "@/components/layout/Documentation/Documentation"
+import codeUsage, { api_documentation, anatomy, features } from "./docs/codeUsage"
+import MeterExample from "./docs/examples/MeterExample"
+
+<Documentation
+  title="Meter"
+  description="Meter represents a bounded scalar measurement, such as storage usage, health, quota, or score."
+>
+  <Documentation.ComponentHero codeUsage={codeUsage}>
+    <MeterExample />
+  </Documentation.ComponentHero>
+
+  <Documentation.ComponentFeatures features={features} />
+
+  <Documentation.ApiReference
+    anatomy={anatomy.code}
+    tables={api_documentation}
+    order={['root', 'indicator']}
+  />
+</Documentation>

--- a/docs/app/docs/components/meter/docs/anatomy.tsx
+++ b/docs/app/docs/components/meter/docs/anatomy.tsx
@@ -1,0 +1,7 @@
+import Meter from "@radui/ui/Meter"
+
+export default () => (
+    <Meter.Root value={72} minValue={0} maxValue={100} lowValue={30} highValue={85}>
+        <Meter.Indicator />
+    </Meter.Root>
+)

--- a/docs/app/docs/components/meter/docs/codeUsage.js
+++ b/docs/app/docs/components/meter/docs/codeUsage.js
@@ -1,0 +1,32 @@
+import root_api_SourceCode from './component_api/root.tsx';
+import indicator_api_SourceCode from './component_api/indicator.tsx';
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+
+const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/meter/docs/examples/MeterExample.tsx');
+const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/meter.scss');
+const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/meter/docs/anatomy.tsx');
+
+const code = {
+    javascript: {
+        code: example_1_SourceCode
+    },
+    css: {
+        code: scss_SourceCode
+    }
+};
+
+export const api_documentation = {
+    root: root_api_SourceCode,
+    indicator: indicator_api_SourceCode
+};
+
+export const anatomy = { code: anatomy_SourceCode };
+
+export const features = [
+    "Uses the native meter ARIA role for bounded measurements",
+    "Supports min, max, low, high, and optimum thresholds",
+    "Exposes data-state and threshold attributes for styling",
+    "Supports compound usage with Root and Indicator parts"
+];
+
+export default code;

--- a/docs/app/docs/components/meter/docs/component_api/indicator.tsx
+++ b/docs/app/docs/components/meter/docs/component_api/indicator.tsx
@@ -1,0 +1,28 @@
+const data = {
+    name: "Indicator",
+    description: "Visual fill element for the Meter primitive.",
+    columns: [
+        { name: "Prop", id: "prop" },
+        { name: "Type", id: "type" },
+        { name: "Default", id: "default" }
+    ],
+    data: [
+        {
+            prop: { name: "asChild", info_tooltips: "Render the indicator attributes onto the child element." },
+            type: "boolean",
+            default: "false"
+        },
+        {
+            prop: { name: "className", info_tooltips: "Additional class names for the indicator." },
+            type: "string",
+            default: "--"
+        },
+        {
+            prop: { name: "style", info_tooltips: "Inline styles merged with the computed transform." },
+            type: "CSSProperties",
+            default: "--"
+        }
+    ]
+};
+
+export default data;

--- a/docs/app/docs/components/meter/docs/component_api/root.tsx
+++ b/docs/app/docs/components/meter/docs/component_api/root.tsx
@@ -1,0 +1,58 @@
+const data = {
+    name: "Root",
+    description: "Root component for the Meter primitive.",
+    columns: [
+        { name: "Prop", id: "prop" },
+        { name: "Type", id: "type" },
+        { name: "Default", id: "default" }
+    ],
+    data: [
+        {
+            prop: { name: "value", info_tooltips: "Current bounded meter value." },
+            type: "number",
+            default: "0"
+        },
+        {
+            prop: { name: "minValue", info_tooltips: "Minimum value in the meter range." },
+            type: "number",
+            default: "0"
+        },
+        {
+            prop: { name: "maxValue", info_tooltips: "Maximum value in the meter range." },
+            type: "number",
+            default: "100"
+        },
+        {
+            prop: { name: "lowValue", info_tooltips: "Optional threshold for low values." },
+            type: "number",
+            default: "--"
+        },
+        {
+            prop: { name: "highValue", info_tooltips: "Optional threshold for high values." },
+            type: "number",
+            default: "--"
+        },
+        {
+            prop: { name: "optimumValue", info_tooltips: "Optional optimum value marker." },
+            type: "number",
+            default: "--"
+        },
+        {
+            prop: { name: "getValueLabel", info_tooltips: "Formats aria-valuetext for assistive technologies." },
+            type: "(value, minValue, maxValue) => string",
+            default: "--"
+        },
+        {
+            prop: { name: "asChild", info_tooltips: "Render the root attributes onto the child element." },
+            type: "boolean",
+            default: "false"
+        },
+        {
+            prop: { name: "customRootClass", info_tooltips: "Custom root class name to override default styling." },
+            type: "string",
+            default: "--"
+        }
+    ]
+};
+
+export default data;

--- a/docs/app/docs/components/meter/docs/examples/MeterExample.tsx
+++ b/docs/app/docs/components/meter/docs/examples/MeterExample.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import Meter from "@radui/ui/Meter"
+
+export default function MeterExample() {
+    return (
+        <div style={{ width: "280px" }}>
+            <Meter.Root
+                value={72}
+                minValue={0}
+                maxValue={100}
+                lowValue={30}
+                highValue={85}
+                getValueLabel={(value) => `${value}% capacity used`}
+            >
+                <Meter.Indicator />
+            </Meter.Root>
+        </div>
+    )
+}

--- a/docs/app/docs/components/meter/page.tsx
+++ b/docs/app/docs/components/meter/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/components/meter/seo.ts
+++ b/docs/app/docs/components/meter/seo.ts
@@ -1,0 +1,6 @@
+import generateSeoMetadata from "@/utils/seo/generateSeoMetadata"
+
+export default generateSeoMetadata({
+    title: "Meter - Rad UI",
+    description: "A headless React Meter primitive for showing a bounded scalar value with accessible native meter semantics and threshold styling hooks."
+})

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -54,6 +54,7 @@ export const docsNavigationSections = [
             { title:"Kbd", path:"/docs/components/kbd" },
             { title:"Link", path:"/docs/components/link", is_preview:true },
             { title:"Menubar", path:"/docs/components/menubar", is_preview:true },
+            { title:"Meter", path:"/docs/components/meter", is_preview:true },
             { title:"Minimap", path:"/docs/components/minimap", is_preview:true },
             { title:"NavigationMenu", path:"/docs/components/navigation-menu", is_preview:true },
             { title:"NumberField", path:"/docs/components/number-field", is_preview:true },

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -112,6 +112,7 @@ const nextConfig = {
         config.resolve.alias = {
             ...config.resolve.alias,
             '@radui/ui/Breadcrumb': path.resolve(__dirname, '../src/components/ui/Breadcrumb/Breadcrumb.tsx'),
+            '@radui/ui/Meter': path.resolve(__dirname, '../src/components/ui/Meter/Meter.tsx'),
             '@radui/ui/Toast': path.resolve(__dirname, '../src/components/ui/Toast/Toast.tsx'),
             '@radui/ui/themes/default.css': path.resolve(__dirname, '../src/design-systems/clarity/default.scss'),
             '@radui/ui/themes/baremetal.css': path.resolve(__dirname, '../src/design-systems/baremetal/default.scss'),

--- a/docs/tsconfig.examples.json
+++ b/docs/tsconfig.examples.json
@@ -9,6 +9,7 @@
   "exclude": [
     "node_modules",
     ".next",
+    "app/docs/components/meter/**",
     "app/docs/components/toast/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
       "require": "./dist/components/Menubar.cjs",
       "types": "./dist/components/Menubar.d.ts"
     },
+    "./Meter": {
+      "import": "./dist/components/Meter.js",
+      "require": "./dist/components/Meter.cjs",
+      "types": "./dist/components/Meter.d.ts"
+    },
     "./Minimap": {
       "import": "./dist/components/Minimap.js",
       "require": "./dist/components/Minimap.cjs",

--- a/scripts/RELEASED_COMPONENTS.cjs
+++ b/scripts/RELEASED_COMPONENTS.cjs
@@ -46,6 +46,7 @@ const RELEASED_COMPONENTS = [
     'DropdownMenu',
     'HoverCard',
     'Menubar',
+    'Meter',
     'Minimap',
     'NavigationMenu',
     'NumberField',

--- a/src/components/ui/Drawer/context/DrawerContext.tsx
+++ b/src/components/ui/Drawer/context/DrawerContext.tsx
@@ -9,6 +9,8 @@ export type DrawerRootActions = {
 
 export type DrawerContextType = {
     rootClass: string;
+    isOpen: boolean;
+    onOpen: () => void;
     swipeDirection: 'left' | 'right' | 'top' | 'bottom';
     // Snap point state
     snapPoints: DrawerSnapPoint[];
@@ -30,6 +32,8 @@ export type DrawerContextType = {
 
 export const DrawerContext = createContext<DrawerContextType>({
     rootClass: '',
+    isOpen: false,
+    onOpen: () => {},
     swipeDirection: 'right',
     snapPoints: [],
     activeSnapPoint: null,

--- a/src/components/ui/Meter/Meter.tsx
+++ b/src/components/ui/Meter/Meter.tsx
@@ -1,0 +1,28 @@
+import React, { forwardRef } from 'react';
+import MeterRoot, {
+    MeterRootElement,
+    MeterRootProps
+} from './fragments/MeterRoot';
+import MeterIndicator from './fragments/MeterIndicator';
+
+export const COMPONENT_NAME = 'Meter';
+
+export type MeterProps = MeterRootProps;
+type MeterComponent = React.ForwardRefExoticComponent<
+    MeterProps & React.RefAttributes<MeterRootElement>
+> & {
+    Root: typeof MeterRoot;
+    Indicator: typeof MeterIndicator;
+};
+
+const Meter = forwardRef<MeterRootElement, MeterProps>((props, ref) => {
+    return <MeterRoot ref={ref} {...props} />;
+}) as MeterComponent;
+
+Meter.displayName = COMPONENT_NAME;
+Meter.Root = MeterRoot;
+Meter.Indicator = MeterIndicator;
+
+export type { MeterRootProps } from './fragments/MeterRoot';
+export type { MeterIndicatorProps } from './fragments/MeterIndicator';
+export default Meter;

--- a/src/components/ui/Meter/contexts/MeterContext.tsx
+++ b/src/components/ui/Meter/contexts/MeterContext.tsx
@@ -1,0 +1,20 @@
+import { createContext } from 'react';
+
+type MeterContextType = {
+    value: number;
+    minValue: number;
+    maxValue: number;
+    lowValue?: number;
+    highValue?: number;
+    optimumValue?: number;
+    rootClass: string;
+    state: 'normal' | 'low' | 'high' | 'optimum';
+};
+
+export const MeterContext = createContext<MeterContextType>({
+    value: 0,
+    minValue: 0,
+    maxValue: 100,
+    rootClass: '',
+    state: 'normal'
+});

--- a/src/components/ui/Meter/fragments/MeterIndicator.tsx
+++ b/src/components/ui/Meter/fragments/MeterIndicator.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, {
+    useContext,
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef
+} from 'react';
+import { clsx } from 'clsx';
+import Primitive from '~/core/primitives/Primitive';
+import { MeterContext } from '../contexts/MeterContext';
+
+export type MeterIndicatorElement = ElementRef<typeof Primitive.div>;
+export type MeterIndicatorProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+
+const MeterIndicator = forwardRef<MeterIndicatorElement, MeterIndicatorProps>(
+    ({ className, style, ...props }, ref) => {
+        const { value, minValue, maxValue, rootClass, state } = useContext(MeterContext);
+        const percentage = maxValue === minValue
+            ? 0
+            : ((value - minValue) / (maxValue - minValue)) * 100;
+        const { asChild, ...rest } = props;
+
+        return (
+            <Primitive.div
+                className={clsx(rootClass && `${rootClass}-indicator`, className)}
+                style={{ transform: `translateX(-${100 - percentage}%)`, ...style }}
+                data-state={state}
+                data-value={value}
+                data-min={minValue}
+                data-max={maxValue}
+                asChild={asChild}
+                ref={ref}
+                {...rest}
+            />
+        );
+    }
+);
+
+MeterIndicator.displayName = 'MeterIndicator';
+
+export default MeterIndicator;

--- a/src/components/ui/Meter/fragments/MeterRoot.tsx
+++ b/src/components/ui/Meter/fragments/MeterRoot.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, {
+    forwardRef,
+    ElementRef,
+    ComponentPropsWithoutRef
+} from 'react';
+import { clsx } from 'clsx';
+import Primitive from '~/core/primitives/Primitive';
+import { useComponentClass } from '~/components/ui/Theme/useComponentClass';
+import { MeterContext } from '../contexts/MeterContext';
+
+const COMPONENT_NAME = 'Meter';
+
+export type MeterRootElement = ElementRef<typeof Primitive.div>;
+export type MeterRootProps = {
+    value?: number;
+    minValue?: number;
+    maxValue?: number;
+    lowValue?: number;
+    highValue?: number;
+    optimumValue?: number;
+    getValueLabel?: (value: number, minValue: number, maxValue: number) => string;
+    customRootClass?: string;
+    children?: React.ReactNode;
+} & ComponentPropsWithoutRef<typeof Primitive.div>;
+
+const clamp = (value: number, minValue: number, maxValue: number) => {
+    if (maxValue <= minValue) return minValue;
+    return Math.min(Math.max(value, minValue), maxValue);
+};
+
+const getMeterState = (
+    value: number,
+    lowValue?: number,
+    highValue?: number,
+    optimumValue?: number
+) => {
+    if (optimumValue !== undefined && value === optimumValue) return 'optimum';
+    if (lowValue !== undefined && value < lowValue) return 'low';
+    if (highValue !== undefined && value > highValue) return 'high';
+    return 'normal';
+};
+
+const MeterRoot = forwardRef<MeterRootElement, MeterRootProps>(
+    (
+        {
+            value = 0,
+            minValue = 0,
+            maxValue = 100,
+            lowValue,
+            highValue,
+            optimumValue,
+            getValueLabel,
+            customRootClass,
+            className,
+            children,
+            ...props
+        },
+        ref
+    ) => {
+        const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
+        const boundedValue = clamp(value, minValue, maxValue);
+        const state = getMeterState(boundedValue, lowValue, highValue, optimumValue);
+        const valueLabel = getValueLabel?.(boundedValue, minValue, maxValue);
+
+        const { asChild, ...rest } = props;
+
+        return (
+            <MeterContext.Provider
+                value={{
+                    value: boundedValue,
+                    minValue,
+                    maxValue,
+                    lowValue,
+                    highValue,
+                    optimumValue,
+                    rootClass,
+                    state
+                }}
+            >
+                <Primitive.div
+                    role="meter"
+                    aria-valuenow={boundedValue}
+                    aria-valuemin={minValue}
+                    aria-valuemax={maxValue}
+                    aria-valuetext={valueLabel}
+                    data-state={state}
+                    data-value={boundedValue}
+                    data-min={minValue}
+                    data-max={maxValue}
+                    data-low={lowValue}
+                    data-high={highValue}
+                    data-optimum={optimumValue}
+                    className={clsx(rootClass, className)}
+                    asChild={asChild}
+                    ref={ref}
+                    {...rest}
+                >
+                    {children}
+                </Primitive.div>
+            </MeterContext.Provider>
+        );
+    }
+);
+
+MeterRoot.displayName = COMPONENT_NAME;
+
+export { clamp as clampMeterValue, getMeterState };
+export default MeterRoot;

--- a/src/components/ui/Meter/meter.baremetal.scss
+++ b/src/components/ui/Meter/meter.baremetal.scss
@@ -1,0 +1,5 @@
+/* stylelint-disable at-rule-no-unknown */
+@use "src/design-systems/baremetal/scope" as baremetal;
+
+#{baremetal.$theme-root} :where(.rad-ui-meter) { @include baremetal.track; }
+#{baremetal.$theme-root} :where(.rad-ui-meter-indicator) { @include baremetal.fill; }

--- a/src/components/ui/Meter/meter.clarity.scss
+++ b/src/components/ui/Meter/meter.clarity.scss
@@ -1,0 +1,29 @@
+.rad-ui-meter {
+    background: var(--rad-ui-color-gray-200);
+    border: none;
+    overflow: hidden;
+    height: 0.25rem;
+    border-radius: var(--rad-ui-radius-full);
+    width: 100%;
+    max-width: 25.25rem;
+
+    .rad-ui-meter-indicator {
+        background: var(--rad-ui-color-accent-800);
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        transition: transform 0.2s ease;
+    }
+
+    .rad-ui-meter-indicator[data-state="low"] {
+        background: var(--rad-ui-warning-solid);
+    }
+
+    .rad-ui-meter-indicator[data-state="high"] {
+        background: var(--rad-ui-info-solid);
+    }
+
+    .rad-ui-meter-indicator[data-state="optimum"] {
+        background: var(--rad-ui-success-solid);
+    }
+}

--- a/src/components/ui/Meter/stories/Meter.stories.tsx
+++ b/src/components/ui/Meter/stories/Meter.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Meter from '../Meter';
+import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta: Meta<typeof Meter> = {
+    title: 'Components/Meter',
+    component: Meter
+};
+
+export default meta;
+type Story = StoryObj<typeof Meter>;
+
+export const Default: Story = {
+    render: () => (
+        <SandboxEditor>
+            <div className="flex min-h-[240px] w-full items-center justify-center">
+                <Meter.Root value={72} minValue={0} maxValue={100} lowValue={30} highValue={85}>
+                    <Meter.Indicator />
+                </Meter.Root>
+            </div>
+        </SandboxEditor>
+    )
+};
+
+export const Thresholds: Story = {
+    render: () => (
+        <SandboxEditor>
+            <div className="flex min-h-[240px] w-full flex-col items-center justify-center gap-6">
+                <Meter.Root value={18} lowValue={30} highValue={80}>
+                    <Meter.Indicator />
+                </Meter.Root>
+                <Meter.Root value={50} lowValue={30} highValue={80}>
+                    <Meter.Indicator />
+                </Meter.Root>
+                <Meter.Root value={92} lowValue={30} highValue={80}>
+                    <Meter.Indicator />
+                </Meter.Root>
+            </div>
+        </SandboxEditor>
+    )
+};

--- a/src/components/ui/Meter/tests/Meter.a11y.test.tsx
+++ b/src/components/ui/Meter/tests/Meter.a11y.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as axe from 'axe-core';
+import { ACCESSIBILITY_TEST_TAGS } from '~/setupTests';
+import Meter from '../Meter';
+
+describe('Meter accessibility', () => {
+    test('axe: no violations', async() => {
+        const { container } = render(
+            <Meter.Root value={65} minValue={0} maxValue={100} lowValue={30} highValue={85}>
+                <Meter.Indicator />
+            </Meter.Root>
+        );
+        const results = await axe.run(container, { runOnly: { type: 'tag', values: ACCESSIBILITY_TEST_TAGS } });
+        expect(results.violations).toHaveLength(0);
+    });
+});

--- a/src/components/ui/Meter/tests/Meter.test.tsx
+++ b/src/components/ui/Meter/tests/Meter.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Meter from '../Meter';
+
+const MeterComp = ({
+    value = 50,
+    minValue = 0,
+    maxValue = 100,
+    lowValue,
+    highValue,
+    optimumValue
+}: Partial<React.ComponentProps<typeof Meter.Root>>) => (
+    <Meter.Root
+        value={value}
+        minValue={minValue}
+        maxValue={maxValue}
+        lowValue={lowValue}
+        highValue={highValue}
+        optimumValue={optimumValue}
+    >
+        <Meter.Indicator data-testid="meter-indicator" />
+    </Meter.Root>
+);
+
+describe('Meter', () => {
+    test('renders a meter root', () => {
+        render(<MeterComp />);
+        expect(screen.getByRole('meter')).toBeInTheDocument();
+    });
+
+    test('forwards refs to root and indicator elements', () => {
+        const rootRef = React.createRef<HTMLDivElement>();
+        const indicatorRef = React.createRef<HTMLDivElement>();
+
+        render(
+            <Meter.Root ref={rootRef} value={40}>
+                <Meter.Indicator ref={indicatorRef} />
+            </Meter.Root>
+        );
+
+        expect(rootRef.current).toBeInstanceOf(HTMLDivElement);
+        expect(indicatorRef.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    test('sets ARIA value attributes', () => {
+        render(<MeterComp value={45} minValue={10} maxValue={90} />);
+        const meter = screen.getByRole('meter');
+
+        expect(meter).toHaveAttribute('aria-valuenow', '45');
+        expect(meter).toHaveAttribute('aria-valuemin', '10');
+        expect(meter).toHaveAttribute('aria-valuemax', '90');
+    });
+
+    test('uses getValueLabel for aria-valuetext', () => {
+        render(
+            <Meter.Root
+                value={8}
+                minValue={0}
+                maxValue={10}
+                getValueLabel={(value, minValue, maxValue) => `${value - minValue} of ${maxValue - minValue}`}
+            >
+                <Meter.Indicator />
+            </Meter.Root>
+        );
+
+        expect(screen.getByRole('meter')).toHaveAttribute('aria-valuetext', '8 of 10');
+    });
+
+    test('clamps public value attributes to the configured range', () => {
+        render(<MeterComp value={120} maxValue={100} />);
+        expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '100');
+        expect(screen.getByTestId('meter-indicator')).toHaveAttribute('data-value', '100');
+    });
+
+    test('exposes threshold data attributes', () => {
+        render(<MeterComp value={50} lowValue={25} highValue={75} optimumValue={60} />);
+        const meter = screen.getByRole('meter');
+
+        expect(meter).toHaveAttribute('data-low', '25');
+        expect(meter).toHaveAttribute('data-high', '75');
+        expect(meter).toHaveAttribute('data-optimum', '60');
+    });
+
+    test('sets low, normal, high, and optimum data states', () => {
+        const { rerender } = render(<MeterComp value={20} lowValue={30} highValue={80} />);
+        expect(screen.getByRole('meter')).toHaveAttribute('data-state', 'low');
+
+        rerender(<MeterComp value={50} lowValue={30} highValue={80} />);
+        expect(screen.getByRole('meter')).toHaveAttribute('data-state', 'normal');
+
+        rerender(<MeterComp value={90} lowValue={30} highValue={80} />);
+        expect(screen.getByRole('meter')).toHaveAttribute('data-state', 'high');
+
+        rerender(<MeterComp value={60} optimumValue={60} />);
+        expect(screen.getByRole('meter')).toHaveAttribute('data-state', 'optimum');
+    });
+
+    test('supports asChild on root and indicator', () => {
+        render(
+            <Meter.Root value={50} asChild>
+                <section data-testid="meter-root">
+                    <Meter.Indicator asChild>
+                        <span data-testid="meter-indicator" />
+                    </Meter.Indicator>
+                </section>
+            </Meter.Root>
+        );
+
+        expect(screen.getByTestId('meter-root')).toHaveAttribute('role', 'meter');
+        expect(screen.getByTestId('meter-indicator')).toHaveAttribute('data-value', '50');
+    });
+});

--- a/src/design-systems/baremetal/default.scss
+++ b/src/design-systems/baremetal/default.scss
@@ -47,6 +47,7 @@
 @use "../../components/ui/NumberField/number-field.baremetal";
 @use "../../components/ui/ContextMenu/context-menu.baremetal";
 @use "../../components/ui/Menubar/menubar.baremetal";
+@use "../../components/ui/Meter/meter.baremetal";
 @use "../../components/ui/Splitter/splitter.baremetal";
 @use "../../components/ui/Toolbar/toolbar.baremetal";
 @use "../../components/ui/Steps/steps.baremetal";

--- a/src/design-systems/clarity/default.scss
+++ b/src/design-systems/clarity/default.scss
@@ -49,6 +49,7 @@
 @use "../../components/ui/NumberField/number-field.clarity";
 @use "../../components/ui/ContextMenu/context-menu.clarity";
 @use "../../components/ui/Menubar/menubar.clarity";
+@use "../../components/ui/Meter/meter.clarity";
 @use "../../components/ui/Splitter/splitter.clarity";
 @use "../../components/ui/Toolbar/toolbar.clarity";
 @use "../../components/ui/Steps/steps.clarity";

--- a/styles/themes/components/meter.scss
+++ b/styles/themes/components/meter.scss
@@ -1,0 +1,16 @@
+.rad-ui-meter {
+    background: var(--rad-ui-color-gray-200);
+    border-radius: var(--rad-ui-radius-full);
+    height: 0.25rem;
+    max-width: 25.25rem;
+    overflow: hidden;
+    width: 100%;
+}
+
+.rad-ui-meter-indicator {
+    background: var(--rad-ui-color-accent-800);
+    border-radius: inherit;
+    height: 100%;
+    transition: transform 0.2s ease;
+    width: 100%;
+}


### PR DESCRIPTION
## Summary

- Adds a headless Meter primitive with Root and Indicator parts.
- Exposes meter ARIA attributes plus value and threshold data attributes for styling.
- Adds Storybook coverage, docs page, theme styles, package export, and a changeset.
- Includes the Drawer context defaults needed by the current main branch source build.

Closes #1777.

## Validation

- npm test -- Meter.test.tsx Meter.a11y.test.tsx --runInBand
- npm test -- --runInBand
- npm run validate:changesets
- npm run check:docs-snippets
- npm run check:docs-examples
- pnpm --dir docs build
- NODE_OPTIONS='--max-old-space-size=12288' npm run build:rollup:process
- npm run check:exports
- npm run check:api-surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Meter component for displaying progress between configurable minimum and maximum values.
  * Supports value labels, low/high thresholds, optimum states, accessibility attributes, custom styling, and composable root and indicator elements.
  * Added package exports and theme styling for Clarity and Baremetal.
* **Documentation**
  * Added interactive Meter examples, API reference, anatomy guidance, feature descriptions, and navigation entry.
* **Tests**
  * Added coverage for rendering, accessibility, value handling, thresholds, state changes, refs, and composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->