### PR TITLE
docs(a11y): add more ARIA reference tables

### DIFF
--- a/.changeset/steady-aria-docs.md
+++ b/.changeset/steady-aria-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+docs(a11y): add ARIA references for alert dialog, context menu, and menubar

--- a/docs/app/docs/components/alert-dialog/content.mdx
+++ b/docs/app/docs/components/alert-dialog/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import AlertDialogExample from "./docs/example_1"
-import {code, anatomy, api_documentation} from "./docs/codeUsage"
+import {code, anatomy, ariaReferences, keyboardShortcuts, api_documentation} from "./docs/codeUsage"
 
 <Documentation
     title={`AlertDialog`}
@@ -17,5 +17,9 @@ import {code, anatomy, api_documentation} from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'trigger', 'portal', 'overlay', 'content', 'title', 'description', 'footer', 'action', 'cancel']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 
 </Documentation>

--- a/docs/app/docs/components/alert-dialog/docs/codeUsage.js
+++ b/docs/app/docs/components/alert-dialog/docs/codeUsage.js
@@ -1,6 +1,14 @@
-import Kbd from '@radui/ui/Kbd';
-import Text from '@radui/ui/Text';
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/alert-dialog/docs/example_1.tsx');
 
@@ -44,5 +52,31 @@ export const api_documentation = {
     cancel: cancel_api_SourceCode,
     action: action_api_SourceCode
 }
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'Closes the alert dialog when cancel or dismiss behavior is available.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to the next focusable control inside the alert dialog.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SHIFT_TAB,
+        'Moves focus to the previous focusable control inside the alert dialog.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.ALERT_DIALOG,
+        'Uses alert dialog semantics for confirmation flows that interrupt the current task and require a response.'
+    ),
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.DIALOG_MODAL,
+        'Inherits modal dialog focus containment, labelling, description, and focus restoration expectations.'
+    )
+]);
 
 export default code

--- a/docs/app/docs/components/context-menu/content.mdx
+++ b/docs/app/docs/components/context-menu/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import ContextMenuExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="ContextMenu"
@@ -15,4 +15,8 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'item']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/context-menu/docs/codeUsage.js
+++ b/docs/app/docs/components/context-menu/docs/codeUsage.js
@@ -1,4 +1,14 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 import root_api from './component_api/root.tsx';
 import item_api from './component_api/item.tsx';
 
@@ -17,5 +27,35 @@ export const api_documentation = {
     root: root_api,
     item: item_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ENTER,
+        'Activates the focused menu item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Activates the focused menu item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_DOWN,
+        'Moves focus to the next enabled item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_UP,
+        'Moves focus to the previous enabled item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'Closes the context menu and returns focus to the trigger context.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.MENU,
+        'Uses menu semantics for contextual action lists with roving focus and item activation.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/menubar/content.mdx
+++ b/docs/app/docs/components/menubar/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import MenubarExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="Menubar"
@@ -15,4 +15,8 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
         tables={api_documentation}
         order={['root']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/menubar/docs/codeUsage.js
+++ b/docs/app/docs/components/menubar/docs/codeUsage.js
@@ -1,4 +1,14 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 import root_api from './component_api/root.tsx';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/menubar/docs/example_1.tsx');
@@ -15,5 +25,35 @@ export const anatomy = { code: anatomy_SourceCode };
 export const api_documentation = {
     root: root_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_RIGHT,
+        'Moves focus to the next top-level menu trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_LEFT,
+        'Moves focus to the previous top-level menu trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_DOWN,
+        'Opens the focused menu and moves focus into its items.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'Closes the open menu and restores focus to its top-level trigger.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.MENUBAR,
+        'Uses menubar semantics for horizontal application-style menus with roving focus.'
+    ),
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.MENU,
+        'Uses menu semantics inside each opened menu for item navigation, submenu entry, and activation.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -17,6 +17,11 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         label: 'Accordion pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion/'
     },
+    ALERT_DIALOG: {
+        id: 'alert-dialog',
+        label: 'Alert dialog pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/'
+    },
     COMBOBOX: {
         id: 'combobox',
         label: 'Combobox pattern',
@@ -31,6 +36,16 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         id: 'listbox',
         label: 'Listbox pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/listbox/'
+    },
+    MENU: {
+        id: 'menu',
+        label: 'Menu pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/menubar/'
+    },
+    MENUBAR: {
+        id: 'menubar',
+        label: 'Menubar pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/menubar/'
     },
     MENU_BUTTON: {
         id: 'menu-button',


### PR DESCRIPTION
## Summary
- add shared APG entries for alert dialog, menu, and menubar patterns
- add keyboard interaction and ARIA reference tables to AlertDialog, ContextMenu, and Menubar docs
- include a patch changeset for the docs update

## Validation
- npm run validate:changesets --if-present
- pnpm --dir docs build
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added keyboard interaction guidance for Alert Dialog, Context Menu, and Menubar components.
  * Added ARIA reference tables linking these components to the relevant WAI-ARIA patterns.
  * Documented keyboard navigation, opening, closing, and menu interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->