### PR TITLE
docs(progress): add accessibility references

### DIFF
--- a/.changeset/progress-a11y-docs.md
+++ b/.changeset/progress-a11y-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Document Progress keyboard behavior and ARIA references.

--- a/docs/app/docs/components/progress/content.mdx
+++ b/docs/app/docs/components/progress/content.mdx
@@ -1,5 +1,5 @@
 import Documentation from "@/components/layout/Documentation/Documentation"
-import codeUsage, { api_documentation, features } from "./docs/codeUsage"
+import codeUsage, { api_documentation, ariaReferences, features, keyboardShortcuts } from "./docs/codeUsage"
 import ProgressExample from "./docs/examples/ProgressExample"
 
 <Documentation 
@@ -20,5 +20,9 @@ import ProgressExample from "./docs/examples/ProgressExample"
     tables={api_documentation}
     order={['root', 'indicator']}
   />
+
+  <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+  <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 
 </Documentation>

--- a/docs/app/docs/components/progress/docs/codeUsage.js
+++ b/docs/app/docs/components/progress/docs/codeUsage.js
@@ -2,6 +2,16 @@
 import root_api_SourceCode from './component_api/root.tsx';
 import indicator_api_SourceCode from './component_api/indicator.tsx';
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/progress/docs/examples/ProgressExample.tsx');
 
@@ -32,5 +42,19 @@ export const features = [
     "Customizable color themes",
     "Smooth animations for value changes"
 ];
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to interactive controls associated with the progress indicator.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.PROGRESSBAR,
+        'Uses progressbar semantics with aria-valuenow for determinate progress. aria-valuemin and aria-valuemax are optional for the default 0 to 100 range, aria-valuetext is only needed when the numeric value is not meaningful on its own, and indeterminate progress omits aria-valuenow.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -52,6 +52,11 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         label: 'Menu button pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/'
     },
+    PROGRESSBAR: {
+        id: 'progressbar',
+        label: 'Progressbar role',
+        href: 'https://www.w3.org/WAI/ARIA/apg/practices/range-related-properties/#using-aria-valuetext'
+    },
     RADIO_GROUP: {
         id: 'radio-group',
         label: 'Radio group pattern',


### PR DESCRIPTION
## Summary
- add Progress keyboard interaction guidance to the docs page
- add a shared Progressbar ARIA reference entry
- document determinate and indeterminate value semantics

## Verification
- pnpm exec eslint app/docs/components/progress/content.mdx app/docs/components/progress/docs/codeUsage.js app/docs/components/shared/ariaReferences.js
- pnpm run check:examples
- pnpm run build

Part of #1837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added keyboard interaction guidance for the Progress component, including Tab focus behavior.
  - Added ARIA references describing progressbar accessibility semantics and range-related properties.
  - Linked the Progress documentation to shared keyboard and accessibility reference tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->