### PR TITLE
feat(live-region): add announcement primitive

### DIFF
--- a/.changeset/live-region-primitive.md
+++ b/.changeset/live-region-primitive.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": minor
+---
+
+Add a LiveRegion primitive for accessible status announcements.

--- a/docs/app/docs/components/live-region/content.mdx
+++ b/docs/app/docs/components/live-region/content.mdx
@@ -1,0 +1,19 @@
+import Documentation from "@/components/layout/Documentation/Documentation"
+import codeUsage, { api_documentation, features } from "./docs/codeUsage"
+import LiveRegionExample from "./docs/examples/LiveRegionExample"
+
+<Documentation
+    title="Live Region"
+    description="Announce dynamic status, validation, and background updates to assistive technologies without adding visual UI."
+>
+    <Documentation.ComponentHero codeUsage={codeUsage}>
+        <LiveRegionExample />
+    </Documentation.ComponentHero>
+
+    <Documentation.ComponentFeatures features={features} />
+
+    <Documentation.ApiReference
+        tables={api_documentation}
+        order={['root']}
+    />
+</Documentation>

--- a/docs/app/docs/components/live-region/docs/codeUsage.js
+++ b/docs/app/docs/components/live-region/docs/codeUsage.js
@@ -1,0 +1,23 @@
+import root_api_SourceCode from './component_api/root.tsx';
+import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+
+const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/live-region/docs/examples/LiveRegionExample.tsx');
+
+const code = {
+    javascript: {
+        code: example_1_SourceCode
+    }
+};
+
+export const api_documentation = {
+    root: root_api_SourceCode
+};
+
+export const features = [
+    "Polite and assertive announcement modes",
+    "Visually hidden by default without removing content from the accessibility tree",
+    "Configurable live region role and ARIA announcement metadata",
+    "Stable data-slot and optional Theme class namespace hooks"
+];
+
+export default code;

--- a/docs/app/docs/components/live-region/docs/component_api/root.tsx
+++ b/docs/app/docs/components/live-region/docs/component_api/root.tsx
@@ -1,0 +1,78 @@
+const data = {
+    name: "Root",
+    description: "Root component for announcing dynamic updates to assistive technologies.",
+    columns: [
+        {
+            name: "Prop",
+            id: "prop",
+        },
+        {
+            name: "Type",
+            id: "type",
+        },
+        {
+            name: "Default",
+            id: "default",
+        }
+    ],
+    data: [
+        {
+            prop: {
+                name: "politeness",
+                info_tooltips: "Sets the aria-live politeness level for updates."
+            },
+            type: "'polite' | 'assertive' | 'off'",
+            default: "'polite'",
+        },
+        {
+            prop: {
+                name: "role",
+                info_tooltips: "Sets the live region role. Defaults to alert for assertive regions and status otherwise."
+            },
+            type: "'status' | 'alert' | 'log'",
+            default: "'status'",
+        },
+        {
+            prop: {
+                name: "atomic",
+                info_tooltips: "Controls whether the full region is announced when content changes."
+            },
+            type: "boolean",
+            default: "true",
+        },
+        {
+            prop: {
+                name: "relevant",
+                info_tooltips: "Controls which content changes should be announced."
+            },
+            type: "'additions' | 'removals' | 'text' | 'all' | 'additions text'",
+            default: "'additions text'",
+        },
+        {
+            prop: {
+                name: "busy",
+                info_tooltips: "Marks the region as busy while related updates are pending."
+            },
+            type: "boolean",
+            default: "--",
+        },
+        {
+            prop: {
+                name: "visuallyHidden",
+                info_tooltips: "Keeps the region available to screen readers while visually hiding it."
+            },
+            type: "boolean",
+            default: "true",
+        },
+        {
+            prop: {
+                name: "customRootClass",
+                info_tooltips: "Custom root class namespace override."
+            },
+            type: "string",
+            default: "''",
+        }
+    ]
+};
+
+export default data;

--- a/docs/app/docs/components/live-region/docs/examples/LiveRegionExample.tsx
+++ b/docs/app/docs/components/live-region/docs/examples/LiveRegionExample.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useState } from "react"
+import Button from "@radui/ui/Button"
+import Card from "@radui/ui/Card"
+import Heading from "@radui/ui/Heading"
+import LiveRegion from "@radui/ui/LiveRegion"
+import Text from "@radui/ui/Text"
+
+export default function LiveRegionExample() {
+    const [message, setMessage] = useState("Ready to sync")
+
+    return (
+        <Card className="w-full max-w-xl bg-gray-50 text-gray-1000">
+            <div className="flex items-center justify-between gap-4">
+                <div>
+                    <Heading as="h3" className="mb-1 text-base">
+                        Sync status
+                    </Heading>
+                    <Text className="text-sm text-gray-800">
+                        {message}
+                    </Text>
+                </div>
+                <Button onClick={() => setMessage("Settings synced")}>
+                    Sync
+                </Button>
+                <LiveRegion>{message}</LiveRegion>
+            </div>
+        </Card>
+    )
+}

--- a/docs/app/docs/components/live-region/page.tsx
+++ b/docs/app/docs/components/live-region/page.tsx
@@ -1,0 +1,7 @@
+import { createDocsPage } from '@/components/docsPage/createDocsPage'
+import metadata from './seo'
+import Content from './content.mdx'
+
+export { metadata }
+
+export default createDocsPage(Content)

--- a/docs/app/docs/components/live-region/seo.ts
+++ b/docs/app/docs/components/live-region/seo.ts
@@ -1,0 +1,8 @@
+import generateSeoMetadata from "@/utils/seo/generateSeoMetadata"
+
+const liveRegionMetadata = generateSeoMetadata({
+    title: "Live Region - Rad UI",
+    description: "A headless React Live Region component for announcing dynamic status, validation, and background updates to assistive technologies."
+});
+
+export default liveRegionMetadata

--- a/docs/app/docs/docsNavigationSections.tsx
+++ b/docs/app/docs/docsNavigationSections.tsx
@@ -54,6 +54,7 @@ export const docsNavigationSections = [
             { title:"HoverCard", path:"/docs/components/hover-card", is_preview:true },
             { title:"Kbd", path:"/docs/components/kbd" },
             { title:"Link", path:"/docs/components/link", is_preview:true },
+            { title:"LiveRegion", path:"/docs/components/live-region", is_preview:true },
             { title:"Menubar", path:"/docs/components/menubar", is_preview:true },
             { title:"Minimap", path:"/docs/components/minimap", is_preview:true },
             { title:"NavigationMenu", path:"/docs/components/navigation-menu", is_preview:true },

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -112,6 +112,7 @@ const nextConfig = {
         config.resolve.alias = {
             ...config.resolve.alias,
             '@radui/ui/Breadcrumb': path.resolve(__dirname, '../src/components/ui/Breadcrumb/Breadcrumb.tsx'),
+            '@radui/ui/LiveRegion': path.resolve(__dirname, '../src/components/ui/LiveRegion/LiveRegion.tsx'),
             '@radui/ui/Toast': path.resolve(__dirname, '../src/components/ui/Toast/Toast.tsx'),
             '@radui/ui/themes/default.css': path.resolve(__dirname, '../src/design-systems/clarity/default.scss'),
             '@radui/ui/themes/baremetal.css': path.resolve(__dirname, '../src/design-systems/baremetal/default.scss'),

--- a/docs/tsconfig.examples.json
+++ b/docs/tsconfig.examples.json
@@ -4,7 +4,8 @@
     "app/docs/**/docs/**/*.ts",
     "app/docs/**/docs/**/*.tsx",
     "app/docs/**/examples/**/*.ts",
-    "app/docs/**/examples/**/*.tsx"
+    "app/docs/**/examples/**/*.tsx",
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",

--- a/docs/types/custom.d.ts
+++ b/docs/types/custom.d.ts
@@ -1,6 +1,27 @@
 // custom.d.ts
 declare module '@radui/ui';
 
+declare module '@radui/ui/LiveRegion' {
+    import * as React from 'react';
+
+    type LiveRegionProps = React.ComponentPropsWithoutRef<'div'> & {
+        politeness?: 'polite' | 'assertive' | 'off';
+        role?: 'status' | 'alert' | 'log';
+        atomic?: boolean;
+        relevant?: 'additions' | 'removals' | 'text' | 'all' | 'additions text';
+        busy?: boolean;
+        visuallyHidden?: boolean;
+        customRootClass?: string;
+        children?: React.ReactNode;
+    };
+
+    const LiveRegion: React.ForwardRefExoticComponent<
+        LiveRegionProps & React.RefAttributes<HTMLDivElement>
+    >;
+
+    export default LiveRegion;
+}
+
 declare module '@radui/ui/ToggleGroup' {
     import * as React from 'react';
 

--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
       "require": "./dist/components/Link.cjs",
       "types": "./dist/components/Link.d.ts"
     },
+    "./LiveRegion": {
+      "import": "./dist/components/LiveRegion.js",
+      "require": "./dist/components/LiveRegion.cjs",
+      "types": "./dist/components/LiveRegion.d.ts"
+    },
     "./Menubar": {
       "import": "./dist/components/Menubar.js",
       "require": "./dist/components/Menubar.cjs",

--- a/scripts/RELEASED_COMPONENTS.cjs
+++ b/scripts/RELEASED_COMPONENTS.cjs
@@ -17,6 +17,7 @@ const RELEASED_COMPONENTS = [
     'Heading',
     'Text',
     'Kbd',
+    'LiveRegion',
     'Progress',
     'Separator',
     'Strong',

--- a/src/components/ui/LiveRegion/LiveRegion.tsx
+++ b/src/components/ui/LiveRegion/LiveRegion.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React, { ComponentPropsWithoutRef, CSSProperties, ElementRef, forwardRef } from 'react';
+import clsx from 'clsx';
+import Primitive from '~/core/primitives/Primitive';
+import { useComponentClass } from '~/components/ui/Theme/useComponentClass';
+
+const COMPONENT_NAME = 'LiveRegion';
+
+type LiveRegionPoliteness = 'polite' | 'assertive' | 'off';
+type LiveRegionRole = 'status' | 'alert' | 'log';
+type LiveRegionRelevant = 'additions' | 'removals' | 'text' | 'all' | 'additions text';
+
+export type LiveRegionElement = ElementRef<typeof Primitive.div>;
+export type LiveRegionProps = {
+    /**
+     * Controls how urgently assistive technology should announce updates.
+     */
+    politeness?: LiveRegionPoliteness;
+    /**
+     * Landmark role for the live region. `status` is appropriate for most
+     * non-blocking updates; use `alert` for urgent errors.
+     */
+    role?: LiveRegionRole;
+    /**
+     * Whether assistive technology should announce the full region on updates.
+     */
+    atomic?: boolean;
+    /**
+     * Describes which changes should be announced.
+     */
+    relevant?: LiveRegionRelevant;
+    /**
+     * Marks the region as temporarily busy while related updates are pending.
+     */
+    busy?: boolean;
+    /**
+     * Keeps the live region in the accessibility tree while visually hiding it.
+     */
+    visuallyHidden?: boolean;
+    customRootClass?: string;
+    style?: CSSProperties;
+} & Omit<ComponentPropsWithoutRef<typeof Primitive.div>, 'role' | 'aria-live' | 'aria-atomic' | 'aria-relevant' | 'aria-busy'>;
+
+const VISUALLY_HIDDEN_STYLES: CSSProperties = {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    margin: '-1px',
+    border: '0',
+    padding: '0',
+    whiteSpace: 'nowrap',
+    clip: 'rect(0 0 0 0)',
+    clipPath: 'inset(50%)',
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    userSelect: 'none'
+} as const;
+
+const LiveRegion = forwardRef<LiveRegionElement, LiveRegionProps>(({
+    children,
+    customRootClass,
+    className,
+    politeness = 'polite',
+    role = politeness === 'assertive' ? 'alert' : 'status',
+    atomic = true,
+    relevant = 'additions text',
+    busy,
+    visuallyHidden = true,
+    style,
+    ...props
+}, ref) => {
+    const rootClass = useComponentClass(customRootClass, COMPONENT_NAME);
+    const rootStyle = visuallyHidden
+        ? { ...VISUALLY_HIDDEN_STYLES, ...style }
+        : style;
+
+    return (
+        <Primitive.div
+            ref={ref}
+            role={role}
+            aria-live={politeness}
+            aria-atomic={atomic}
+            aria-relevant={relevant}
+            aria-busy={busy}
+            data-slot="live-region-root"
+            className={clsx(rootClass, className)}
+            style={rootStyle}
+            {...props}
+        >
+            {children}
+        </Primitive.div>
+    );
+});
+
+LiveRegion.displayName = COMPONENT_NAME;
+
+export default LiveRegion;

--- a/src/components/ui/LiveRegion/stories/LiveRegion.stories.tsx
+++ b/src/components/ui/LiveRegion/stories/LiveRegion.stories.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import LiveRegion from '../LiveRegion';
+import Button from '~/components/ui/Button/Button';
+import SandboxEditor from '~/components/tools/SandboxEditor/SandboxEditor';
+
+export default {
+    title: 'Components/LiveRegion',
+    component: LiveRegion
+};
+
+export const Default = {
+    render: () => {
+        const [message, setMessage] = useState('Ready');
+
+        return (
+            <SandboxEditor>
+                <div className="flex items-center gap-3">
+                    <Button onClick={() => setMessage(`Saved at ${new Date().toLocaleTimeString()}`)}>
+                        Save
+                    </Button>
+                    <span aria-hidden="true">{message}</span>
+                    <LiveRegion>{message}</LiveRegion>
+                </div>
+            </SandboxEditor>
+        );
+    }
+};
+
+export const Assertive = {
+    render: () => (
+        <SandboxEditor>
+            <LiveRegion politeness="assertive">
+                Payment failed. Check the card details and try again.
+            </LiveRegion>
+        </SandboxEditor>
+    )
+};

--- a/src/components/ui/LiveRegion/tests/LiveRegion.test.tsx
+++ b/src/components/ui/LiveRegion/tests/LiveRegion.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LiveRegion from '../LiveRegion';
+import Theme from '~/components/ui/Theme/Theme';
+
+describe('LiveRegion', () => {
+    const originalMatchMedia = window.matchMedia;
+
+    beforeEach(() => {
+        window.matchMedia = jest.fn().mockReturnValue({
+            matches: false,
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        } as unknown as MediaQueryList);
+    });
+
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia;
+    });
+
+    test('renders a polite status region by default', () => {
+        render(<LiveRegion>Saved</LiveRegion>);
+        const region = screen.getByRole('status');
+
+        expect(region).toHaveTextContent('Saved');
+        expect(region).toHaveAttribute('aria-live', 'polite');
+        expect(region).toHaveAttribute('aria-atomic', 'true');
+        expect(region).toHaveAttribute('aria-relevant', 'additions text');
+        expect(region).toHaveAttribute('data-slot', 'live-region-root');
+    });
+
+    test('uses alert semantics for assertive announcements by default', () => {
+        render(<LiveRegion politeness="assertive">Upload failed</LiveRegion>);
+        const region = screen.getByRole('alert');
+
+        expect(region).toHaveAttribute('aria-live', 'assertive');
+        expect(region).toHaveTextContent('Upload failed');
+    });
+
+    test('allows explicit role and announcement metadata', () => {
+        render(
+            <LiveRegion
+                role="log"
+                politeness="polite"
+                atomic={false}
+                relevant="all"
+                busy
+            >
+                Syncing
+            </LiveRegion>
+        );
+        const region = screen.getByRole('log');
+
+        expect(region).toHaveAttribute('aria-live', 'polite');
+        expect(region).toHaveAttribute('aria-atomic', 'false');
+        expect(region).toHaveAttribute('aria-relevant', 'all');
+        expect(region).toHaveAttribute('aria-busy', 'true');
+    });
+
+    test('is visually hidden by default', () => {
+        render(<LiveRegion>Hidden announcement</LiveRegion>);
+        const region = screen.getByText('Hidden announcement');
+
+        expect(region).toHaveStyle({
+            position: 'absolute',
+            width: '1px',
+            height: '1px',
+            clip: 'rect(0 0 0 0)'
+        });
+    });
+
+    test('can render visibly', () => {
+        render(<LiveRegion visuallyHidden={false}>Visible announcement</LiveRegion>);
+        const region = screen.getByRole('status');
+
+        expect(region).not.toHaveStyle({ position: 'absolute' });
+        expect(region).toHaveTextContent('Visible announcement');
+    });
+
+    test('forwards refs and DOM props', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <LiveRegion ref={ref} data-testid="announcer" id="announcement-region">
+                Ready
+            </LiveRegion>
+        );
+
+        expect(ref.current).toBe(screen.getByTestId('announcer'));
+        expect(ref.current).toHaveAttribute('id', 'announcement-region');
+    });
+
+    test('only emits generated classes when a namespace is provided', () => {
+        const { rerender } = render(<LiveRegion>Default</LiveRegion>);
+        expect(screen.getByRole('status')).not.toHaveClass('rad-ui-live-region');
+
+        rerender(
+            <Theme classNamespace="acme">
+                <LiveRegion>Namespaced</LiveRegion>
+            </Theme>
+        );
+
+        expect(screen.getByRole('status')).toHaveClass('acme-live-region');
+    });
+});


### PR DESCRIPTION
## Summary\n- add a headless LiveRegion primitive for polite/assertive announcements\n- document the new component and add it to the docs navigation\n- add package export metadata, release allowlist entry, tests, and a changeset\n\nCloses #1810\n\n## Checks\n- npm test -- --runTestsByPath src/components/ui/LiveRegion/tests/LiveRegion.test.tsx\n- npm run validate:changesets\n- NODE_OPTIONS='--max-old-space-size=12288' npm run build:components\n- npm run build:generate-exports -- --check\n\nNote: npm run check:types is currently blocked by existing unrelated story type errors in Breadcrumb, Popover, and Clarity stories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the LiveRegion component for accessible status announcements.
  - Supports configurable announcement politeness, ARIA attributes, visibility, styling, and forwarded DOM properties.
  - Published the component for package consumers.

- **Documentation**
  - Added comprehensive LiveRegion documentation, API reference, usage examples, and navigation entry.

- **Tests**
  - Added coverage for announcement behavior, accessibility attributes, visibility, refs, DOM properties, and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->