### PR TITLE
docs: clarify CSS token fallbacks

### DIFF
--- a/.changeset/css-token-fallback-docs.md
+++ b/.changeset/css-token-fallback-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Document CSS variable fallback and partial token override expectations for Rad UI styled layers.

--- a/docs/app/docs/guides/design-token-contract/content.mdx
+++ b/docs/app/docs/guides/design-token-contract/content.mdx
@@ -54,6 +54,51 @@ When using Rad UI headlessly:
 
 - Tokens are optional; bring your own design tokens and map them in wrappers.
 
+## Complete token sets
+
+Rad UI-provided styled layers assume that the theme CSS supplies a complete token set for the component styles being used.
+
+Supported:
+
+- import a Rad UI theme CSS file and override selected `--rad-ui-*` variables
+- scope overrides to `:root`, a `Theme` container, or another stable application boundary
+- leave all non-overridden variables inherited from the imported theme
+
+Unsupported:
+
+- importing only a small subset of token definitions and expecting every styled component to recover
+- removing required token families used by loaded component CSS
+- relying on browser-invalid CSS declarations caused by missing variables
+
+Partial overrides are supported when they sit on top of a complete theme. Partial token definitions are not a complete theme by themselves.
+
+## Fallback values
+
+Inline CSS fallback values such as `var(--rad-ui-radius-md, 6px)` are not the public customization contract for Rad UI styled layers.
+
+Rad UI may use fallback values where they make a declaration resilient during development, migration, or progressive token rollout. Treat those fallbacks as internal implementation details unless a variable's documentation explicitly says otherwise.
+
+Consumers should provide the documented variables they depend on instead of depending on fallback branches. Missing documented variables are unsupported configuration, not a guaranteed graceful-degradation path.
+
+## Safe override pattern
+
+Prefer additive token overrides:
+
+```css
+@import "@radui/ui/themes/default.css";
+
+:root {
+  --rad-ui-radius-md: 8px;
+  --rad-ui-spacing-4: 1rem;
+}
+
+[data-rad-ui-theme][data-rad-ui-accent-color="brand"] {
+  --rad-ui-color-accent-9: #3157d5;
+}
+```
+
+Avoid replacement strategies that redefine only a handful of variables without importing or generating the rest of the theme contract.
+
 ## Adding or changing tokens
 
 1. Update `styles/cssTokens/` and regenerate via `npm run generate-tokens`.

--- a/docs/app/docs/guides/styling-and-customization/content.mdx
+++ b/docs/app/docs/guides/styling-and-customization/content.mdx
@@ -23,6 +23,25 @@ Use these stable hooks when styling:
 
 See [Usage](/docs/first-steps/usage) for `Theme` and `classNamespace` examples.
 
+## CSS variable fallbacks
+
+Rad UI's tokenized styles expect the loaded theme CSS to provide the documented `--rad-ui-*` variables that those styles use.
+
+Use CSS variable overrides as a layer on top of a complete theme:
+
+```css
+@import "@radui/ui/themes/default.css";
+
+.billing-theme {
+  --rad-ui-radius-md: 10px;
+  --rad-ui-spacing-4: 1rem;
+}
+```
+
+Do not treat `var(--token, fallback)` branches as a supported theming API unless the token guide documents that behavior for a specific variable. Fallback values may exist to keep internal migrations resilient, but consumers should not rely on missing variables resolving to Rad UI-chosen defaults.
+
+See [Design Token Contract](/docs/guides/design-token-contract) for complete-theme and partial-override rules.
+
 ## What not to rely on
 
 Avoid styling strategies that break when Rad UI refactors internals:
@@ -31,6 +50,7 @@ Avoid styling strategies that break when Rad UI refactors internals:
 - overriding private class names that are not part of your `classNamespace`
 - `!important` rules that fight component state styles
 - copying markup from Storybook and assuming incidental wrapper elements are stable
+- replacing the default theme with a partial CSS variable map
 
 If a style requirement needs a hook that does not exist, open an issue or PR to add a **documented** public attribute rather than targeting internals.
 


### PR DESCRIPTION
## Summary
- document that Rad UI styled layers expect complete theme token sets
- clarify partial overrides are supported only on top of a complete theme
- explain that CSS variable fallback branches are implementation details unless explicitly documented

Closes #1857.

## Validation
- npm run lint
- pnpm --dir docs build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented complete theme token requirements for Rad UI styled layers.
  - Clarified CSS variable fallback behavior and supported override patterns.
  - Added guidance for safely applying additive CSS customizations.
  - Identified partial CSS variable maps and undocumented fallback values as unsupported approaches.

- **Chores**
  - Prepared a patch release for `@radui/ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->