### PR TITLE
docs(select): add large list example

### DIFF
--- a/.changeset/select-virtualized-docs.md
+++ b/.changeset/select-virtualized-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Add Select documentation for large option lists.

--- a/docs/app/docs/components/select/content.mdx
+++ b/docs/app/docs/components/select/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import SelectExample from "./docs/example_1"
-import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
+import { code, largeListCode, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="Select"
@@ -9,6 +9,14 @@ import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } f
     <Documentation.ComponentHero codeUsage={code}>
         <SelectExample />
     </Documentation.ComponentHero>
+
+    <Documentation.Section title="Large Lists">
+        Use a controlled value and keep each option's `value` and `label` stable when a Select has hundreds of options.
+        This incremental pattern keeps keyboard navigation intact by mounting more rows before focus reaches the boundary.
+        <Documentation.CodeBlock language="tsx">
+            {largeListCode.javascript.code}
+        </Documentation.CodeBlock>
+    </Documentation.Section>
 
     <Documentation.ApiReference
         anatomy={anatomy.code}

--- a/docs/app/docs/components/select/docs/codeUsage.js
+++ b/docs/app/docs/components/select/docs/codeUsage.js
@@ -13,12 +13,17 @@ import root_api from './component_api/root.tsx';
 import item_api from './component_api/item.tsx';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/select/docs/example_1.tsx');
+const largeList_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/select/docs/large-list.tsx');
 const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/select.scss');
 const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/select/docs/anatomy.tsx');
 
 export const code = {
     javascript: { code: example_1_SourceCode },
     scss: { code: scss_SourceCode }
+};
+
+export const largeListCode = {
+    javascript: { code: largeList_SourceCode }
 };
 
 export const anatomy = { code: anatomy_SourceCode };

--- a/docs/app/docs/components/select/docs/large-list.tsx
+++ b/docs/app/docs/components/select/docs/large-list.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import * as React from "react"
+import { flushSync } from "react-dom"
+import Select from "@radui/ui/Select"
+
+const OPTIONS = Array.from({ length: 1000 }, (_, index) => ({
+    value: `item-${index + 1}`,
+    label: `Item ${index + 1}`
+}))
+
+const PAGE_SIZE = 40
+
+const LargeListSelectExample = () => {
+    const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE)
+    const [value, setValue] = React.useState("")
+
+    const selectedLabel = OPTIONS.find((option) => option.value === value)?.label
+    const visibleOptions = OPTIONS.slice(0, visibleCount)
+    const canShowMore = visibleCount < OPTIONS.length
+
+    const showMore = React.useCallback(() => {
+        setVisibleCount((current) => Math.min(current + PAGE_SIZE, OPTIONS.length))
+    }, [])
+
+    const showMoreBeforeNavigation = React.useCallback(() => {
+        flushSync(() => {
+            setVisibleCount((current) => Math.min(current + PAGE_SIZE, OPTIONS.length))
+        })
+    }, [])
+
+    return (
+        <Select.Root value={value} onValueChange={setValue}>
+            <Select.Trigger>
+                <span>{selectedLabel || "Select an item..."}</span>
+            </Select.Trigger>
+            <Select.Portal>
+                <Select.Content
+                    style={{ "--rad-select-content-height": "256px" } as React.CSSProperties}
+                    onScroll={(event) => {
+                        const target = event.currentTarget
+                        const remaining = target.scrollHeight - target.scrollTop - target.clientHeight
+
+                        if (remaining < 48 && canShowMore) {
+                            showMore()
+                        }
+                    }}
+                    onKeyDownCapture={(event) => {
+                        if (!canShowMore || event.key !== "ArrowDown") {
+                            return
+                        }
+
+                        const activeValue = document.activeElement?.getAttribute("data-value")
+                        const lastVisibleValue = visibleOptions[visibleOptions.length - 1]?.value
+
+                        if (activeValue === lastVisibleValue) {
+                            showMoreBeforeNavigation()
+                        }
+                    }}
+                >
+                    <Select.Group>
+                        {visibleOptions.map((option) => (
+                            <Select.Item
+                                key={option.value}
+                                value={option.value}
+                                label={option.label}
+                            >
+                                <Select.Indicator />
+                                {option.label}
+                            </Select.Item>
+                        ))}
+                    </Select.Group>
+                </Select.Content>
+            </Select.Portal>
+        </Select.Root>
+    )
+}
+
+export default LargeListSelectExample


### PR DESCRIPTION
## Summary
- add a Select large-list example for large option sets
- document the controlled value and stable label contract for rows mounted on demand
- grow the mounted window before keyboard focus reaches its boundary
- add a patch changeset for the docs update

## Validation
- git diff --check
- npm run validate:changesets --if-present
- pnpm --dir docs build

Partially addresses #1987.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select now includes an example for handling large option lists with incremental loading and keyboard navigation.
  * Added guidance for controlled values and stable option identifiers when using large lists.

* **Documentation**
  * Added an interactive example demonstrating a Select with 1,000 options and progressive loading as users scroll or navigate with the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->