### PR TITLE
docs(collapsible): add accessibility tables

### DIFF
--- a/.changeset/collapsible-accessibility-docs.md
+++ b/.changeset/collapsible-accessibility-docs.md
@@ -1,0 +1,5 @@
+---
+"@radui/ui": patch
+---
+
+Document Collapsible keyboard interactions and ARIA references.

--- a/docs/app/docs/components/collapsible/content.mdx
+++ b/docs/app/docs/components/collapsible/content.mdx
@@ -1,6 +1,6 @@
 import Documentation from '@/components/layout/Documentation/Documentation';
 import CollapsibleExample from "./docs/example_1"
-import { code, anatomy, api_documentation } from "./docs/codeUsage"
+import { code, anatomy, ariaReferences, keyboardShortcuts, api_documentation } from "./docs/codeUsage"
 
 <Documentation
     title="Collapsible"
@@ -15,4 +15,8 @@ import { code, anatomy, api_documentation } from "./docs/codeUsage"
         tables={api_documentation}
         order={['root', 'trigger', 'content']}
     />
+
+    <Documentation.Table title="Keyboard Interactions" columns={keyboardShortcuts.columns} data={keyboardShortcuts.data} />
+
+    <Documentation.Table title="ARIA References" columns={ariaReferences.columns} data={ariaReferences.data} />
 </Documentation>

--- a/docs/app/docs/components/collapsible/docs/codeUsage.js
+++ b/docs/app/docs/components/collapsible/docs/codeUsage.js
@@ -2,6 +2,16 @@ import { getSourceCodeFromPath } from '@/utils/parseSourceCode';
 import root_api from './component_api/root.tsx';
 import trigger_api from './component_api/trigger.tsx';
 import content_api from './component_api/content.tsx';
+import {
+    createAriaReferenceRow,
+    createAriaReferenceTable,
+    DOCS_ARIA_PATTERNS
+} from '../../shared/ariaReferences';
+import {
+    createKeyboardShortcutRow,
+    createKeyboardShortcutTable,
+    DOCS_KEYBOARD_SHORTCUTS
+} from '../../shared/keyboardShortcuts';
 
 const example_1_SourceCode = await getSourceCodeFromPath('docs/app/docs/components/collapsible/docs/example_1.tsx');
 const scss_SourceCode = await getSourceCodeFromPath('styles/themes/components/collapsible.scss');
@@ -19,5 +29,31 @@ export const api_documentation = {
     trigger: trigger_api,
     content: content_api
 };
+
+export const keyboardShortcuts = createKeyboardShortcutTable([
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.TAB,
+        'Moves focus to the Collapsible.Trigger.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.SPACE,
+        'Toggles the controlled content open or closed.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ENTER,
+        'Toggles the controlled content open or closed.'
+    ),
+    createKeyboardShortcutRow(
+        DOCS_KEYBOARD_SHORTCUTS.ESCAPE,
+        'When the content is open and focus is on the trigger, closes the content.'
+    )
+]);
+
+export const ariaReferences = createAriaReferenceTable([
+    createAriaReferenceRow(
+        DOCS_ARIA_PATTERNS.DISCLOSURE,
+        'Uses a button trigger with aria-expanded and aria-controls to expose the content relationship.'
+    )
+]);
 
 export default code;

--- a/docs/app/docs/components/shared/ariaReferences.js
+++ b/docs/app/docs/components/shared/ariaReferences.js
@@ -32,6 +32,11 @@ export const DOCS_ARIA_PATTERNS = Object.freeze({
         label: 'Combobox pattern',
         href: 'https://www.w3.org/WAI/ARIA/apg/patterns/combobox/'
     },
+    DISCLOSURE: {
+        id: 'disclosure',
+        label: 'Disclosure pattern',
+        href: 'https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/'
+    },
     DIALOG_MODAL: {
         id: 'dialog-modal',
         label: 'Dialog modal pattern',


### PR DESCRIPTION
## Summary
- add Collapsible keyboard interaction docs
- add a shared WAI-ARIA Disclosure pattern reference
- render Collapsible ARIA references in the docs page

## Checks
- npm run check:docs-snippets
- npm run validate:changesets
- pnpm --dir docs build

Continues #1837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Collapsible keyboard interaction guidance, including focus movement, toggling, and Escape handling.
  - Added ARIA reference documentation describing the component’s disclosure semantics.
  - Linked the Collapsible documentation to the relevant WAI-ARIA Disclosure pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->