### PR TITLE
docs(command): add accessibility reference tables

### DIFF
--- a/.changeset/command-accessibility-docs.md
+++ b/.changeset/command-accessibility-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Document Command keyboard interactions and ARIA references.

--- a/docs/app/docs/components/command/content.mdx
+++ b/docs/app/docs/components/command/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import CommandExample from './docs/example_1';
-import { anatomy, api_documentation, code } from './docs/codeUsage';
+import { anatomy, api_documentation, ariaReferences, code, keyboardShortcuts } from './docs/codeUsage';
 
 <Documentation
     title="Command"
@@ -15,4 +15,8 @@ import { anatomy, api_documentation, code } from './docs/codeUsage';
         tables={api_documentation}
         order={['root', 'dialog', 'item']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/command/docs/codeUsage.js
+++ b/docs/app/docs/components/command/docs/codeUsage.js
@@ -1,4 +1,14 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 import root_api from './component_api/root.tsx';
 import dialog_api from './component_api/dialog.tsx';
 import item_api from './component_api/item.tsx';
@@ -19,3 +29,53 @@ export const api_documentation = {
     dialog: dialog_api,
     item: item_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_DOWN,
+        'Moves the active selection to the next available command item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ARROW_UP,
+        'Moves the active selection to the previous available command item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.HOME,
+        'Moves the active selection to the first available command item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.END,
+        'Moves the active selection to the last available command item.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ENTER,
+        'Runs the active command from the input, or the focused command item from the list.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Runs the focused command item when focus is inside the list.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'Closes the command palette when it is rendered with Command.Dialog.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus through or out of the command palette using the normal page tab order.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.COMBOBOX,
+        'Uses editable combobox semantics for the search input that controls the command results.'
+    ),
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.LISTBOX,
+        'Uses listbox option semantics for selectable command results and active item state.'
+    ),
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.DIALOG_MODAL,
+        'Uses modal dialog semantics when Command.Dialog presents the palette in a portal.'
+    )
+]);


### PR DESCRIPTION
## Summary
- add Command keyboard interaction docs using the shared table helper
- add Command ARIA reference docs for combobox, listbox, and dialog usage
- add a patch changeset for the docs update

## Checks
- npm run validate:changesets
- npm run check:docs-snippets
- git diff --check
- npm test -- Command.keyboard.test.tsx

Part of #1837 and #1811.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for Command keyboard interactions, including available shortcuts.
  - Added ARIA reference information describing the Command component’s accessibility semantics.
  - Updated the Command usage documentation with keyboard and accessibility reference tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->