### PR TITLE
docs(a11y): add ARIA pattern references

### DIFF
--- a/docs/app/docs/components/accordion/content.mdx
+++ b/docs/app/docs/components/accordion/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import AccordionExample from "./docs/example_1"
-import {code, anatomy, keyboardShortcuts, api_documentation} from "./docs/codeUsage"
+import {code, anatomy, ariaReferences, keyboardShortcuts, api_documentation} from "./docs/codeUsage"
 
 
 
@@ -24,4 +24,6 @@ import {code, anatomy, keyboardShortcuts, api_documentation} from "./docs/codeUs
 
     {/* Keyboard Shortcuts */}
     <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/accordion/docs/codeUsage.js
+++ b/docs/app/docs/components/accordion/docs/codeUsage.js
@@ -4,6 +4,11 @@ import {
     createKeyboardShortcutTable,
     DOCS_KEYBOARD_SHORTCUTS
 } from '../../shared/keyboardShortcuts';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/accordion/docs/example_1.tsx');
 
@@ -71,6 +76,13 @@ export const keyboardShortcuts = createKeyboardShortcutTable([
     createKeyboardShortcutRow(
         DOCS_KEYBOARD_SHORTCUTS.END,
         'When focus is on an Accordion.Trigger, focuses the last Accordion.Trigger.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.ACCORDION,
+        'Uses button triggers with expanded state and associated content regions for collapsible sections.'
     )
 ]);
 

--- a/docs/app/docs/components/dialog/content.mdx
+++ b/docs/app/docs/components/dialog/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import DialogExample from "./docs/example_1"
-import {code, anatomy, api_documentation} from "./docs/codeUsage"
+import {code, anatomy, ariaReferences, keyboardShortcuts, api_documentation} from "./docs/codeUsage"
 
 <Documentation
     title={`Dialog`}
@@ -17,5 +17,9 @@ import {code, anatomy, api_documentation} from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'trigger', 'portal', 'overlay', 'content', 'title', 'description', 'footer', 'close']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 
 </Documentation>

--- a/docs/app/docs/components/dialog/docs/codeUsage.js
+++ b/docs/app/docs/components/dialog/docs/codeUsage.js
@@ -1,4 +1,14 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/dialog/docs/example_1.tsx');
 
@@ -42,5 +52,27 @@ export const api_documentation = {
     footer: footer_api_SourceCode,
     close: close_api_SourceCode,
 }
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'Closes the dialog when the close interaction is enabled.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to the next focusable element inside the dialog.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SHIFT_TAB,
+        'Moves focus to the previous focusable element inside the dialog.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.DIALOG_MODAL,
+        'Uses modal dialog semantics with labelled content, description support, focus containment, and dismiss behavior.'
+    )
+]);
 
 export default code

--- a/docs/app/docs/components/radio-group/content.mdx
+++ b/docs/app/docs/components/radio-group/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import RadioGroupExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="RadioGroup"
@@ -15,4 +15,8 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
         tables={api_documentation}
         order={['root']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/radio-group/docs/codeUsage.js
+++ b/docs/app/docs/components/radio-group/docs/codeUsage.js
@@ -1,5 +1,15 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
 import root_api from './component_api/root.tsx';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/radio-group/docs/example_1.tsx');
 const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/radio-group.scss');
@@ -15,5 +25,39 @@ export const anatomy = { code: anatomy_SourceCode };
 export const api_documentation = {
     root: root_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus into or out of the radio group.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_RIGHT,
+        'Moves focus to the next enabled radio item and selects it.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_DOWN,
+        'Moves focus to the next enabled radio item and selects it.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_LEFT,
+        'Moves focus to the previous enabled radio item and selects it.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_UP,
+        'Moves focus to the previous enabled radio item and selects it.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Selects the focused radio item.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.RADIO_GROUP,
+        'Uses grouped radio semantics for a single required or optional selection among related items.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -1,0 +1,66 @@
+import Text from '@radui/ui/Text';
+
+export const ariaReferenceColumns = [
+    {
+        name: 'Reference',
+        id: 'reference'
+    },
+    {
+        name: 'What Rad UI follows',
+        id: 'description'
+    }
+];
+
+export const DOCS_ARIA_PATTERNS = Object.freeze({
+    ACCORDION: {
+        id: 'accordion',
+        label: 'Accordion pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion/'
+    },
+    DIALOG_MODAL: {
+        id: 'dialog-modal',
+        label: 'Dialog modal pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/'
+    },
+    RADIO_GROUP: {
+        id: 'radio-group',
+        label: 'Radio group pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/radio/'
+    },
+    TABS: {
+        id: 'tabs',
+        label: 'Tabs pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/tabs/'
+    },
+    TOOLTIP: {
+        id: 'tooltip',
+        label: 'Tooltip pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/'
+    }
+});
+
+export const createAriaReferenceRow = (pattern, description) => {
+    if (!pattern || typeof pattern !== 'object' || !pattern.id || !pattern.label || !pattern.href) {
+        throw new Error('createAriaReferenceRow: invalid pattern; use a DOCS_ARIA_PATTERNS value.');
+    }
+
+    return {
+        id: pattern.id,
+        reference: (
+            <a
+                className="font-medium text-blue-900 underline underline-offset-4 hover:text-blue-700"
+                href={pattern.href}
+                rel="noreferrer"
+                target="_blank"
+            >
+                {pattern.label}
+            </a>
+        ),
+        description: <Text>{description}</Text>
+    };
+};
+
+export const createAriaReferenceTable = (rows = []) => ({
+    columns: ariaReferenceColumns,
+    data: rows
+});

--- a/docs/app/docs/components/shared/keyboardShortcuts.js
+++ b/docs/app/docs/components/shared/keyboardShortcuts.js
@@ -14,6 +14,8 @@ export const keyboardShortcutColumns = [
 
 export const DOCS_KEYBOARD_SHORTCUTS = Object.freeze({
     ARROW_DOWN: { id: 'arrow-down', label: 'ArrowDown' },
+    ARROW_LEFT: { id: 'arrow-left', label: 'ArrowLeft' },
+    ARROW_RIGHT: { id: 'arrow-right', label: 'ArrowRight' },
     ARROW_UP: { id: 'arrow-up', label: 'ArrowUp' },
     END: { id: 'end', label: 'End' },
     ENTER: { id: 'enter', label: 'Enter' },

--- a/docs/app/docs/components/tabs/content.mdx
+++ b/docs/app/docs/components/tabs/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import TabsExample from "./docs/example_1"
-import {code, anatomy, api_documentation} from "./docs/codeUsage"
+import {code, anatomy, ariaReferences, keyboardShortcuts, api_documentation} from "./docs/codeUsage"
 
 
 
@@ -21,4 +21,8 @@ import {code, anatomy, api_documentation} from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'trigger', 'list', 'content']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/tabs/docs/codeUsage.js
+++ b/docs/app/docs/components/tabs/docs/codeUsage.js
@@ -1,6 +1,14 @@
-import Kbd from '@radui/ui/Kbd';
-import Text from '@radui/ui/Text';
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tabs/docs/example_1.tsx');
 
@@ -33,5 +41,35 @@ export const api_documentation = {
     list: list_api_SourceCode,
     content: content_api_SourceCode
 }
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus into or out of the tab list.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_RIGHT,
+        'When focus is on a tab trigger, moves focus to the next trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_LEFT,
+        'When focus is on a tab trigger, moves focus to the previous trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.HOME,
+        'When focus is on a tab trigger, moves focus to the first trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.END,
+        'When focus is on a tab trigger, moves focus to the last trigger.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.TABS,
+        'Uses tab list, tab trigger, and tab panel semantics for switching between related views.'
+    )
+]);
 
 export default code

--- a/docs/app/docs/components/tooltip/content.mdx
+++ b/docs/app/docs/components/tooltip/content.mdx
@@ -1,5 +1,5 @@
 import Documentation from "@/components/layout/Documentation/Documentation"
-import codeUsage, { anatomy, api_documentation, keyboardShortcuts } from "./docs/codeUsage"
+import codeUsage, { anatomy, ariaReferences, api_documentation, keyboardShortcuts } from "./docs/codeUsage"
 import TooltipExample1 from "./docs/examples/tooltip_example1"
 
 <Documentation 
@@ -33,5 +33,11 @@ import TooltipExample1 from "./docs/examples/tooltip_example1"
     title="Keyboard Interactions" 
     columns={keyboardShortcuts.columns}
     data={keyboardShortcuts.data}
+  />
+
+  <Documentation.Table
+    title="ARIA References"
+    columns={ariaReferences.columns}
+    data={ariaReferences.data}
   />
 </Documentation>

--- a/docs/app/docs/components/tooltip/docs/codeUsage.js
+++ b/docs/app/docs/components/tooltip/docs/codeUsage.js
@@ -4,6 +4,11 @@ import {
     createKeyboardShortcutTable,
     DOCS_KEYBOARD_SHORTCUTS
 } from '../../shared/keyboardShortcuts';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tooltip/docs/examples/tooltip_example1.tsx');
 const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tooltip/docs/anatomy.tsx');
@@ -63,6 +68,13 @@ export const keyboardShortcuts = {
         )
     ])
 };
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.TOOLTIP,
+        'Uses tooltip semantics for contextual information that appears on hover or focus and dismisses with Escape.'
+    )
+]);
 
 // Legacy table export - keeping for backward compatibility
 export const TooltipTable = {


### PR DESCRIPTION
## Summary

- Add a shared ARIA reference table helper for component docs.
- Add ARIA reference sections to Accordion, Dialog, Tabs, RadioGroup, and Tooltip docs.
- Add missing keyboard interaction tables for Dialog, Tabs, and RadioGroup.

Part of #1811 and #1837.

## Validation

- npm run lint
- pnpm --dir docs build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ARIA reference tables to Accordion, Dialog, Radio Group, Tabs, and Tooltip documentation.
  * Added keyboard interaction guidance for Dialog, Radio Group, and Tabs, including arrow-key navigation.
  * Linked accessibility guidance to relevant WAI-ARIA patterns and clarified focus, navigation, selection, and dismissal behavior.
  * Standardized accessibility reference tables across component documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->