### PR TITLE
docs(tree): add large data example

### DIFF
--- a/.changeset/tree-large-data-docs.md
+++ b/.changeset/tree-large-data-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+docs(Tree): add large-data branch mounting guidance and correct item API docs.

--- a/docs/app/docs/components/tree/content.mdx
+++ b/docs/app/docs/components/tree/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import TreeExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, largeDataCode, anatomy, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="Tree"
@@ -9,6 +9,14 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
     <Documentation.ComponentHero codeUsage={code}>
         <TreeExample />
     </Documentation.ComponentHero>
+
+    <Documentation.Section title="Large Data">
+        Model large trees as collapsed branches and keep each node's `label` stable.
+        Tree only mounts a branch group while its parent item is expanded, so deep file trees can defer most child nodes until users open that branch.
+        <Documentation.CodeBlock language="tsx">
+            {largeDataCode.javascript.code}
+        </Documentation.CodeBlock>
+    </Documentation.Section>
 
     <Documentation.ApiReference
         anatomy={anatomy.code}

--- a/docs/app/docs/components/tree/docs/codeUsage.js
+++ b/docs/app/docs/components/tree/docs/codeUsage.js
@@ -3,12 +3,17 @@ import root_api from './component_api/root.tsx';
 import item_api from './component_api/item.tsx';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tree/docs/example_1.tsx');
+const largeData_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tree/docs/large-data.tsx');
 const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/tree.scss');
 const anatomy_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/tree/docs/anatomy.tsx');
 
 export const code = {
     javascript: { code: example_1_SourceCode },
     scss: { code: scss_SourceCode }
+};
+
+export const largeDataCode = {
+    javascript: { code: largeData_SourceCode }
 };
 
 export const anatomy = { code: anatomy_SourceCode };

--- a/docs/app/docs/components/tree/docs/component_api/item.tsx
+++ b/docs/app/docs/components/tree/docs/component_api/item.tsx
@@ -1,14 +1,17 @@
 const data = {
     name: "Item",
-    description: "A single tree node. Can contain nested Tree.Item elements.",
+    description: "A single tree node rendered from an item object.",
     columns: [
         { name: "Prop", id: "prop" },
         { name: "Type", id: "type" },
         { name: "Default", id: "default" }
     ],
     data: [
-        { prop: { name: "label*", info_tooltips: "The label displayed for this tree node." }, type: "string | ReactNode", default: "--" },
-        { prop: { name: "defaultOpen", info_tooltips: "Whether this node is expanded by default." }, type: "boolean", default: "false" },
+        { prop: { name: "item*", info_tooltips: "Node data for this item. Use item.items for children and item.expanded for the initial expanded state." }, type: "{ label: string; expanded?: boolean; items?: object[] }", default: "--" },
+        { prop: { name: "level", info_tooltips: "Zero-based nesting level. Nested items receive this automatically." }, type: "number", default: "0" },
+        { prop: { name: "isSelected", info_tooltips: "Marks this item as selected when selection is managed externally." }, type: "boolean", default: "false" },
+        { prop: { name: "getIsSelected", info_tooltips: "Returns whether a child item should be marked selected." }, type: "(item) => boolean", default: "--" },
+        { prop: { name: "onToggleSelect", info_tooltips: "Called with the internal item id and node data when an item is selected." }, type: "(id, item) => void", default: "--" },
         { prop: { name: "className", info_tooltips: "Additional CSS classes." }, type: "string", default: '""' }
     ]
 }

--- a/docs/app/docs/components/tree/docs/large-data.tsx
+++ b/docs/app/docs/components/tree/docs/large-data.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import Tree from "@radui/ui/Tree"
+
+type FileNode = {
+    label: string
+    expanded?: boolean
+    items?: FileNode[]
+}
+
+const createFiles = (folder: string, count: number): FileNode[] => (
+    Array.from({ length: count }, (_, index) => ({
+        label: `${folder}-file-${String(index + 1).padStart(3, "0")}.tsx`
+    }))
+)
+
+const folders: FileNode[] = [
+    {
+        label: "packages",
+        expanded: true,
+        items: [
+            { label: "core", items: createFiles("core", 80) },
+            { label: "react", items: createFiles("react", 120) },
+            { label: "theme", items: createFiles("theme", 64) }
+        ]
+    },
+    {
+        label: "docs",
+        items: [
+            { label: "components", items: createFiles("component-doc", 96) },
+            { label: "guides", items: createFiles("guide", 48) }
+        ]
+    },
+    {
+        label: "examples",
+        items: createFiles("example", 72)
+    }
+]
+
+const LazyBranchTreeExample = () => {
+    const [selectedPath, setSelectedPath] = React.useState("packages")
+
+    const getIsSelected = React.useCallback((item: FileNode) => (
+        item.label === selectedPath
+    ), [selectedPath])
+
+    return (
+        <Tree.Root aria-label="Project files" loop={false}>
+            {folders.map((item) => (
+                <Tree.Item
+                    key={item.label}
+                    item={item}
+                    getIsSelected={getIsSelected}
+                    onToggleSelect={(_, selectedItem) => {
+                        setSelectedPath(selectedItem.label)
+                    }}
+                >
+                    {item.label}
+                </Tree.Item>
+            ))}
+        </Tree.Root>
+    )
+}
+
+export default LazyBranchTreeExample


### PR DESCRIPTION
## Summary
- add a Tree large-data docs example showing collapsed branch mounting for deep file trees
- document stable item labels and branch deferral for large data sets
- correct the Tree.Item API table to match the current item-driven props

Fixes #1987

## Checks
- npm run lint
- npm test -- --runInBand src/components/ui/Tree/tests/Tree.test.tsx src/components/ui/Tree/tests/Tree.a11y.test.tsx
- npm run check:docs-snippets
- npm run validate:changesets
- npm run check:docs-examples