### PR TITLE
docs(switch): add accessibility reference tables

### DIFF
--- a/.changeset/switch-accessibility-docs.md
+++ b/.changeset/switch-accessibility-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Document Switch keyboard interactions and ARIA pattern references.

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -57,6 +57,11 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         label: 'Radio group pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/radio/'
     },
+    SWITCH: {
+        id: 'switch',
+        label: 'Switch pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/switch/'
+    },
     TABS: {
         id: 'tabs',
         label: 'Tabs pattern',

--- a/docs/app/docs/components/switch/content.mdx
+++ b/docs/app/docs/components/switch/content.mdx
@@ -1,5 +1,5 @@
 import Documentation from "@/components/layout/Documentation/Documentation"
-import codeUsage, { api_documentation } from "./docs/codeUsage"
+import codeUsage, { api_documentation, ariaReferences, keyboardShortcuts } from "./docs/codeUsage"
 import SwitchExample from "./docs/examples/SwitchExample"
 
 <Documentation  title='Switch' description={`
@@ -14,5 +14,9 @@ import SwitchExample from "./docs/examples/SwitchExample"
         tables={api_documentation}
         order={['root', 'thumb']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 
         </Documentation>

--- a/docs/app/docs/components/switch/docs/codeUsage.js
+++ b/docs/app/docs/components/switch/docs/codeUsage.js
@@ -1,4 +1,14 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/switch/docs/examples/SwitchExample.tsx');
 
@@ -36,4 +46,27 @@ export const SwitchTable = {
         {prop: 'color', type: 'string', default: 'null', description: 'Accent Color of the switch', id: 'color'},
     ]
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to the switch.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Toggles the checked state.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ENTER,
+        'Toggles the checked state.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.SWITCH,
+        'Uses switch semantics with aria-checked to expose the current on or off state.'
+    )
+]);
+
 export default code;


### PR DESCRIPTION
## Summary
- add the WAI-ARIA APG Switch reference to the shared docs metadata
- document Switch keyboard interactions for Tab, Space, and Enter
- add a patch changeset for the user-facing docs update

## Verification
- npm test -- --runTestsByPath src/components/ui/Switch/tests/Switch.test.tsx src/components/ui/Switch/tests/Switch.controlledSwitch.test.tsx
- cd docs && pnpm check:examples
- npx changeset status --since=origin/main
- npm run lint -- --quiet
- cd docs && pnpm build

Part of #1837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added keyboard interaction guidance for the Switch component, including focus, navigation, and toggle behavior.
  - Added ARIA references and semantic guidance linking to the WAI-ARIA Switch pattern.
- **Release**
  - Documented a patch release for the UI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->