### PR TITLE
docs(checkbox): add accessibility tables

### DIFF
--- a/.changeset/checkbox-accessibility-docs.md
+++ b/.changeset/checkbox-accessibility-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Add Checkbox keyboard interaction and ARIA reference tables to the docs.

--- a/docs/app/docs/components/checkbox/content.mdx
+++ b/docs/app/docs/components/checkbox/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import CheckboxExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="Checkbox"
@@ -15,4 +15,8 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'indicator']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/checkbox/docs/codeUsage.js
+++ b/docs/app/docs/components/checkbox/docs/codeUsage.js
@@ -1,6 +1,16 @@
 import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
 import root_api from './component_api/root.tsx';
 import indicator_api from './component_api/indicator.tsx';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/checkbox/docs/example_1.tsx');
 const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/checkbox.scss');
@@ -17,5 +27,23 @@ export const api_documentation = {
     root: root_api,
     indicator: indicator_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to the checkbox.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Toggles between checked and unchecked states.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.CHECKBOX,
+        'Uses checkbox semantics with aria-checked to expose checked, unchecked, or mixed state.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -22,6 +22,11 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         label: 'Alert dialog pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/'
     },
+    CHECKBOX: {
+        id: 'checkbox',
+        label: 'Checkbox pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/'
+    },
     COMBOBOX: {
         id: 'combobox',
         label: 'Combobox pattern',


### PR DESCRIPTION
## Summary
- add Checkbox keyboard interaction docs
- add a shared Checkbox ARIA reference row
- include a patch changeset for the docs update

## Verification
- npm run check:docs-snippets
- npm run validate:changesets
- pnpm --dir docs build

Part of #1837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Checkbox keyboard interaction guidance, including Tab and Space behavior.
  * Added an ARIA reference table covering checkbox semantics and `aria-checked` states.
  * Added a link to the official WAI-ARIA checkbox pattern documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->