### PR TITLE
fix(disclosure): expose data slots

### DIFF
--- a/.changeset/disclosure-data-slots.md
+++ b/.changeset/disclosure-data-slots.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Expose stable Disclosure anatomy data slots and initialize `defaultOpen`.

--- a/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureContent.tsx
@@ -17,6 +17,8 @@ const DisclosureContent = React.forwardRef<React.ElementRef<'div'>, DisclosureCo
                 ref={forwardedRef}
                 className={clsx(rootClass && `${rootClass}-content`, className)}
 
+                data-state="open"
+                data-slot="disclosure-content"
                 role="region"
                 aria-hidden={activeItem !== itemValue}
             >

--- a/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
@@ -37,6 +37,7 @@ const DisclosureItem = React.forwardRef<React.ElementRef<'div'>, DisclosureItemP
                     className={clsx(rootClass && `${rootClass}-item`, className)}
                     ref={forwardedRef}
                     data-state={isOpen ? 'open' : 'closed'}
+                    data-slot="disclosure-item"
                     id={`disclosure-data-item-${id}`}
                     role="region"
                     aria-labelledby={`disclosure-trigger-${id}`}

--- a/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureItem.tsx
@@ -12,7 +12,7 @@ const DisclosureItem = React.forwardRef<React.ElementRef<'div'>, DisclosureItemP
     const { activeItem, rootClass } = useContext(DisclosureContext);
 
     const [itemValue, setItemValue] = useState<number>(value);
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(activeItem === value);
 
     useEffect(() => {
         setIsOpen(activeItem === itemValue);

--- a/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureRoot.tsx
@@ -13,11 +13,11 @@ export type DisclosureRootProps = React.ComponentPropsWithoutRef<'div'> & {
      loop?: boolean;
 };
 
-const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, customRootClass, 'aria-label': ariaLabel, loop = true, ...props }, forwardedRef) => {
+const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootProps>(({ children, className, customRootClass, defaultOpen = null, 'aria-label': ariaLabel, loop = true, ...props }, forwardedRef) => {
     const disclosureRef = useRef<React.ElementRef<'div'> | null>(null);
     const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
 
-    const [activeItem, setActiveItem] = useState<number | null>(null);
+    const [activeItem, setActiveItem] = useState<number | null>(defaultOpen);
 
     const setRefs = useCallback((node: React.ElementRef<'div'> | null) => {
         disclosureRef.current = node;
@@ -42,10 +42,11 @@ const DisclosureRoot = React.forwardRef<React.ElementRef<'div'>, DisclosureRootP
                 <RovingFocusGroup.Group className={clsx(rootClass && `${rootClass}-root`)}>
                     <div
                         {...props}
-                        className={clsx(rootClass && `${rootClass}-root`)}
+                        className={clsx(rootClass && `${rootClass}-root`, className)}
                         ref={setRefs}
                         role="region"
                         aria-label={ariaLabel}
+                        data-slot="disclosure-root"
                         data-testid='disclosure-root'
                     >
 

--- a/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
+++ b/src/components/ui/Disclosure/fragments/DisclosureTrigger.tsx
@@ -29,6 +29,8 @@ const DisclosureTrigger = React.forwardRef<React.ElementRef<'button'>, Disclosur
                     type='button'
                     className={clsx(rootClass && `${rootClass}-trigger`, className)}
                     onClick={onClickHandler}
+                    data-state={activeItem === itemValue ? 'open' : 'closed'}
+                    data-slot="disclosure-trigger"
                     aria-expanded={activeItem === itemValue}
                     aria-haspopup='true'
                 >

--- a/src/components/ui/Disclosure/tests/Disclosure.test.tsx
+++ b/src/components/ui/Disclosure/tests/Disclosure.test.tsx
@@ -56,6 +56,39 @@ describe('Disclosure', () => {
         expect(screen.getByText('Content 1')).toBeInTheDocument();
     });
 
+    test('reflects anatomy and open state through data attributes', () => {
+        render(
+            <Disclosure.Root aria-label="test" defaultOpen={0} className="custom-root">
+                <Disclosure.Item value={0} data-testid="item-one">
+                    <Disclosure.Trigger>Item 1</Disclosure.Trigger>
+                    <Disclosure.Content>Content 1</Disclosure.Content>
+                </Disclosure.Item>
+                <Disclosure.Item value={1} data-testid="item-two">
+                    <Disclosure.Trigger>Item 2</Disclosure.Trigger>
+                    <Disclosure.Content>Content 2</Disclosure.Content>
+                </Disclosure.Item>
+            </Disclosure.Root>
+        );
+
+        const root = screen.getByTestId('disclosure-root');
+        const openItem = screen.getByTestId('item-one');
+        const closedItem = screen.getByTestId('item-two');
+        const openTrigger = screen.getByText('Item 1');
+        const closedTrigger = screen.getByText('Item 2');
+        const content = screen.getByText('Content 1');
+
+        expect(root).toHaveClass('custom-root');
+        expect(root).toHaveAttribute('data-slot', 'disclosure-root');
+        expect(openItem).toHaveAttribute('data-slot', 'disclosure-item');
+        expect(openItem).toHaveAttribute('data-state', 'open');
+        expect(closedItem).toHaveAttribute('data-state', 'closed');
+        expect(openTrigger).toHaveAttribute('data-slot', 'disclosure-trigger');
+        expect(openTrigger).toHaveAttribute('data-state', 'open');
+        expect(closedTrigger).toHaveAttribute('data-state', 'closed');
+        expect(content).toHaveAttribute('data-slot', 'disclosure-content');
+        expect(content).toHaveAttribute('data-state', 'open');
+    });
+
     test('loop={false} stops focus wrap between triggers', async() => {
         const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- expose stable Disclosure data-slot markers for root, item, trigger, and content
- reflect trigger/content open state through data-state
- initialize the existing defaultOpen prop and preserve root className

## Testing
- npm test -- src/components/ui/Disclosure/tests/Disclosure.test.tsx --runInBand
- npm test -- src/components/ui/Disclosure/tests/Disclosure.a11y.test.tsx --runInBand
- npm run validate:changesets

Contributes to #1782.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable anatomy markers for Disclosure roots, items, triggers, and content.
  * Added open/closed state indicators to Disclosure triggers and content for styling and interaction feedback.
  * Disclosure now supports custom root classes and correctly initializes with the configured default-open item.

* **Bug Fixes**
  * Improved Disclosure initialization so the default-open state is applied when rendered.

* **Tests**
  * Added coverage for Disclosure structure, state indicators, default-open behavior, and custom classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->